### PR TITLE
Add path to realpath for debian, redhat and freebsd

### DIFF
--- a/lib/3.5/paths.cf
+++ b/lib/3.5/paths.cf
@@ -158,6 +158,7 @@ bundle common paths
       "path[sed]"      string => "/usr/bin/sed";
       "path[sort]"     string => "/usr/bin/sort";
       "path[tr]"       string => "/usr/bin/tr";
+      "path[realpath]" string => "/bin/realpath";
 
     openbsd::
 
@@ -245,6 +246,7 @@ bundle common paths
       "path[sort]"          string => "/bin/sort";
       "path[test]"          string => "/usr/bin/test";
       "path[tr]"            string => "/usr/bin/tr";
+      "path[realpath]"      string => "/usr/bin/realpath";
 
       #
       "path[chkconfig]" string => "/sbin/chkconfig";
@@ -328,6 +330,7 @@ bundle common paths
       "path[sort]"          string => "/usr/bin/sort";
       "path[test]"          string => "/usr/bin/test";
       "path[tr]"            string => "/usr/bin/tr";
+      "path[realpath]"      string => "/usr/bin/realpath";
 
       #
       "path[apt_cache]"           string => "/usr/bin/apt-cache";

--- a/lib/3.6/paths.cf
+++ b/lib/3.6/paths.cf
@@ -174,6 +174,7 @@ bundle common paths
       "path[sed]"      string => "/usr/bin/sed";
       "path[sort]"     string => "/usr/bin/sort";
       "path[tr]"       string => "/usr/bin/tr";
+      "path[realpath]" string => "/bin/realpath";
 
     openbsd::
 
@@ -262,6 +263,7 @@ bundle common paths
       "path[sort]"          string => "/bin/sort";
       "path[test]"          string => "/usr/bin/test";
       "path[tr]"            string => "/usr/bin/tr";
+      "path[realpath]"      string => "/usr/bin/realpath";
 
       #
       "path[chkconfig]" string => "/sbin/chkconfig";
@@ -346,6 +348,7 @@ bundle common paths
       "path[sort]"          string => "/usr/bin/sort";
       "path[test]"          string => "/usr/bin/test";
       "path[tr]"            string => "/usr/bin/tr";
+      "path[realpath]"      string => "/usr/bin/realpath";
 
       #
       "path[apt_cache]"           string => "/usr/bin/apt-cache";


### PR DESCRIPTION
I would like to add `realpath` to paths.path to work around an issue I have in 3.5.3 where symlinks that do not have the same permissions are not followed. This will make calling the realpath binary more generic across platforms

```
vars:
    "realpath_src" string => execresult("$(paths.path[realpath]) /src", "noshell");
```
