### PR TITLE
these classes are very verbose in reporting

### DIFF
--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -325,14 +325,6 @@ bundle agent cfe_autorun_inventory_dmidecode
   classes:
       "have_dmidecode" expression => fileexists($(inventory_control.dmidecoder));
 
-      "dmidecode_$(_canonified_var[$(dmivars)])_$(_canonified[$(dmivars)])"
-      expression => "any",
-      meta => { "inventory",
-                "attribute_name=none",
-                "derived-from=inventory_dmidecode.dmi[$(dmivars)]"
-      },
-      scope => "namespace";
-
   reports:
     inform_mode::
       "$(this.bundle): Obtained $(dmidefs[$(dmivars)]) = '$(dmi[$(dmivars)])'";


### PR DESCRIPTION
I suggest removing them, as I don't see how they would be used in policy either.
But they definitively need to go from reporting, e.g. one host has this:
- dmidecode____canonified_var_system_version______canonified_system_version__
- dmidecode_bios_vendor_innotek_GmbH
- dmidecode____canonified_var_system_serial_number______canonified_system_serial_number__
- dmidecode____canonified_var_processor_version______canonified_processor_version__
- dmidecode____canonified_var_system_manufacturer______canonified_system_manufacturer__
- dmidecode_system_serial_number_0
- dmidecode_system_version_1_2
- dmidecode_system_manufacturer_innotek_GmbH
- dmidecode_bios_version_VirtualBox
- dmidecode_processor_version_
- dmidecode____canonified_var_bios_version______canonified_bios_version__
- dmidecode____canonified_var_bios_vendor______canonified_bios_vendor__
