### PR TITLE
Add a bundle to do postgresql maintenance (vacuumdb)

### DIFF
--- a/cfe_internal/CFE_cfengine.cf
+++ b/cfe_internal/CFE_cfengine.cf
@@ -68,8 +68,7 @@ bundle agent cfe_internal_management
       handle => "cfe_internal_truncate_events",
       comment => "To run CFE truncate to pending";
 
-    # pre-defined every Sunday at 2 a.m. This can be changed later on.
-    am_policy_hub.enterprise.Sunday.Hr02.Min00_05::
+    postgresql_maintenance::
 
       "hub" usebundle => cfe_internal_postgresql_maintenance,
       handle => "cfe_internal_management_postgresql_maintenance",

--- a/cfe_internal/CFE_hub_specific.cf
+++ b/cfe_internal/CFE_hub_specific.cf
@@ -643,9 +643,9 @@ bundle agent cfe_internal_postgresql_maintenance
 {
   vars:
 
-    am_policy_hub::
+    any::
 
-      "vacuumdb_cmd" string => "$(sys.workdir)/bin/vacuumdb --full cfdb",
+      "vacuumdb_cmd" string => "$(sys.bindir)/vacuumdb --full cfdb",
       comment => "Command for cleaning a PostgreSQL database",
       handle => "cfe_internal_postgresql_maintenance_vars_vacuum_cmd";
 
@@ -653,7 +653,7 @@ bundle agent cfe_internal_postgresql_maintenance
 
   processes:
 
-    am_policy_hub::
+    any::
 
    "cf-hub"      signals => { "term" },
    comment => "Terminate cf-hub while doing PostgreSQL maintenance",
@@ -667,7 +667,7 @@ bundle agent cfe_internal_postgresql_maintenance
 
   commands:
   
-    am_policy_hub::
+    any::
 
       "$(vacuumdb_cmd)"
       comment => "Run vacuumdb command",

--- a/def.cf
+++ b/def.cf
@@ -157,6 +157,13 @@ bundle common def
       # NOTE THAT THIS CLASS ALSO NEEDS TO BE SET IN update.cf
 
       "cfengine_internal_purge_policies" expression => "!any";
+
+      # This class is for PosgreSQL maintenance
+      # pre-defined to every Sunday at 2 a.m.
+      # This can be changed later on.
+
+      "postgresql_maintenance" expression => "am_policy_hub.enterprise.Sunday.Hr02.Min00_05";
+
 }
 
 bundle common inventory_control

--- a/update.cf
+++ b/update.cf
@@ -100,10 +100,4 @@ bundle common update_def
 
       "cfengine_internal_purge_policies" expression => "!any";
 
-    am_policy_hub.enterprise::
-
-      "no_vacuumdb" not => returnszero("ps -ef  | grep -v grep | grep -q vacuumdb","useshell"),
-      comment => "Check if vacuumdb still running",
-      handle => "update_def_classes_no_vacuumdb";
-      
 }

--- a/update/update_processes.cf
+++ b/update/update_processes.cf
@@ -120,6 +120,12 @@ bundle agent maintain_cfe_hub_process
       handle => "cfe_internal_maintain_cfe_hub_process_processes_mongod",
       ifvarclass => "nova|enterprise";
 
+      "$(sys.bindir)/vacuumdb"
+      restart_class => "no_vacuumdb",
+      comment => "Monitor vacuumdb process",
+      handle => "cfe_internal_maintain_cfe_hub_process_processes_check_vacuumdb",
+      ifvarclass => "nova|enterprise";
+
    am_policy_hub.!(cfengine_3_4||cfengine_3_5)::
       "$(sys.bindir)/redis-server"
       restart_class => "start_redis_server",


### PR DESCRIPTION
Regarding https://cfengine.com/dev/issues/5311
- agent bundle to stop cf-hub and cf-consumer before running vacuumdb
- pre-defined running once a week on Sunday 2am
- if vacuumdb is still running, we don't restart cf-hub and cf-consumer in update.cf
- haven't touched anything in body hub control{} yet

@awsiv, @jeffali what do you think?
