### PR TITLE
Add path for nologin shell in redhat and debian

### DIFF
--- a/lib/3.6/paths.cf
+++ b/lib/3.6/paths.cf
@@ -50,7 +50,7 @@
 bundle common paths
 # @brief Defines an array `path` with common paths to standard binaries,
 # and classes for defined and existing paths.
-# 
+#
 # If the current platform knows that binary XYZ should be present,
 # `_stdlib_has_path_XYZ` is defined. Furthermore, if XYZ is actually present
 # (i.e. the binary exists) in the expected location, `_stdlib_path_exists_XYZ` is
@@ -254,6 +254,7 @@ bundle common paths
       "path[ls]"            string => "/bin/ls";
       "path[lsof]"          string => "/usr/sbin/lsof";
       "path[netstat]"       string => "/bin/netstat";
+      "path[nologin]"       string => "/sbin/nologin";
       "path[ping]"          string => "/usr/bin/ping";
       "path[perl]"          string => "/usr/bin/perl";
       "path[printf]"        string => "/usr/bin/printf";
@@ -337,6 +338,7 @@ bundle common paths
       "path[ls]"            string => "/bin/ls";
       "path[lsof]"          string => "/usr/bin/lsof";
       "path[netstat]"       string => "/bin/netstat";
+      "path[nologin]"       string => "/usr/sbin/nologin";
       "path[ping]"          string => "/bin/ping";
       "path[perl]"          string => "/usr/bin/perl";
       "path[printf]"        string => "/usr/bin/printf";


### PR DESCRIPTION
This supports the Security::nologin sketch localusers_nologin entry
