### PR TITLE
files_ok:: in enable_cfengine_agents() bundle

### DIFF
--- a/update/update_processes.cf
+++ b/update/update_processes.cf
@@ -221,7 +221,7 @@ bundle agent enable_cfengine_agents(process)
 
   processes:
 
-    files_ok::
+    !windows::
 
       "$(sys.bindir)/$(process)"
       restart_class => "restart_$(cprocess)",


### PR DESCRIPTION
I don't see `files_ok::` check in the bundle causing CFEngine processes will not be restarted. Better to change it to `!windows::` as Linux/UNIX hosts will use this bundle.

@tzz please review.
