### PR TITLE
Vendor specific -release files are deprecated in favor of generic /etc/o...

### DIFF
--- a/inventory/linux.cf
+++ b/inventory/linux.cf
@@ -1,0 +1,34 @@
+bundle common inventory_linux
+# @brief Linux inventory
+#
+# This common bundle is for Linux inventory work.
+{
+  vars:
+    has_os_release::
+      "os_release_info" string => readfile("/etc/os-release", "512"),
+      comment => "Read /etc/os-release" ;
+
+    os_release_has_id::
+      "os_release_id" string => canonify("$(id_array[1])");
+
+    os_release_has_version::
+      "os_release_version" string => canonify("$(version_array[1])");
+
+  classes:
+
+    any::
+      "has_os_release" expression => fileexists("/etc/os-release"),
+      comment => "Check if we can get more info from /etc/os-release";
+
+      "os_release_has_id" expression => regextract('^ID="?([^"]+)"?$', "$(os_release_info)", "id_array"),
+      comment => "Extract ID= line from os-release to id_array";
+
+      "os_release_has_version" expression => regextract('^VERSION_ID="?([^"]+)"?$', "$(os_release_info)", "version_array"),
+      comment => "Extract VERSION_ID= line from os-release to version_array";
+      
+    os_release_has_id::
+      "$(os_release_id)" expression => "any";
+
+   os_release_has_version::
+     "$(os_release_id)_$(os_release_version)" expression => "any";
+}

--- a/inventory/suse.cf
+++ b/inventory/suse.cf
@@ -1,0 +1,14 @@
+bundle common inventory_suse
+# @brief SUSE inventory bundle
+#
+# This common bundle is for SUSE Linux inventory work.
+{
+  classes:
+      "suse_pure" expression => "(sles||sled).!opensuse",
+      comment => "pure SUSE",
+      meta => { "inventory", "attribute_name=none" };
+
+      "suse_derived" expression => "opensuse.!suse_pure",
+      comment => "derived from SUSE",
+      meta => { "inventory", "attribute_name=none" };
+}

--- a/promises.cf
+++ b/promises.cf
@@ -84,18 +84,21 @@ bundle common inventory
   vars:
       # This list is intended to grow as needed
     !(cfengine_3_4||cfengine_3_5).debian::
-      "inputs" slist => { "inventory/any.cf", "inventory/lsb.cf", "inventory/debian.cf" };
-      "bundles" slist => { "inventory_control", "inventory_any", "inventory_autorun", "inventory_lsb", "inventory_debian" };
+      "inputs" slist => { "inventory/any.cf", "inventory/linux.cf", "inventory/lsb.cf", "inventory/debian.cf" };
+      "bundles" slist => { "inventory_control", "inventory_any", "inventory_autorun", "inventory_linux", "inventory_lsb", "inventory_debian" };
     !(cfengine_3_4||cfengine_3_5).redhat::
-      "inputs" slist => { "inventory/any.cf", "inventory/lsb.cf", "inventory/redhat.cf" };
-      "bundles" slist => { "inventory_control", "inventory_any", "inventory_autorun", "inventory_lsb", "inventory_redhat" };
+      "inputs" slist => { "inventory/any.cf", "inventory/linux.cf", "inventory/lsb.cf", "inventory/redhat.cf" };
+      "bundles" slist => { "inventory_control", "inventory_any", "inventory_autorun", "inventory_linux", "inventory_lsb", "inventory_redhat" };
+    !(cfengine_3_4||cfengine_3_5).SUSE::
+      "inputs" slist => { "inventory/any.cf", "inventory/linux.cf", "inventory/lsb.cf", "inventory/suse.cf" };
+      "bundles" slist => { "inventory_control", "inventory_any", "inventory_autorun", "inventory_linux", "inventory_lsb", "inventory_suse" };
     !(cfengine_3_4||cfengine_3_5).windows::
       "inputs" slist => { "inventory/any.cf", "inventory/windows.cf" };
       "bundles" slist => { "inventory_control", "inventory_any", "inventory_autorun", "inventory_windows" };
     !(cfengine_3_4||cfengine_3_5).macos::
       "inputs" slist => { "inventory/any.cf", "inventory/macos.cf" };
       "bundles" slist => { "inventory_control", "inventory_any", "inventory_autorun", "inventory_macos" };
-    !(cfengine_3_4||cfengine_3_5).!windows.!macos.!debian.!redhat::
+    !(cfengine_3_4||cfengine_3_5).!windows.!macos.!debian.!redhat.!SUSE::
       "inputs" slist => { "inventory/any.cf", "inventory/lsb.cf", "inventory/generic.cf" };
       "bundles" slist => { "inventory_control", "inventory_any", "inventory_autorun", "inventory_lsb", "inventory_generic" };
 


### PR DESCRIPTION
...s-release files.

Fedora, openSUSE, RHEL, and SLES already ship /etc/os-release.

See http://www.freedesktop.org/software/systemd/man/os-release.html
for details about this file.

This patch adds inventory/linux.cf to parse the ID and VERSION_ID
fields of os-release and adds global classes for <ID> and
<ID>_<VERSION_ID>

It also adds inventory/suse.cf to distinguish between SUSE Linux
Enterprise and openSUSE.
