### PR TITLE
Try any conceivable way to detect a Linux Mint system of any kind

### DIFF
--- a/inventory/debian.cf
+++ b/inventory/debian.cf
@@ -16,10 +16,21 @@ bundle common inventory_debian
       "linuxmint_info"  string => readfile("/etc/linuxmint/info","1024"),
       comment => "Read Linux Mint specific info" ;
 
+      "lm_info_count"
+	  int => parsestringarray("mint_info", # array to populate
+				  "$(linuxmint_info)", # data to parse
+				  "\s*#[^\n]*",        # comments
+				  "=",                 # split
+				  100,                 # maxentries
+				  1024) ;              # maxbytes
+
+      "mint_release" string  => "$(mint_info[RELEASE][1])" ;
+      "mint_codename" string => "$(mint_info[CODENAME][1])" ;
 
   classes:
     any::
-      "debian_derived_evaluated" or => { "has_os_release","has_lsb_release" } ;
+      "debian_derived_evaluated"
+	  or => { "has_os_release","has_lsb_release","has_etc_linuxmint_info" } ;
 
     has_os_release::
       "linuxmint"
@@ -46,6 +57,15 @@ bundle common inventory_debian
       expression => regcmp('(?ms).*^DESCRIPTION="LMDE.*',"$(linuxmint_info)"),
       comment => "this is a Linux Mint Debian Edition" ;
 
+    debian_derived_evaluated.linuxmint.has_etc_linuxmint_info.!lmde::
+      # These need to be evaluated only after debian_derived_evaluated is defined
+      # to ensure that the mint_info array has been evaluated as well.
+      # Failing to do that will create meaningless classes
+      # On non-LMDE Mint systems, this will create classes like, e.g.:
+      # linuxmint_14, nadia, linuxmint_nadia
+      "linuxmint_$(mint_release)"  expression => "any" ;
+      "$(mint_codename)"           expression => "any" ;
+      "linuxmint_$(mint_codename)" expression => "any" ;
 
     debian_derived_evaluated::
       "debian_pure" expression => "debian.!(ubuntu|linuxmint)",
@@ -68,4 +88,5 @@ bundle common inventory_debian
       "has_etc_linuxmint_info" expression => fileexists("/etc/linuxmint/info"),
       comment => "If this is a Linux Mint system, this *could* be available",
       meta => { "inventory", "attribute_name=none" };
+
 }


### PR DESCRIPTION
see https://cfengine.com/dev/issues/2278

This additions to the debian inventory try to detect a Linux Mint system by checking /etc/lsb-release, /etc/os-release, /etc/linuxmint/info (overlapping with lsb.cf can be safely removed if it makes sense). At the end of the process, classes like linuxmint, lmde, linuxmint_14, nadia may be defined.
