### PR TITLE
Redmine #3280 - Permit CFEngine to compare the package name installed and the package name promised on Debian Wheezy

### DIFF
--- a/lib/3.5/packages.cf
+++ b/lib/3.5/packages.cf
@@ -113,7 +113,7 @@ body package_method apt
 {
       package_changes => "bulk";
       package_list_command => "$(debian_knowledge.call_dpkg) -l";
-      package_list_name_regex    => ".i\s+([^\s]+).*";
+      package_list_name_regex    => ".i\s+([^\s:]+).*";
       package_list_version_regex => ".i\s+[^\s]+\s+([^\s]+).*";
       package_installed_regex => ".i.*"; # packages that have been uninstalled may be listed
       package_name_convention => "$(name)";
@@ -173,7 +173,7 @@ body package_method apt_get
 {
       package_changes => "bulk";
       package_list_command => "$(debian_knowledge.call_dpkg) -l";
-      package_list_name_regex    => ".i\s+([^\s]+).*";
+      package_list_name_regex    => ".i\s+([^\s:]+).*";
       package_list_version_regex => ".i\s+[^\s]+\s+([^\s]+).*";
       package_installed_regex => ".i.*"; # packages that have been uninstalled may be listed
       package_name_convention => "$(name)";
@@ -215,7 +215,7 @@ body package_method apt_get_release(release)
 {
       package_changes => "bulk";
       package_list_command => "$(debian_knowledge.call_dpkg) -l";
-      package_list_name_regex    => ".i\s+([^\s]+).*";
+      package_list_name_regex    => ".i\s+([^\s:]+).*";
       package_list_version_regex => ".i\s+[^\s]+\s+([^\s]+).*";
       package_installed_regex => ".i.*"; # packages that have been uninstalled may be listed
       package_name_convention => "$(name)";
@@ -264,7 +264,7 @@ body package_method dpkg_version(repo)
       package_list_update_command => "$(debian_knowledge.call_apt_get) update";
       package_list_update_ifelapsed => "240";
 
-      package_list_name_regex    => ".i\s+([^\s]+).*";
+      package_list_name_regex    => ".i\s+([^\s:]+).*";
       package_list_version_regex => ".i\s+[^\s]+\s+([^\s]+).*";
 
       package_installed_regex => ".i.*"; # packages that have been uninstalled may be listed
@@ -1001,7 +1001,7 @@ body package_method generic
     debian::
       package_changes => "bulk";
       package_list_command => "$(debian_knowledge.call_dpkg) -l";
-      package_list_name_regex    => ".i\s+([^\s]+).*";
+      package_list_name_regex    => ".i\s+([^\s:]+).*";
       package_list_version_regex => ".i\s+[^\s]+\s+([^\s]+).*";
       package_installed_regex => ".i.*"; # packages that have been uninstalled may be listed
       package_name_convention => "$(name)";

--- a/lib/3.6/packages.cf
+++ b/lib/3.6/packages.cf
@@ -118,7 +118,7 @@ body package_method apt
 {
       package_changes => "bulk";
       package_list_command => "$(debian_knowledge.call_dpkg) -l";
-      package_list_name_regex    => ".i\s+([^\s]+).*";
+      package_list_name_regex    => ".i\s+([^\s:]+).*";
       package_list_version_regex => ".i\s+[^\s]+\s+([^\s]+).*";
       package_installed_regex => ".i.*"; # packages that have been uninstalled may be listed
       package_name_convention => "$(name)";
@@ -178,7 +178,7 @@ body package_method apt_get
 {
       package_changes => "bulk";
       package_list_command => "$(debian_knowledge.call_dpkg) -l";
-      package_list_name_regex    => ".i\s+([^\s]+).*";
+      package_list_name_regex    => ".i\s+([^\s:]+).*";
       package_list_version_regex => ".i\s+[^\s]+\s+([^\s]+).*";
       package_installed_regex => ".i.*"; # packages that have been uninstalled may be listed
       package_name_convention => "$(name)";
@@ -220,7 +220,7 @@ body package_method apt_get_release(release)
 {
       package_changes => "bulk";
       package_list_command => "$(debian_knowledge.call_dpkg) -l";
-      package_list_name_regex    => ".i\s+([^\s]+).*";
+      package_list_name_regex    => ".i\s+([^\s:]+).*";
       package_list_version_regex => ".i\s+[^\s]+\s+([^\s]+).*";
       package_installed_regex => ".i.*"; # packages that have been uninstalled may be listed
       package_name_convention => "$(name)";
@@ -269,7 +269,7 @@ body package_method dpkg_version(repo)
       package_list_update_command => "$(debian_knowledge.call_apt_get) update";
       package_list_update_ifelapsed => "240";
 
-      package_list_name_regex    => ".i\s+([^\s]+).*";
+      package_list_name_regex    => ".i\s+([^\s:]+).*";
       package_list_version_regex => ".i\s+[^\s]+\s+([^\s]+).*";
 
       package_installed_regex => ".i.*"; # packages that have been uninstalled may be listed
@@ -1006,7 +1006,7 @@ body package_method generic
     debian::
       package_changes => "bulk";
       package_list_command => "$(debian_knowledge.call_dpkg) -l";
-      package_list_name_regex    => ".i\s+([^\s]+).*";
+      package_list_name_regex    => ".i\s+([^\s:]+).*";
       package_list_version_regex => ".i\s+[^\s]+\s+([^\s]+).*";
       package_installed_regex => ".i.*"; # packages that have been uninstalled may be listed
       package_name_convention => "$(name)";

--- a/libraries/cfengine_stdlib.cf
+++ b/libraries/cfengine_stdlib.cf
@@ -1773,7 +1773,7 @@ body package_method apt
 {
       package_changes => "bulk";
       package_list_command => "$(debian_knowledge.call_dpkg) -l";
-      package_list_name_regex    => ".i\s+([^\s]+).*";
+      package_list_name_regex    => ".i\s+([^\s:]+).*";
       package_list_version_regex => ".i\s+[^\s]+\s+([^\s]+).*";
       package_installed_regex => ".i.*"; # packages that have been uninstalled may be listed
       package_name_convention => "$(name)";
@@ -1823,7 +1823,7 @@ body package_method apt_get
 {
       package_changes => "bulk";
       package_list_command => "$(debian_knowledge.call_dpkg) -l";
-      package_list_name_regex    => ".i\s+([^\s]+).*";
+      package_list_name_regex    => ".i\s+([^\s:]+).*";
       package_list_version_regex => ".i\s+[^\s]+\s+([^\s]+).*";
       package_installed_regex => ".i.*"; # packages that have been uninstalled may be listed
       package_name_convention => "$(name)";
@@ -1853,7 +1853,7 @@ body package_method apt_get_release(release)
 {
       package_changes => "bulk";
       package_list_command => "$(debian_knowledge.call_dpkg) -l";
-      package_list_name_regex    => ".i\s+([^\s]+).*";
+      package_list_name_regex    => ".i\s+([^\s:]+).*";
       package_list_version_regex => ".i\s+[^\s]+\s+([^\s]+).*";
       package_installed_regex => ".i.*"; # packages that have been uninstalled may be listed
       package_name_convention => "$(name)";
@@ -1890,7 +1890,7 @@ body package_method dpkg_version(repo)
       package_list_update_command => "$(debian_knowledge.call_apt_get) update";
       package_list_update_ifelapsed => "240";
 
-      package_list_name_regex    => ".i\s+([^\s]+).*";
+      package_list_name_regex    => ".i\s+([^\s:]+).*";
       package_list_version_regex => ".i\s+[^\s]+\s+([^\s]+).*";
 
       package_installed_regex => ".i.*"; # packages that have been uninstalled may be listed
@@ -2619,7 +2619,7 @@ body package_method generic
     debian::
       package_changes => "bulk";
       package_list_command => "$(debian_knowledge.call_dpkg) -l";
-      package_list_name_regex    => ".i\s+([^\s]+).*";
+      package_list_name_regex    => ".i\s+([^\s:]+).*";
       package_list_version_regex => ".i\s+[^\s]+\s+([^\s]+).*";
       package_installed_regex => ".i.*"; # packages that have been uninstalled may be listed
       package_name_convention => "$(name)";


### PR DESCRIPTION
This is a proposal related to https://cfengine.com/dev/issues/3280.

Following previous discussion with @tzz from https://github.com/cfengine/copbl/pull/30 and https://github.com/cfengine/core/pull/904 , here is a new Pull Request on the good repository for CFEngine Standard Library.

This Pull Request will permit to compare on Debian Wheezy the name of the package installed and the name of the package promised. Since Wheezy, Debian is multiarch and the actual comparison does not work since the name contains `:amd64`, `:i586`,etc...

To fix that issue we have to add into the regexp for the name of the package to not match what contains `:`. By its simplicity this modification is compatible with previous Debian version.

Hope it will fit your recommendations.
