### PR TITLE
Resubmit services.cf with changes

### DIFF
--- a/lib/3.6/services.cf
+++ b/lib/3.6/services.cf
@@ -71,128 +71,138 @@ body service_method force_deps
 ##
 
 bundle agent standard_services(service,state)
-
- # There's multiple ways you can add new services to this list.
- # Here's few examples:
- #
- # a) The zeroconf mode; If the new service matches these rules,
- #    you don't need to add anything to the standard_services:
- #
- #  1. Your init script basename = $(service)
- #  2. Your init script argument = $(state)
- #  3. Your init script lives in /etc/init.d/ (for non-*bsd),
- #     or /etc/rc.d/ (for *bsd)
- #  4. Your process regex pattern = \b$(service)\b
- #  5. You call the init as /etc/init.d/<script> <arg> (for non-*bsd), 
- #     or /etc/rc.d/<script> <arg> (for *bsd)
- #
- # b) If the 1st rule doesn't match, but rest does:
- #
- #   Use the "baseinit[$(service)]" array to point towards your
- #   init script's basename. For example:
- #
- #    "baseinit[www]" string => "httpd";
- #
- #   This would fire up init script /etc/init.d/httpd, instead of
- #   the default /etc/init.d/www. From /etc/rc.d/ if you're on *bsd system.
- #
- # c) If the 4th rule doesn't match, but rest does:
- #
- #   Use the "pattern[$(service)]" array to specify your own
- #   regex match. It's advisable to use conservative regex so
- #   there's less chance of getting a mismatch.
- #
- #    "pattern[www]" string => ".*httpd.*";
- #
- #   Instead of matching the default '\bwww\b', this now matches
- #   your given string,
- #
- # d) 5th rule doesn't match:
- #
- #   If you can specify the init system used. 
- #    Currently supported: sysvinitd, sysvservice, systemd
- #   
- #     "init[www]" string => "sysvservice";
- #     "init[www]" string => "sysvinitd";
- #     "init[www]" string => "systemd";
- # 
- #   ^^ The above is not a valid syntax as you can only use one init[]
- #      per service, but it shows all the currently supported ones.
- #
- #     "sysvservice" == /(usr/)?sbin/service
- #     "sysvinitd"   == /etc/init.d/ (non-*bsd) | /etc/rc.d/ (*bsd)
- #     "systemd"     == /bin/systemctl
- #
- # e) 2nd and 3rd rule matches, but rest doesn't:
- #
- #   Use a combination of the "pattern[]", "baseinit[]" and "init[]",
- #   to fill your need.
- #
- #     "baseinit[www]" string => "httpd";
- #     "pattern[www]"  string => ".*httpd.*";
- #     "init[www]"     string => "sysvservice";
- #
- # f) As a fallback, if none of the above rules match, you can also
- #    define exactly what you need for each $(state).
- #
- #    "startcommand[rhnsd]"   string => "/sbin/service rhnsd start";
- #    "restartcommand[rhnsd]" string => "/sbin/service rhnsd restart";
- #    "reloadcommand[rhnsd]"  string => "/sbin/service rhnsd reload";
- #    "stopcommand[rhnsd]"    string => "/sbin/service rhnsd stop";
- #    "pattern[rhnsd]"        string => "rhnsd";
- # 
- # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
- #
- # If *any* of the "(re)?(start|load|stop)command" variables are set for
- # your service, they take *priority* in case there's conflict of intent
- # with other data.
- # 
- # Say you'd have the following service definition:
- #
- #    "startcommand[qwerty]"   string => "/sbin/service qwerty start";
- #    "stopcommand[qwerty]"    string => "/sbin/service qwerty stop";
- #    "pattern[qwerty]"        string => ".*qwerty.*";
- #    "baseinit[qwerty]"       string => "asdfgh"
- #    "init[qwerty]"           string => "systemd";
- # 
- # There's a conflict of intent now. As the ~command definitions takes
- # priority, this kind of service config for "qwerty" would execute the
- # following commands:
- #
- #   start:   "/sbin/service qwerty start"
- #   stop:    "/sbin/service qwerty stop"
- #   restart: "/bin/systemctl asdfgh restart"
- #   reload:  "/bin/systemctl asdfgh reload"
- #
-
+# @brief Standard services bundle, used by CFEngine by default
+# @author CFEngine AS
+# @author Tero Kantonen <prkele@gmail.com>
+# @params service specific service to control
+# @params state desired state for that service
+#
+# This bundle is used by CFEngine if you don't specify a services
+# handler explicitly.
+#
+# It receives the service name and the desired service state, then
+# does the needful to reach the desired state..
+#
+# **Example:**
+# ```cf3
+# services:
+#     "ntp" service_policy => "start";
+#     "ssh" service_policy => "stop";
+# ```
+#
+# There's multiple ways you can add new services to this list.
+# Here's few examples:
+#
+# a) The zeroconf mode; If the new service matches these rules,
+#    you don't need to add anything to the standard_services:
+#
+#  1. Your init script basename = $(service)
+#  2. Your init script argument = $(state)
+#  3. Your init script lives in /etc/init.d/ (for non-*bsd),
+#     or /etc/rc.d/ (for *bsd)
+#  4. Your process regex pattern = \b$(service)\b
+#  5. You call the init as /etc/init.d/<script> <arg> (for non-*bsd),
+#     or /etc/rc.d/<script> <arg> (for *bsd)
+#
+# b) If the 1st rule doesn't match, but rest does:
+#
+#   Use the "baseinit[$(service)]" array to point towards your
+#   init script's basename. For example:
+#
+#    "baseinit[www]" string => "httpd";
+#
+#   This would fire up init script /etc/init.d/httpd, instead of
+#   the default /etc/init.d/www. From /etc/rc.d/ if you're on *bsd system.
+#
+# c) If the 4th rule doesn't match, but rest does:
+#
+#   Use the "pattern[$(service)]" array to specify your own
+#   regex match. It's advisable to use conservative regex so
+#   there's less chance of getting a mismatch.
+#
+#    "pattern[www]" string => ".*httpd.*";
+#
+#   Instead of matching the default '\bwww\b', this now matches
+#   your given string,
+#
+# d) 5th rule doesn't match:
+#
+#   If you can specify the init system used.
+#    Currently supported: sysvinitd, sysvservice, systemd
+#
+#     "init[www]" string => "sysvservice";
+#     "init[www]" string => "sysvinitd";
+#     "init[www]" string => "systemd";
+#
+#   ^^ The above is not a valid syntax as you can only use one init[]
+#      per service, but it shows all the currently supported ones.
+#
+#     "sysvservice" == /(usr/)?sbin/service
+#     "sysvinitd"   == /etc/init.d/ (non-*bsd) | /etc/rc.d/ (*bsd)
+#     "systemd"     == /bin/systemctl
+#
+# e) 2nd and 3rd rule matches, but rest doesn't:
+#
+#   Use a combination of the "pattern[]", "baseinit[]" and "init[]",
+#   to fill your need.
+#
+#     "baseinit[www]" string => "httpd";
+#     "pattern[www]"  string => ".*httpd.*";
+#     "init[www]"     string => "sysvservice";
+#
+# f) As a fallback, if none of the above rules match, you can also
+#    define exactly what you need for each $(state).
+#
+#    "startcommand[rhnsd]"   string => "/sbin/service rhnsd start";
+#    "restartcommand[rhnsd]" string => "/sbin/service rhnsd restart";
+#    "reloadcommand[rhnsd]"  string => "/sbin/service rhnsd reload";
+#    "stopcommand[rhnsd]"    string => "/sbin/service rhnsd stop";
+#    "pattern[rhnsd]"        string => "rhnsd";
+#
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+#
+# If *any* of the "(re)?(start|load|stop)command" variables are set for
+# your service, they take *priority* in case there's conflict of intent
+# with other data.
+#
+# Say you'd have the following service definition:
+#
+#    "startcommand[qwerty]"   string => "/sbin/service qwerty start";
+#    "stopcommand[qwerty]"    string => "/sbin/service qwerty stop";
+#    "pattern[qwerty]"        string => ".*qwerty.*";
+#    "baseinit[qwerty]"       string => "asdfgh"
+#    "init[qwerty]"           string => "systemd";
+#
+# There's a conflict of intent now. As the ~command definitions takes
+# priority, this kind of service config for "qwerty" would execute the
+# following commands:
+#
+#   start:   "/sbin/service qwerty start"
+#   stop:    "/sbin/service qwerty stop"
+#   restart: "/bin/systemctl asdfgh restart"
+#   reload:  "/bin/systemctl asdfgh reload"
+#
 {
-      # DATA,
-
   vars:
+      "all_states" slist => { "start", "restart", "reload", "stop" };
 
-    any::
       "inits" slist => { "sysvinitd", "sysvservice", "systemd" },
       comment => "Currently handled init systems";
 
       "default[prefix][sysvservice]" string => "$(paths.path[service]) ",
-      comment => "Set default prefix for executing sysv service script operations";
+      comment => "Command for sysv service interactions";
+
       "default[prefix][systemd]" string => "/bin/systemctl ",
-      comment => "Set default prefix for executing systmctl operations";
+      comment => "Command for systemd interactions";
 
-    openbsd|freebsd|netbsd::
-      "default[prefix][sysvinitd]" string => "/etc/rc.d/",
-      comment => "Set default prefix for executing sysv init script operations.";
-    !openbsd.!freebsd.!netbsd::
-      "default[prefix][sysvinitd]" string => "/etc/init.d/",
-      comment => "Set default prefix for executing sysv init script operations.";
+      "default[prefix][sysvinitd]" string => ifelse("openbsd", "/etc/rc.d/",
+                                                    "freebsd", "/etc/rc.d/",
+                                                    "netbsd", "/etc/rc.d/",
+                                                    "/etc/init.d/"),
+      comment => "Command prefix for sysv init script interactions";
 
-    any::
-      "default[cmd][sysvinitd]" string => "$(default[prefix][sysvinitd])$(service) $(state)",
-      comment => "Set default init command for sysv init.d script";
-      "default[cmd][sysvservice]" string => "$(default[prefix][sysvservice])$(service) $(state)",
-      comment => "Set default init command for sysv service script";
-      "default[cmd][systemd]" string => "$(default[prefix][systemd])$(service) $(state)",
-      comment => "Set default init command for systemctl";
+      "default[cmd][$(inits)]" string => "$(default[prefix][$(inits)])$(service) $(state)",
+      comment => "Default command to control the service";
 
       "default[pattern]" string => "\b$(service)\b",
       comment => "Set default pattern for proc matching";
@@ -311,7 +321,8 @@ bundle agent standard_services(service,state)
       "pattern[www]"              string => ".*httpd.*";
 
       "baseinit[ssh]"             string => "sshd";
-      "pattern[ssh]"              string => ".*sshd.*";
+      # filter out "sshd: ..." children
+      "pattern[ssh]"              string => ".*\Ssshd.*";
 
       "init[rhnsd]"               string => "sysvservice";
       "pattern[rhnsd]"            string => "rhnsd";
@@ -359,20 +370,10 @@ bundle agent standard_services(service,state)
       "baseinit[omsa-dataeng]"    string => "dataeng";
       "pattern[omsa-dataeng]"     string => ".*dsm_sa_datamgr.*";
 
-
-      # METHODS that implement these ............................................
-
-
   classes:
-
-      "start" expression => strcmp("start","$(state)"),
-      comment => "Check if to start a service";
-      "restart" expression => strcmp("restart","$(state)"),
-      comment => "Check if to restart a service";
-      "reload" expression => strcmp("reload","$(state)"),
-      comment => "Check if to reload a service";
-      "stop"  expression => strcmp("stop","$(state)"),
-      comment => "Check if to stop a service";
+      # Set classes for each possible state after $(all_states)
+      "$(all_states)" expression => strcmp($(all_states), $(state)),
+      comment => "Set a class named after the desired state";
 
       "$(inits)_set" expression => strcmp("$(init[$(service)])","$(inits)"),
       comment => "Check if init system is specified";
@@ -388,6 +389,7 @@ bundle agent standard_services(service,state)
       comment => "Verify that the service appears in the process table",
       restart_class => "start_$(service)",
       ifvarclass => and(isvariable("pattern[$(service)]"));
+
 
       "$(default[pattern])" ->  { "@(stakeholders[$(service)])" }
 
@@ -405,6 +407,7 @@ bundle agent standard_services(service,state)
       ifvarclass => and(isvariable("stopcommand[$(service)]"),
                         isvariable("pattern[$(service)]"));
 
+
       "$(default[pattern])" -> { "@(stakeholders[$(service)])" }
 
       comment => "Verify that the service does not appear in the process",
@@ -412,7 +415,8 @@ bundle agent standard_services(service,state)
       signals => { "term", "kill"},
       ifvarclass => and(isvariable("stopcommand[$(service)]"),
                         not(isvariable("pattern[$(service)]")));
-##
+
+
       "$(pattern[$(service)])" -> { "@(stakeholders[$(service)])" }
 
       comment => "Verify that the service does not appear in the process",
@@ -423,6 +427,7 @@ bundle agent standard_services(service,state)
                         isvariable("pattern[$(service)]"),
                         "no_inits_set");
 
