### PR TITLE
Remove track_value

### DIFF
--- a/controls/cf_agent.cf
+++ b/controls/cf_agent.cf
@@ -35,10 +35,4 @@ body agent control
                        # "APT_LISTCHANGES_FRONTEND=none",
       };
 
-      # Switch on tracking of promise valuation
-
-    any::
-
-      track_value => "true";
-
 }


### PR DESCRIPTION
track_value was deprecated in cfengine/core@e23056d4de4ffc762e5881cdaa02fd52ad72b993 for lack of use
