### PR TITLE
Remove unnecessary argument to masterfiles-stage

### DIFF
--- a/update/update_masterfiles_internal.cf
+++ b/update/update_masterfiles_internal.cf
@@ -23,7 +23,6 @@ bundle agent cfe_internal_masterfiles_stage
       contain => u_cfe_internal_no_output_as_cfe_apache;
 
       "$(u_def.dc_scripts)/masterfiles-stage.sh"
-      args => "GIT",
       handle => "masterfiles_update_stage",
       contain => u_cfe_internal_no_output;
 }


### PR DESCRIPTION
GIT is taken from params.sh, not as an argument.