+
       "$(pattern[$(service)])" -> { "@(stakeholders[$(service)])" }
 
       comment => "Verify that the service does not appear in the process",
@@ -432,6 +437,7 @@ bundle agent standard_services(service,state)
                         isvariable("baseinit[$(service)]"),
                         isvariable("pattern[$(service)]"),
                         canonify("$(inits)_set"));
+
 ##
       "$(default[pattern])" -> { "@(stakeholders[$(service)])" }
 
@@ -443,6 +449,7 @@ bundle agent standard_services(service,state)
                         not(isvariable("pattern[$(service)]")),
                         "no_inits_set");
 
+
       "$(default[pattern])" -> { "@(stakeholders[$(service)])" }
 
       comment => "Verify that the service does not appear in the process",
@@ -452,6 +459,7 @@ bundle agent standard_services(service,state)
                         isvariable("baseinit[$(service)]"),
                         not(isvariable("pattern[$(service)]")),
                         canonify("$(inits)_set"));
+
 ##
       "$(pattern[$(service)])" -> { "@(stakeholders[$(service)])" }
 
@@ -462,6 +470,7 @@ bundle agent standard_services(service,state)
                         not(isvariable("baseinit[$(service)]")),
                         isvariable("pattern[$(service)]"),
                         "no_inits_set");
