### PR TITLE
Add path to shadow password file on multiple platforms

### DIFF
--- a/lib/3.5/paths.cf
+++ b/lib/3.5/paths.cf
@@ -428,6 +428,18 @@ bundle common paths
       "path[usermod]"       string => "/usr/sbin/usermod";
       "path[zypper]"        string => "/usr/bin/zypper";
 
+    linux|solaris::
+
+      "path[shadow]"       string => "/etc/shadow";
+
+    freebsd|openbsd|netbsd|darwin::
+
+      "path[shadow]"       string => "/etc/master.passwd";
+
+    aix::
+
+      "path[shadow]"       string => "/etc/security/passwd";
+
     any::
       "all_paths"     slist => getindices("path");
       "$(all_paths)" string => "$(path[$(all_paths)])";

--- a/lib/3.6/paths.cf
+++ b/lib/3.6/paths.cf
@@ -444,6 +444,18 @@ bundle common paths
       "path[usermod]"       string => "/usr/sbin/usermod";
       "path[zypper]"        string => "/usr/bin/zypper";
 
+    linux|solaris::
+
+      "path[shadow]"       string => "/etc/shadow";
+
+    freebsd|openbsd|netbsd|darwin::
+
+      "path[shadow]"       string => "/etc/master.passwd";
+
+    aix::
+
+      "path[shadow]"       string => "/etc/security/passwd";
+
     any::
       "all_paths"     slist => getindices("path");
       "$(all_paths)" string => "$(path[$(all_paths)])";


### PR DESCRIPTION
This will allow you to reference that shadow password file across multiple flavors of unix as just $(paths.path[shadow])

Also see https://github.com/cfengine/core/pull/1374 for additional discussion
