### PR TITLE
Enable maid service by default so we dont fill disks

### DIFF
--- a/def.cf
+++ b/def.cf
@@ -118,7 +118,7 @@ bundle common def
     ### Enable special features policies. Set to "any" to enable.
 
     # Internal CFEngine log files rotation
-    "cfengine_internal_rotate_logs" expression => "!any";
+    "cfengine_internal_rotate_logs" expression => "any";
 
     # Transfer policies and binaries with encryption
     "cfengine_internal_encrypt_transfers" expression => "!any";


### PR DESCRIPTION
Ref: Redmine:4387 (https://cfengine.com/dev/issues/4387)
