### PR TITLE
Centralize log rotation to cfe_internal_log_roation

### DIFF
--- a/cfe_internal/CFE_cfengine.cf
+++ b/cfe_internal/CFE_cfengine.cf
@@ -69,19 +69,9 @@ bundle agent cfe_internal_management
       handle => "cfe_internal_management_limit_cfe_agents",
       comment => "Manage CFE processes";
 
-      "any" usebundle => cfe_internal_garbage_collection,
-      handle => "cfe_internal_management_garbage_collection",
-      comment => "Log rotate and tidy up CFE internal usage files";
-
-    cfengine_internal_rotate_logs::
-      # CFEngine generates internal log files that need to be rotated.
-      # Have a look at def.cf to enable rotation of these files
-      "rotate_promise_summary" usebundle => logrotate("@(def.cfe_log_files)", "1m", "10"),
-                               comment   => "Rotate log files once their size reach 1MB, keep 10 versions";
-
-      "rotate_outputs"         usebundle => prunedir("@(def.cfe_log_dirs)", "30"),
-                               comment   => "Delete outputs/* files older than 30 days";
-
+      "any" usebundle => cfe_internal_log_rotation,
+      handle => "cfe_internal_management_log_rotation",
+      comment => "Rotate CFEngine logs so we dont fill the disk";
 }
 
 ##################################################################
@@ -207,80 +197,25 @@ body copy_from local_cp_libtwin(from)
 
 ##################################################################
 #
-# cfe_internal_garbage_collection
-#  - do a garbage clean up. Mostly CFEngine 3 Enterprise logs
+# cfe_internal_log_rotation
+#  - Rotate logs and clean up old files so the disk doesnt get full
 #
 ##################################################################
 
-bundle agent cfe_internal_garbage_collection
+
+bundle agent cfe_internal_log_rotation
+# @brief Manage CFEngine log files so they dont fill up disks
+# See def.cf to enable rotation
 {
-  files:
 
-    Sunday::
+  methods:
 
-      "$(sys.workdir)/cf_repair.log"
-      comment => "Rotate the promises repaired logs each week",
-      handle => "cfe_internal_garbage_collection_files_cf_repair_log",
-      rename => rotate("7"),
-      action => if_elapsed("10000");
+    cfengine_internal_rotate_logs::
+      # CFEngine generates internal log files that need to be rotated.
+      # Have a look at def.cf to enable rotation of these files
+      "rotate_promise_summary" usebundle => logrotate("@(def.cfe_log_files)", "1m", "10"),
+                               comment   => "Rotate log files once their size reach 1MB, keep 10 versions";
 
-      "$(sys.workdir)/cf_notkept.log"
-      comment => "Rotate the promises not kept logs each week",
-      handle => "cfe_internal_garbage_collection_files_cf_notkept_log",
-      rename => rotate("7"),
-      action => if_elapsed("10000");
-
-      "$(sys.workdir)/promise_summary.log"
-      comment => "Rotate the promises not kept logs each week",
-      handle => "cfe_internal_garbage_collection_files_promise_log",
-      rename => rotate("7"),
-      action => if_elapsed("10000");
-
-      "$(sys.workdir)/state/cf_value.log"
-      comment => "Rotate the promises not kept logs each week",
-      handle => "cfe_internal_garbage_collection_files_cf_value_log",
-      rename => rotate("7"),
-      action => if_elapsed("10000");
-
-    any::
-
-      "$(sys.workdir)/outputs"
-      comment => "Garbage collection of any output files",
-      handle => "cfe_internal_garbage_collection_files_tidy_outputs",
-      delete => tidy,
-      file_select => days_old("7"),
-      depth_search => recurse("inf");
-
-      # Other resources
-    !(darwin|windows)::
-
-      #   "/tmp"  # this is a symlink on Macs
-      #           comment => "Garbage collection of any temporary files",
-      #            handle => "cfe_internal_garbage_collection_files_tidy_tmp",
-      #            delete => tidy,
-      #       file_select => days_old("3"),
-      #      depth_search => recurse("inf");
-
-    debian::
-
-      "/var/log/apache2/.*bz"
-      comment => "Garbage collection of rotated log files",
-      handle => "cfe_internal_garbage_collection_files_tidy_bz",
-      delete => tidy,
-      file_select => days_old("30");
-
-      "/var/log/apache2/.*gz"
-      comment => "Garbage collection of rotated log files",
-      handle => "cfe_internal_garbage_collection_files_tidy_gz",
-      delete => tidy,
-      file_select => days_old("30");
-
-    SuSE::
-
-      "/var/log/zypper.log"
-      comment => "Prevent the zypper log from choking the disk",
-      handle => "cfe_internal_garbage_collection_files_zypper_log",
-      rename => rotate("0"),
-      action => if_elapsed("10000");
-
+      "rotate_outputs"         usebundle => prunedir("@(def.cfe_log_dirs)", "30"),
+                               comment   => "Delete outputs/* files older than 30 days";
 }

--- a/def.cf
+++ b/def.cf
@@ -58,7 +58,12 @@ bundle common def
       # CFEngine own log files
       "cfe_log_files"    slist => {
                                     "$(sys.workdir)/cf3.$(sys.host).runlog",
-                                    "$(sys.workdir)/promise_summary.log"
+                                    "$(sys.workdir)/cf_notkept.log",
+                                    "$(sys.workdir)/cf_repair.log",
+                                    "$(sys.workdir)/httpd/logs/access_log",# Mission Portal
+                                    "$(sys.workdir)/httpd/logs/error_log", # Mission Portal
+                                    "$(sys.workdir)/promise_summary.log",
+                                    "$(sys.workdir)/state/cf_value.log",
                                   };
 
       "cfe_log_dirs"     slist => {


### PR DESCRIPTION
closes: https://cfengine.com/dev/issues/3639 & https://cfengine.com/dev/issues/3632
