### PR TITLE
Fix cf-runagent configuration to work with solaris

### DIFF
--- a/controls/cf_serverd.cf
+++ b/controls/cf_serverd.cf
@@ -41,13 +41,16 @@ body server control
       cfruncommand => "$(sys.cf_twin) -f \"$(sys.update_policy_path)\" & $(sys.cf_agent)";
 
     hpux::
-      cfruncommand => "/bin/sh -c \"SHLIB_PATH=\"/var/cfengine/lib-twin\" $(sys.cf_twin) -f $(sys.update_policy_path)\" ; $(sys.cf_agent)";
+      cfruncommand => "$(def.cf_runagent_shell) -c \"SHLIB_PATH=\"/var/cfengine/lib-twin\" $(sys.cf_twin) -f $(sys.update_policy_path)\" ; $(sys.cf_agent)";
 
     aix::
-      cfruncommand => "/bin/sh -c \"LIBPATH=\"/var/cfengine/lib-twin\" $(sys.cf_twin) -f $(sys.update_policy_path)\" ; $(sys.cf_agent)";
+      cfruncommand => "$(def.cf_runagent_shell) -c \"LIBPATH=\"/var/cfengine/lib-twin\" $(sys.cf_twin) -f $(sys.update_policy_path)\" ; $(sys.cf_agent)";
 
-    !(windows|hpux|aix)::
-      cfruncommand => "/bin/sh -c \"LD_LIBRARY_PATH=\"/var/cfengine/lib-twin\" $(sys.cf_twin) -f $(sys.update_policy_path)\" ; $(sys.cf_agent)";
+    solaris::
+      cfruncommand => "$(def.cf_runagent_shell) -c \"LD_LIBRARY_PATH=\"/var/cfengine/lib-twin\" $(sys.cf_twin) -f $(sys.update_policy_path)\" ; $(sys.cf_agent)"; 
+
+    !(windows|hpux|aix|solaris)::
+      cfruncommand => "$(def.cf_runagent_shell) -c \"LD_LIBRARY_PATH=\"/var/cfengine/lib-twin\" $(sys.cf_twin) -f $(sys.update_policy_path)\" ; $(sys.cf_agent)";
 
 }
 
@@ -86,7 +89,7 @@ bundle server access_rules()
       comment => "Grant access to plugins directory",
       admit => { ".*$(def.domain)", @(def.acl) };
 
-      "/bin/sh"
+      "$(def.cf_runagent_shell)"
       handle => "server_access_grant_access_shell_cmd",
       comment => "Grant access to shell for cfruncommand",
       admit => { "$(sys.policy_hub)" };

--- a/def.cf
+++ b/def.cf
@@ -59,6 +59,20 @@ bundle common def
       comment => "Define plugins path",
       handle => "common_def_vars_dir_plugins";
 
+      solaris::
+      "cf_runagent_shell"
+        string  => "/usr/bin/sh",
+        comment => "Define path to shell used by cf-runagent",
+        handle  => "common_def_vars_solaris_cf_runagent_shell";
+
+      !(windows|solaris)::
+      "cf_runagent_shell"
+        string  => "/bin/sh",
+        comment => "Define path to shell used by cf-runagent",
+        handle  => "common_def_vars_cf_runagent_shell";
+
+      any::
+
       # CFEngine own log files
       "cfe_log_files"    slist => {
                                     "$(sys.workdir)/cf3.$(sys.host).runlog",


### PR DESCRIPTION
As noted here: https://cfengine.com/dev/issues/3453
Solaris does not have /bin/sh path.
