### PR TITLE
Redmine#4202: special apt method to avoid network updates

### DIFF
--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -311,7 +311,7 @@ bundle agent cfe_autorun_inventory_packages
     debian::
       "cfe_internal_non_existing_package"
       package_policy => "add",
-      package_method => apt_get;
+      package_method => apt_get_noupdate;
 
     redhat::
       "cfe_internal_non_existing_package"

--- a/lib/3.6/packages.cf
+++ b/lib/3.6/packages.cf
@@ -454,6 +454,51 @@ body package_method apt_get
 
 }
 
+body package_method apt_get_noupdate
+# @depends debian_knowledge
+# @brief APT installation package method
+#
+# This package method interacts with the APT package manager through
+# `apt-get`.  It will never run "apt-get update" but is otherwise
+# exactly like the `apt_get` package method and *may* use the network
+# to install packages, as APT may decide.
+#
+# It doesn't work to use a class.
+#
+# This is a great use case for CFEngine body inheritance.
+#
+# **Example:**
+#
+# ```cf3
+# packages:
+#     "mypackage" package_method => apt_get_noupdate, package_policy => "add";
+# ```
+{
+      package_changes => "bulk";
+      package_list_command => "$(debian_knowledge.call_dpkg) -l";
+      package_list_name_regex => "$(debian_knowledge.list_name_regex)";
+      package_list_version_regex => "$(debian_knowledge.list_version_regex)";
+      package_installed_regex => ".i.*"; # packages that have been uninstalled may be listed
+      package_name_convention => "$(name)=$(version)";
+
+      # Target a specific release, such as backports
+      package_add_command => "$(debian_knowledge.call_apt_get) $(debian_knowledge.dpkg_options) --yes install";
+      package_delete_command => "$(debian_knowledge.call_apt_get) $(debian_knowledge.dpkg_options) --yes -q remove";
+      package_update_command =>  "$(debian_knowledge.call_apt_get) $(debian_knowledge.dpkg_options) --yes install";
+      package_patch_command =>  "$(debian_knowledge.call_apt_get) $(debian_knowledge.dpkg_options) --yes install";
+      package_verify_command => "$(debian_knowledge.call_dpkg) -s";
+      package_noverify_returncode => "1";
+
+      package_patch_list_command => "$(debian_knowledge.call_apt_get) --just-print dist-upgrade";
+      package_patch_name_regex => "$(debian_knowledge.patch_name_regex)";
+      package_patch_version_regex => "$(debian_knowledge.patch_version_regex)";
+
+      # make correct version comparisons
+      package_version_less_command => "$(debian_knowledge.dpkg_compare_less)";
+      package_version_equal_command => "$(debian_knowledge.dpkg_compare_equal)";
+
+}
+
 body package_method apt_get_release(release)
 # @depends common_knowledge debian_knowledge
 # @brief APT installation package method


### PR DESCRIPTION
see https://cfengine.com/dev/issues/4202

Ensures `apt-get update` won't be called.

A class exclusion in the `apt_get` body doesn't work.  See docs for `apt_get_noupdate`.
