### PR TITLE
use SunOS not solaris

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ endif
 
 UNAME := $(shell uname)
 
-ifeq ($(UNAME), Solaris)
+ifeq ($(UNAME), SunOS)
 INSTALL = /usr/local/bin/install
 else
 INSTALL = /usr/bin/install


### PR DESCRIPTION
This provides the correct detection of Solaris as the build platform / corrected from "solaris" to SunOS
