### PR TITLE
Add a perms body for setting permissions on system owned files

### DIFF
--- a/lib/3.5/files.cf
+++ b/lib/3.5/files.cf
@@ -1142,6 +1142,15 @@ body perms owner(user)
 }
 
 body perms system_owned(mode)
+# @brief Set the file owner and group to the system default
+# @param mode the access permission in octal format
+#
+# **Example:**
+#
+# ```cf3
+# files:
+#     "/etc/passwd" perms => system_owned("0644");
+# ```
 {
       mode   => "$(mode)";
       owners => { "root" };

--- a/lib/3.6/files.cf
+++ b/lib/3.6/files.cf
@@ -1345,6 +1345,15 @@ body perms owner(user)
 }
 
 body perms system_owned(mode)
+# @brief Set the file owner and group to the system default
+# @param mode the access permission in octal format
+#
+# **Example:**
+#
+# ```cf3
+# files:
+#     "/etc/passwd" perms => system_owned("0644");
+# ```
 {
       mode   => "$(mode)";
       owners => { "root" };


### PR DESCRIPTION
For system owned files on FreeBSD, the group assigned is 'wheel' and on Linux it is 'root'. To simply making permission based promises for system files, I would like to include a new body called sysm that allows you to pass what the permission should be and ensures that on FreeBSD, the owner and group are root:wheel and on Linux its root:root

Example:

```
files:

    "$(sys.resolv)"
        perms => sysm("0644");
```
