### PR TITLE
Redmine#3584: add "make check" target that takes TESTS parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,19 @@
 cf_promises_validated
+
+# acceptance tests
+tests/acceptance/*.log
+tests/acceptance/.succeeded
+tests/acceptance/workdir
+tests/acceptance/mock-package-manager
+tests/acceptance/mock-package-manager.exe
+tests/acceptance/xml-c14nize
+tests/acceptance//xml-c14nize.exe
+tests/acceptance/dnswrapper.so
+tests/*/*.xml
+tests/*/xml.tmp
+tests/*/xml_tmp_*
+tests/*/*.trs
+
+# copied from core
+tests/acceptance/default.cf.sub
+tests/acceptance/testall

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+PWD:=$(shell pwd)
+
+ifeq ($(CORE),)
+  CORE:=../
+endif
+
+copy:
+	cp $(CORE)/tests/acceptance/default.cf.sub tests/acceptance
+	cp $(CORE)/tests/acceptance/testall tests/acceptance
+
+check: copy
+	cd tests/acceptance && ./testall --agent=$(CORE)/cf-agent/cf-agent --cfpromises=$(CORE)/cf-promises/cf-promises --cfserverd=$(CORE)/cf-serverd/cf-serverd --cfkey=$(CORE)/cf-key/cf-key
+
+checklog: copy
+	cd tests/acceptance && ./testall --agent=$(CORE)/cf-agent/cf-agent --cfpromises=$(CORE)/cf-promises/cf-promises --cfserverd=$(CORE)/cf-serverd/cf-serverd --cfkey=$(CORE)/cf-key/cf-key --printlog

--- a/tests/acceptance/README.md
+++ b/tests/acceptance/README.md
@@ -1,0 +1,5 @@
+To use the acceptance tests:
+
+* check out core from https://github.com/cfengine/core to directory `$CHECKOUT`
+* run `make check CORE=$CHECKOUT`
+* to see the test logs, run `make checklog CORE=$CHECKOUT`

--- a/tests/acceptance/lib/bodies/common/always.cf
+++ b/tests/acceptance/lib/bodies/common/always.cf
@@ -1,0 +1,43 @@
+#######################################################
+#
+# Test body always
+#
+#######################################################
+
+body common control
+{
+      inputs => { '../../../default.cf.sub', '../../../../../$(sys.local_libdir)/common.cf' };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+}
+
+#######################################################
+
+bundle agent test
+{
+  reports:
+      "" classes => always("ok_a");
+}
+
+
+#######################################################
+
+bundle agent check
+{
+  classes:
+      "ok" and => { "ok_a" };
+
+  reports:
+    DEBUG::
+
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}


### PR DESCRIPTION
See https://cfengine.com/dev/issues/3584

~~Requires the `@include` mechanism from https://github.com/cfengine/core/pull/902~~

Reworked as suggested by @kacfengine and in conjunction with https://github.com/cfengine/core/pull/1058

@cduclos @kacfengine @nickanderson please review
