### PR TITLE
Decoupling trustkeysfrom to be its own setting

### DIFF
--- a/controls/cf_serverd.cf
+++ b/controls/cf_serverd.cf
@@ -21,11 +21,11 @@ body server control
       allowallconnects      => { "127.0.0.1" , "::1", @(def.acl) };
 
       # Out of the hosts in allowconnects, trust new keys only from the
-      # following ones.  This is open by default for bootstrapping,
-      # comment it out after all machines have been bootstrapped.
-      trustkeysfrom         => { "0.0.0.0/0" };
+      # following ones.  SEE COMMENTS IN def.cf
+      trustkeysfrom         => { @(def.trustkeysfrom) };
 
-      # Maximum number of concurrent connections. Suggest >= total_hosts
+      # Maximum number of concurrent connections.
+      # Suggested value >= total number of hosts
       maxconnections        => "100";
 
       allowusers            => { "root" };

--- a/def.cf
+++ b/def.cf
@@ -33,6 +33,15 @@ bundle common def
       comment => "Define an acl for the machines to be granted accesses",
       handle => "common_def_vars_acl";
 
+      # Out of the hosts in allowconnects, trust new keys only from the
+      # following ones.  This is open by default for bootstrapping.
+
+      "trustkeysfrom" slist => {
+                                 # COMMENT THE NEXT LINE OUT AFTER ALL MACHINES HAVE BEEN BOOTSTRAPPED.
+                                 "0.0.0.0/0", # allow any IP
+      },
+      comment => "Define from which machines keys can be trusted";
+
       # End change #
 
   cfengine_3_4|cfengine_3_5::


### PR DESCRIPTION
replaces https://github.com/cfengine/masterfiles/pull/201
