### PR TITLE
drop git-core folder inside lib not need by cf-twin

### DIFF
--- a/cfe_internal/CFE_cfengine.cf
+++ b/cfe_internal/CFE_cfengine.cf
@@ -159,6 +159,10 @@ body process_count check_monitord(n)
 
 bundle agent cfe_internal_correct_cftwin
 {
+
+  vars:
+    "folder_inside_lib_to_drop" slist => {"git-core"};
+    
   files:
 
     windows::
@@ -178,7 +182,7 @@ bundle agent cfe_internal_correct_cftwin
       perms => m("644"),
       move_obstructions => "true",
       copy_from => local_cp_libtwin("/var/cfengine/lib"),
-      depth_search => recurse("inf");
+      depth_search => recurse_ignore("inf","@(folder_inside_lib_to_drop)");
 
       "/var/cfengine/bin/cf-twin"
       comment => "Correct cf-twin to be the same as cf-agent, in case of dependency upgrade",


### PR DESCRIPTION
We dont required cf-agent to copy each and every thing from lib to lib-twin in order for cf-twin to run, a simple fix to ignore git-core related binaries and libraries located inside the lib.
