### PR TITLE
fix cf-execd/cf-serverd doesn't run after auto-upgrade

### DIFF
--- a/update/update_bins.cf
+++ b/update/update_bins.cf
@@ -110,14 +110,14 @@ bundle agent cfe_internal_update_bins
 
   processes:
 
-    bin_newpkg::
+    bin_newpkg.!bin_update_success::
 
       "$(cf_components)" signals => { "$(stop_signal)" },
       comment => "Stop cfengine running processes before binary update",
       handle => "cfe_internal_update_bins_processes_stop_cfengine",
       classes => u_if_repaired("stopped_cfprocs");
 
-    bin_newpkg.!windows::
+    bin_newpkg.!bin_update_success.!windows::
 
       "cf-execd"  signals => { "$(stop_signal)" },
       comment => "Stop cf-execd running process before binary update",


### PR DESCRIPTION
This was fixed for 3.5.x. So I think we should include it to 3.6.0 too. (even though it would be purge when 3.6.1 published)
https://github.com/cfengine/nova/pull/588
