### PR TITLE
RM4890: Put quotes round non-function edit_line names.

### DIFF
--- a/cfe_internal/CFE_hub_specific.cf
+++ b/cfe_internal/CFE_hub_specific.cf
@@ -341,7 +341,7 @@ bundle agent cfe_internal_apache_sudoer
       "/etc/sudoers"
       comment => "Permit Apache user to run passwordless sudo cf-runagent",
       handle => "cfe_internal_apache_sudoer_files_etc_sudoer",
-      edit_line => apache_sudoer;
+      edit_line => "apache_sudoer";
 }
 
 #

--- a/cfe_internal/CFE_knowledge.cf
+++ b/cfe_internal/CFE_knowledge.cf
@@ -116,7 +116,7 @@ bundle agent cfe_internal_setup_knowledge
       comment => "Create HTACCESS file for REST",
       handle => "cfe_internal_setup_knowledge_files_rest_htaccess",
       create => "true",
-      edit_line => rest_htaccess,
+      edit_line => "rest_htaccess",
       edit_defaults => empty,
       perms => mog("0644",$(def.cf_apache_user),$(def.cf_apache_group));
 


### PR DESCRIPTION
see https://cfengine.com/dev/issues/4890

It's not clear that we _should_ require these, but I get errors, in
their absence, about "Apparent body '$name' was undeclared, but used
in a promise near $loc (possible unquoted literal value)" and these
quotes fix the error.  See RedMine 4890 for discussion of whether we
should cope without the quotes.
