### PR TITLE
Redmine#3169: add cfengine_internal_encrypt_transfers class to set rcp/pcp encrypt to true

### DIFF
--- a/def.cf
+++ b/def.cf
@@ -70,5 +70,8 @@ bundle common def
     ### Enable special features policies. Set to "any" to enable.
 
     # Internal CFEngine log files rotation
-    "cfengine_internal_rotate_logs" expression  =>  "!any";
+    "cfengine_internal_rotate_logs" expression => "!any";
+
+    # Transfer policies and binaries with encryption
+    "cfengine_internal_encrypt_transfers" expression => "!any";
 }

--- a/update.cf
+++ b/update.cf
@@ -68,6 +68,11 @@ bundle agent cfe_internal_update
       comment => "Check for $(sys.masterdir)/promises.cf",
       handle => "update_classes_files_ok";
 
+      # Transfer policies and binaries with encryption
+      # you can also request it from the command line with
+      # -Dcfengine_internal_encrypt_transfers
+      "cfengine_internal_encrypt_transfers" expression => "!any";
+
       #
 
   processes:
@@ -231,6 +236,9 @@ body copy_from u_rcp(from,server)
     !am_policy_hub::
 
       servers => { "$(server)" };
+
+    cfengine_internal_encrypt_transfers::
+      encrypt => "true";
 }
 
 #########################################################

--- a/update/update_bins.cf
+++ b/update/update_bins.cf
@@ -258,6 +258,9 @@ body copy_from u_pcp(from,server)
     !am_policy_hub::
 
       servers => { "$(server)" };
+
+    cfengine_internal_encrypt_transfers::
+      encrypt => "true";
 }
 
 ################################################################################

--- a/update/update_policy.cf
+++ b/update/update_policy.cf
@@ -230,6 +230,9 @@ body copy_from u_rcp(from,server)
     !am_policy_hub::
 
       servers => { "$(server)" };
+
+    cfengine_internal_encrypt_transfers::
+      encrypt => "true";
 }
 
 #########################################################


### PR DESCRIPTION
This new class can be set in `def.cf` for regular updates or in `update.cf` for standalone updates.
