### PR TITLE
Include reports dir as part of log rotation

### DIFF
--- a/def.cf
+++ b/def.cf
@@ -109,7 +109,8 @@ bundle common def
                                   };
 
       "cfe_log_dirs"     slist => {
-                                    "$(sys.workdir)/outputs"
+                                    "$(sys.workdir)/outputs",
+                                    "$(sys.workdir)/reports",
                                   };
 
   classes:


### PR DESCRIPTION
Ref: Redmine:3634 (https://cfengine.com/dev/issues/3634)
