### PR TITLE
not to run cf-twin by cf-execd

### DIFF
--- a/controls/cf_execd.cf
+++ b/controls/cf_execd.cf
@@ -29,21 +29,21 @@ body executor control
     windows.(cfengine_3_4|cfengine_3_5)::
       exec_command => "$(sys.cf_twin) -f \"$(sys.workdir)\inputs\update.cf\" & $(sys.cf_agent) -Dcf_execd_initiated";
     windows.!(cfengine_3_4|cfengine_3_5)::
-      exec_command => "$(sys.cf_twin) -f \"$(sys.update_policy_path)\" & $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "$(sys.cf_agent) -f \"$(sys.update_policy_path)\" & $(sys.cf_agent) -Dcf_execd_initiated";
 
     hpux.(cfengine_3_4|cfengine_3_5)::
       exec_command => "SHLIB_PATH=\"/var/cfengine/lib-twin\" $(sys.cf_twin) -f \"$(sys.workdir)/inputs/update.cf\" ; $(sys.cf_agent) -Dcf_execd_initiated";
     hpux.!(cfengine_3_4|cfengine_3_5)::
-      exec_command => "SHLIB_PATH=\"/var/cfengine/lib-twin\" $(sys.cf_twin) -f \"$(sys.update_policy_path)\" ; $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "$(sys.cf_agent) -f \"$(sys.update_policy_path)\" ; $(sys.cf_agent) -Dcf_execd_initiated";
 
     aix.(cfengine_3_4|cfengine_3_5)::
       exec_command => "LIBPATH=\"/var/cfengine/lib-twin\" $(sys.cf_twin) -f \"$(sys.workdir)/inputs/update.cf\" ; $(sys.cf_agent) -Dcf_execd_initiated";
     aix.!(cfengine_3_4|cfengine_3_5)::
-      exec_command => "LIBPATH=\"/var/cfengine/lib-twin\" $(sys.cf_twin) -f \"$(sys.update_policy_path)\" ; $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "$(sys.cf_agent) -f \"$(sys.update_policy_path)\" ; $(sys.cf_agent) -Dcf_execd_initiated";
 
     !(windows|hpux|aix).(cfengine_3_4|cfengine_3_5)::
       exec_command => "LD_LIBRARY_PATH=\"/var/cfengine/lib-twin\" $(sys.cf_twin) -f \"$(sys.workdir)/inputs/update.cf\" ; $(sys.cf_agent) -Dcf_execd_initiated";
     !(windows|hpux|aix).!(cfengine_3_4|cfengine_3_5)::
-      exec_command => "LD_LIBRARY_PATH=\"/var/cfengine/lib-twin\" $(sys.cf_twin) -f \"$(sys.update_policy_path)\" ; $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "$(sys.cf_agent) -f \"$(sys.update_policy_path)\" ; $(sys.cf_agent) -Dcf_execd_initiated";
 
 }


### PR DESCRIPTION
- since no point to use cf-twin for binary upgrade, we don't need to run it on update.cf policy
- leave cfe_internal_correct_cftwin bundle as it is. it might be purged on later release, not 3.6.0
