### PR TITLE
Add documentation for freebsd{} and freebsd_portmaster{}

### DIFF
--- a/lib/3.5/packages.cf
+++ b/lib/3.5/packages.cf
@@ -1126,7 +1126,6 @@ body package_method freebsd
 #     package_method   =>  freebsd;
 #
 # ```
-
 {
       package_changes => "individual";
 
@@ -1169,7 +1168,6 @@ body package_method freebsd_portmaster
 #     package_policy   =>  "add",
 #     package_method   =>  freebsd_portmaster;
 #
-
 # ```
 {
       package_changes => "individual";

--- a/lib/3.6/packages.cf
+++ b/lib/3.6/packages.cf
@@ -1074,6 +1074,30 @@ basedir=default"
 ##
 
 body package_method freebsd
+# @depends common_knowledge
+# @brief FreeBSD pkg_add installation package method
+#
+# This package method interacts with FreeBSD pkg_add to install from remote 
+# repositories.
+#
+# **Example:**
+# NOTE: Do not use this method on pkgng systems! It will appear to operate 
+# normally but is highly likely to break your package system.
+#
+# ```cf3
+# Policies examples:
+#
+# -To install "perl5" from a non-default repository:
+# ----------------------------
+#
+# vars:
+#   environment => { "PACKAGESITE=http://repo.example.com/private/8_STABLE/" };
+# packages:
+#   "perl5"
+#     package_policy   =>  "add",
+#     package_method   =>  freebsd;
+#
+# ```
 {
       package_changes => "individual";
 
@@ -1097,6 +1121,27 @@ body package_method freebsd
 }
 
 body package_method freebsd_portmaster
+# @depends common_knowledge
+# @brief FreeBSD portmaster package installation method
+#
+# This package method interacts with portmaster to build and install packages.
+#
+# Note that you must use the complete package name as it appears in 
+# /usr/ports/*/name, such as 'perl5.14' rather than 'perl5'.
+# Repositories are hard-coded to /usr/ports; alternate locations are 
+# unsupported at this time.
+# This method supports both pkg_* and pkgng systems.
+#
+# **Example:**
+#
+# ```cf3
+#
+# packages:
+#   "perl5.14"
+#     package_policy   =>  "add",
+#     package_method   =>  freebsd_portmaster;
+#
+# ```
 {
       package_changes => "individual";
 


### PR DESCRIPTION
Redmine#3616 - added documentation for freebsd and freebsd_portmaster methods for 3.5.3. 
Removed one comment; can't use RPM for it anyway due to pkg/pkgng behaviors with descriptions.
