### PR TITLE
Add outputs/dc-scripts.log as a CFEngine log file for cleanup

### DIFF
--- a/def.cf
+++ b/def.cf
@@ -106,6 +106,7 @@ bundle common def
                                     "$(sys.workdir)/httpd/logs/error_log", # Mission Portal
                                     "$(sys.workdir)/promise_summary.log",
                                     "$(sys.workdir)/state/cf_value.log",
+                                    "$(sys.workdir)/outputs/dc-scripts.log",
                                   };
 
       "cfe_log_dirs"     slist => {


### PR DESCRIPTION
Ref: Redmine:4387 (https://cfengine.com/dev/issues/4387)
