### PR TITLE
fix#3482 creating more Solaris folders on self-upgrade purpose

### DIFF
--- a/cfe_internal/CFE_hub_specific.cf
+++ b/cfe_internal/CFE_hub_specific.cf
@@ -62,6 +62,13 @@ bundle agent cfe_internal_update_folders
 			"debian_7_x86_64",
 			"windows_i686",
 			"windows_x86_64",
+      "sunos_5.8_sun4u",
+      "sunos_5.8_sun4v",
+      "sunos_5.9_sun4u",
+      "sunos_5.9_sun4v",
+      "sunos_5.10_sun4u",
+      "sunos_5.10_sun4v",
+      "sunos_5.10_i86pc",
       },
       comment => "Define a list for $(sys.flavour)_$(sys.arch) directories",
       handle => "cfe_internal_update_folders_vars_dirs";


### PR DESCRIPTION
Folders to drop solaris package + admin files seems to be missing. Create it by CFEngine policy.
