### PR TITLE
Make cfe_internal_selinux parameters less imperative

### DIFF
--- a/cfe_internal/CFE_cfengine.cf
+++ b/cfe_internal/CFE_cfengine.cf
@@ -29,9 +29,9 @@ bundle agent cfe_internal_management
       handle => "cfe_internal_management_update_folders",
       comment => "Create empty directories for CFE self-upgrade";
 
-      #### cfengine_selinux() can be "fix" or "disable"
+      #### cfengine_internal_selinux() can be "enabled" or "disabled"
 
-      "hub" usebundle => cfe_internal_selinux("fix"),
+      "hub" usebundle => cfe_internal_selinux("enabled"),
       handle => "cfe_internal_management_fix_selinux",
       comment => "Fix SELinux to be able to run Mission Portal and Mongo DB";
 

--- a/cfe_internal/CFE_hub_specific.cf
+++ b/cfe_internal/CFE_hub_specific.cf
@@ -201,11 +201,11 @@ bundle agent cfe_internal_selinux(condition)
       comment => "Install packages from the list",
       handle => "cfe_internal_selinux_classes_have_semanage";
 
-      "fix_selinux"        expression => strcmp("$(condition)","fix"),
+      "enable_selinux"        expression => strcmp("$(condition)","enabled"),
       comment => "Check to allow SELinux rules for Mission Portal to function",
-      handle => "cfe_internal_selinux_classes_fix_selinux";
+      handle => "cfe_internal_selinux_classes_enable_selinux";
 
-      "disable_selinux"    expression => strcmp("$(condition)","disable"),
+      "disable_selinux"    expression => strcmp("$(condition)","disabled"),
       comment => "Check to disable SELinux",
       handle => "cfe_internal_selinux_classes_disable_selinux";
 
@@ -239,7 +239,7 @@ bundle agent cfe_internal_selinux(condition)
 
   commands:
 
-    selinux_enforcing.fix_selinux.have_semanage::
+    selinux_enforcing.enable_selinux.have_semanage::
 
       "/usr/bin/chcon -R -h -t httpd_sys_content_t /var/cfengine/lib"
       comment => "Allow apache to load CFEngine shared libraries with SELinux on",
@@ -256,7 +256,7 @@ bundle agent cfe_internal_selinux(condition)
 
       # Allow httpd_can_network_connect so HTTPD will be able to talk with MongoDB
 
-    httpd_can_network_connect.fix_selinux::
+    httpd_can_network_connect.enable_selinux::
 
       "/usr/sbin/setsebool -P httpd_can_network_connect 1"
       comment => "SELinux allows HTTPD to use files on the host",


### PR DESCRIPTION
closes: https://cfengine.com/dev/issues/3633