+
 
       "$(pattern[$(service)])" -> { "@(stakeholders[$(service)])" }
 
@@ -483,6 +492,7 @@ bundle agent standard_services(service,state)
                         not(isvariable("baseinit[$(service)]")),
                         not(isvariable("pattern[$(service)]")),
                         "no_inits_set");
+
 
       "$(default[pattern])" -> { "@(stakeholders[$(service)])" }
 
@@ -587,4 +597,51 @@ bundle agent standard_services(service,state)
       ifvarclass => and(not(isvariable("reloadcommand[$(service)]")),
                         not(isvariable("baseinit[$(service)]")),
                         canonify("$(inits)_set"));
+
+  reports:
+    inform_mode::
+      "$(this.bundle): Using init system $(inits)"
+      ifvarclass => and(canonify("$(inits)_set"));
+
+      "$(this.bundle): No init system is set, using $(default[init])"
+      ifvarclass => "no_inits_set";
+
+      "$(this.bundle): The service $(service) needs to be started"
+      ifvarclass => and(canonify("start_$(service)"));
+
+      "$(this.bundle): The service pattern is provided: $(pattern[$(service)])"
+      ifvarclass => and(isvariable("pattern[$(service)]"));
+
+      "$(this.bundle): The default service pattern was used: $(default[pattern])"
+      ifvarclass => not(isvariable("pattern[$(service)]"));
+
+      "$(this.bundle): The stopcommand is provided: $(stopcommand[$(service)])"
+      ifvarclass => and(isvariable("stopcommand[$(service)]"));
+
+      "$(this.bundle): The stopcommand is NOT provided, using default"
+      ifvarclass => not(isvariable("stopcommand[$(service)]"));
+
+      "$(this.bundle): The startcommand is provided: $(startcommand[$(service)])"
+      ifvarclass => and(isvariable("startcommand[$(service)]"));
+
+      "$(this.bundle): The startcommand is NOT provided, using default"
+      ifvarclass => not(isvariable("startcommand[$(service)]"));
+
+      "$(this.bundle): The restartcommand is provided: $(restartcommand[$(service)])"
+      ifvarclass => and(isvariable("restartcommand[$(service)]"));
+
+      "$(this.bundle): The restartcommand is NOT provided, using default"
+      ifvarclass => not(isvariable("restartcommand[$(service)]"));
+
+      "$(this.bundle): The reloadcommand is provided: $(reloadcommand[$(service)])"
+      ifvarclass => and(isvariable("reloadcommand[$(service)]"));
+
+      "$(this.bundle): The reloadcommand is NOT provided, using default"
+      ifvarclass => not(isvariable("reloadcommand[$(service)]"));
+
+      "$(this.bundle): The baseinit is provided: $(baseinit[$(service)])"
+      ifvarclass => and(isvariable("baseinit[$(service)]"));
+
+      "$(this.bundle): The baseinit is NOT provided, using default"
+      ifvarclass => not(isvariable("baseinit[$(service)]"));
 }


### PR DESCRIPTION
@teroka this is https://github.com/cfengine/masterfiles/pull/8 with two extra commits:

One, a change revert:
- we have to take out the changes to `lib/3.5` because they are not bug fixes.  Convince me otherwise if you feel strongly about it, because I'd have to propose it to @vohi and his team.

Two, my fixups:
- I fixed up some minor whitespace and commenting issues
- used `ifelse` instead of the explicit negation context
- fixed sshd pattern on Redhat (all the patterns should be tested similarly)

I tested this and it worked OK for me, so I'm going to merge the PR and then we can iterate further as we discussed in https://github.com/cfengine/masterfiles/pull/8
