### PR TITLE
Removing cf-twin

### DIFF
--- a/controls/cf_execd.cf
+++ b/controls/cf_execd.cf
@@ -27,15 +27,15 @@ body executor control
       # cf-twin needs its own safe environment because of the update mechanism
 
     windows::
-      exec_command => "$(sys.cf_twin) -f \"$(sys.update_policy_path)\" & $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "$(sys.cf_agent) -Dcf_execd_initiated";
 
     hpux::
-      exec_command => "SHLIB_PATH=\"/var/cfengine/lib-twin\" $(sys.cf_twin) -f \"$(sys.update_policy_path)\" ; $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "$(sys.cf_agent) -Dcf_execd_initiated";
 
     aix::
-      exec_command => "LIBPATH=\"/var/cfengine/lib-twin\" $(sys.cf_twin) -f \"$(sys.update_policy_path)\" ; $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "$(sys.cf_agent) -Dcf_execd_initiated";
 
     !(windows|hpux|aix)::
-      exec_command => "LD_LIBRARY_PATH=\"/var/cfengine/lib-twin\" $(sys.cf_twin) -f \"$(sys.update_policy_path)\" ; $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "$(sys.cf_agent) -Dcf_execd_initiated";
 
 }


### PR DESCRIPTION
cf-twin is not needed anymore. The upgrade functionality was replaced
by cf-upgrade.
