### PR TITLE
If the init process (pid 1) is systemd, set class 'systemd'

### DIFF
--- a/inventory/linux.cf
+++ b/inventory/linux.cf
@@ -13,6 +13,17 @@ bundle common inventory_linux
 
     os_release_has_version::
       "os_release_version" string => canonify("$(version_array[1])");
+    
+    has_proc_1_cmdline::
+      "proc_1_cmdline_split" slist => string_split(readfile("/proc/1/cmdline", "512"), " ", "2"),
+      comment => "Read /proc/1/cmdline and split off arguments";
+
+      "proc_1_cmdline" string => nth("proc_1_cmdline_split", 0),
+      comment => "Get argv[0] of /proc/1/cmdline";
+
+      "proc_1_process" string => ifelse("proc_1_cmdline_islink", filestat("$(proc_1_cmdline)", "linktarget"),
+                                        "$(proc_1_cmdline)"),
+      comment => "Follow the symlink if the init process name is a symlink";
 
   classes:
 
@@ -25,10 +36,20 @@ bundle common inventory_linux
 
       "os_release_has_version" expression => regextract('^VERSION_ID="?([^"]+)"?$', "$(os_release_info)", "version_array"),
       comment => "Extract VERSION_ID= line from os-release to version_array";
+      
+      "has_proc_1_cmdline" expression => fileexists("/proc/1/cmdline"),
+      comment => "Check if we can read /proc/1/cmdline";
 
     os_release_has_id::
       "$(os_release_id)" expression => "any";
 
     os_release_has_version::
       "$(os_release_id)_$(os_release_version)" expression => "any";
+
+    has_proc_1_cmdline::
+      "proc_1_cmdline_islink" expression => islink("$(proc_1_cmdline)"),
+      comment => "Check if /proc/1/cmdline is a symbolic link";
+      "systemd" expression => strcmp(lastnode("$(proc_1_process)", "/"), "systemd"),
+      comment => "Check if (the link target of) /proc/1/cmdline is systemd";
+
 }


### PR DESCRIPTION
This commit checks /proc/1/cmdline on Linux and tries to determine if
its running systemd. Handle SUSE (symlink) and RHEL (arguments) cases
correctly.

On SUSE, /proc/1/cmdline reads
  "/sbin/init" which is a symlink to /usr/lib/systemd/systemd.

On RHEL, /proc/1/cmdline reads
  "/usr/lib/systemd/systemd --switched-root --system--deserialize23"
