### PR TITLE
Add cron, snmp and newsyslog service entries for FreeBSD

### DIFF
--- a/lib/3.5/services.cf
+++ b/lib/3.5/services.cf
@@ -752,6 +752,22 @@ bundle agent standard_services(service,state)
       "stopcommand[syslog]"    string => "/etc/rc.d/syslogd stop";
       "pattern[syslog]"        string => "/usr/sbin/syslogd.*";
 
+      "startcommand[crond]"   string => "/etc/rc.d/cron start";
+      "restartcommand[crond]" string => "/etc/rc.d/cron restart";
+      "stopcommand[crond]"    string => "/etc/rc.d/cron stop";
+      "pattern[crond]"        string => "/usr/sbin/cron.*";
+
+      "startcommand[snmpd]"   string => "/etc/rc.d/bsnmpd start";
+      "restartcommand[snmpd]" string => "/etc/rc.d/bsnmpd restart";
+      "stopcommand[snmpd]"    string => "/etc/rc.d/bsnmpd stop";
+      "pattern[snmpd]"        string => "/usr/sbin/bsnmpd.*";
+
+      "startcommand[newsyslog]"   string => "/etc/rc.d/newsyslog start";
+      "restartcommand[newsyslog]" string => "/etc/rc.d/newsyslog restart";
+      "reloadcommand[newsyslog]"  string => "/etc/rc.d/newsyslog reload";
+      "stopcommand[newsyslog]"    string => "/etc/rc.d/newsyslog stop";
+      "pattern[newsyslog]"        string => "/usr/sbin/newsyslog.*";
+
       # METHODS that implement these ............................................
 
   classes:

--- a/lib/3.6/services.cf
+++ b/lib/3.6/services.cf
@@ -407,6 +407,14 @@ bundle agent standard_services(service,state)
       "baseinit[syslog]"    string => "syslogd";
       "pattern[syslog]"     string => "/usr/sbin/syslogd.*";
 
+      "baseinit[crond]"     string => "cron";
+      "pattern[crond]"      string => "/usr/sbin/cron.*";
+
+      "baseinit[snmpd]"     string => "bsnmpd";
+      "pattern[snmpd]"      string => "/usr/sbin/bsnmpd.*";
+
+      "pattern[newsyslog]"  string => "/usr/sbin/newsyslog.*";
+
   classes:
       # Set classes for each possible state after $(all_states)
       "$(all_states)" expression => strcmp($(all_states), $(state)),


### PR DESCRIPTION
This patch will add support for starting, restarting and stopping cron, snmp and newsyslog on FreeBSD
