### PR TITLE
Remove deprecated option 'skipverify'

### DIFF
--- a/controls/cf_serverd.cf
+++ b/controls/cf_serverd.cf
@@ -30,8 +30,8 @@ body server control
       trustkeysfrom         => { "127.0.0.1" , "::1", @(def.acl) };
 
       # List of hosts that don't need to verify identity with reverse DNS lookup
-      # (deprecated now that key authentication is the norm)
-      skipverify            => { ".*$(def.domain)", "127.0.0.1" , "::1", @(def.acl) };
+      # (deprecated in 3.6 now that key authentication is the norm)
+      # skipverify            => { ".*$(def.domain)", "127.0.0.1" , "::1", @(def.acl) };
 
       allowusers            => { "root" };
 


### PR DESCRIPTION
Commenting it out should make it easier for the end user when diffing.
