### PR TITLE
Redmine#2112: pure and derived Debian and Red Hat classes

### DIFF
--- a/inventory/debian.cf
+++ b/inventory/debian.cf
@@ -3,4 +3,7 @@ bundle common inventory_debian
 #
 # This common bundle is for Debian inventory work.
 {
+  classes:
+      "pure_debian" expression => "debian.!ubuntu";
+      "debian_derived" expression => "debian.!pure_debian";
 }

--- a/inventory/redhat.cf
+++ b/inventory/redhat.cf
@@ -3,4 +3,7 @@ bundle common inventory_redhat
 #
 # This common bundle is for Red Hat Linux inventory work.
 {
+  classes:
+      "pure_redhat" expression => "redhat.!centos";
+      "redhat_derived" expression => "redhat.!pure_redhat";
 }


### PR DESCRIPTION
Assuming that only CentOS gets `redhat` and only Ubuntu gets `debian` right now.  Please correct me if I'm wrong.
