### PR TITLE
Add 3.4/3.5 compatible def.dir_masterfiles

### DIFF
--- a/def.cf
+++ b/def.cf
@@ -35,6 +35,12 @@ bundle common def
 
       # End change #
 
+  cfengine_3_4|cfengine_3_5::
+      "dir_masterfiles" string => translatepath("$(sys.workdir)/masterfiles"),
+      comment => "Define masterfiles path",
+      handle => "common_def_vars_dir_masterfiles_backport";
+
+  !cfengine_3_4.!cfengine_3_5::
       "dir_masterfiles" string => translatepath("$(sys.masterdir)"),
       comment => "Define masterfiles path",
       handle => "common_def_vars_dir_masterfiles";


### PR DESCRIPTION
Fix incompatibility with 3.4/3.5 introduced in 6733bf5499b2b7118bb8244b1636a349db32e1c9
