### PR TITLE
Redmine#5339: add inventory update_interval to ensure CSV files are there; support SUSE

### DIFF
--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -352,31 +352,58 @@ bundle agent cfe_autorun_inventory_packages
 # This bundle is for refreshing the package inventory.  It runs on
 # startup, unless disabled.  Other package methods can be added below.
 {
+  classes:
+      "have_patches" or => { "community_edition", # not in Community
+                             fileexists("$(sys.workdir)/state/software_patches_avail.csv") };
+
+      "have_inventory" and => { "have_patches",
+                                fileexists("$(sys.workdir)/state/software_packages.csv"),
+      };
+
+  vars:
+      # if we have the patches, 7 days; otherwise keep trying
+      "refresh" string => ifelse("have_inventory", "10080",
+                                 "0");
+
   packages:
     debian::
       "cfe_internal_non_existing_package"
       package_policy => "add",
-      package_method => inventory_apt_get;
+      package_method => inventory_apt_get($(refresh));
 
     redhat::
       "cfe_internal_non_existing_package"
       package_policy => "add",
-      package_method => inventory_yum_rpm;
+      package_method => inventory_yum_rpm($(refresh));
+
+    suse::
+      "cfe_internal_non_existing_package"
+      package_policy => "add",
+      package_method => inventory_zypper($(refresh));
 
     gentoo::
       "cfe_internal_non_existing_package"
       package_policy => "add",
       package_method => emerge;
 
-    !redhat.!debian.!gentoo::
+    !redhat.!debian.!gentoo.!suse::
       "cfe_internal_non_existing_package"
       package_policy => "add",
       package_method => generic;
+
+  reports:
+    inform_mode::
+      "$(this.bundle): refresh interval is $(refresh)";
+    inform_mode.have_inventory::
+      "$(this.bundle): we have the inventory files.";
+    inform_mode.!have_inventory::
+      "$(this.bundle): we don't have the inventory files.";
 }
 
-body package_method inventory_apt_get
+body package_method inventory_apt_get(update_interval)
 # @depends debian_knowledge
 # @brief APT installation package method for inventory purposes only
+# @param update_interval how often to update the package and patch list
 #
 # This package method is a copy of the yum_rpm method just for
 # inventory purposes.
@@ -394,7 +421,7 @@ body package_method inventory_apt_get
       package_name_convention => "$(name)=$(version)";
 
       # set it to "0" to avoid caching of list during upgrade
-      package_list_update_ifelapsed => "10080"; # 7 days, 24 hours, 60 minutes
+      package_list_update_ifelapsed => $(update_interval);
 
       # Target a specific release, such as backports
       package_add_command => "$(debian_knowledge.call_apt_get) $(debian_knowledge.dpkg_options) --yes install";
@@ -414,9 +441,10 @@ body package_method inventory_apt_get
       package_version_equal_command => "$(debian_knowledge.dpkg_compare_equal)";
 }
 
-body package_method inventory_yum_rpm
-# @depends common_knowledge redhat_knowledge
+body package_method inventory_yum_rpm(update_interval)
+# @depends common_knowledge redhat_knowledge redhat_knowledge
 # @brief Yum+RPM installation method for inventory purposes only
+# @param update_interval how often to update the package and patch list
 #
 # This package method is a copy of the yum_rpm method just for
 # inventory purposes.
@@ -441,7 +469,7 @@ body package_method inventory_yum_rpm
 
       # set it to "0" to avoid caching of list during upgrade
       package_list_update_command => "$(redhat_knowledge.call_yum) $(redhat_knowledge.yum_options) check-update";
-      package_list_update_ifelapsed => "10080"; # 7 days, 24 hours, 60 minutes
+      package_list_update_ifelapsed => $(update_interval);
 
       package_patch_name_regex    => "([^.]+).*";
       package_patch_version_regex => "[^\s]\s+([^\s]+).*";
@@ -452,6 +480,40 @@ body package_method inventory_yum_rpm
       package_patch_command  => "$(redhat_knowledge.call_yum) $(redhat_knowledge.yum_options) -y update";
       package_delete_command => "$(redhat_knowledge.call_rpm) -e --nodeps";
       package_verify_command => "$(redhat_knowledge.call_rpm) -V";
+}
+
+body package_method inventory_zypper(update_interval)
+# @depends common_knowledge redhat_knowledge
+# @brief SUSE zypper installation method for inventory purposes only
+# @param update_interval how often to update the package and patch list
+#
+# This package method is a copy of the SUSE zypper method just for
+# inventory purposes.
+{
+      package_changes => "bulk";
+
+      package_list_command => "$(paths.path[rpm]) -qa --queryformat \"i | repos | %{name} | %{version}-%{release} | %{arch}\n\"";
+
+      # set it to "0" to avoid caching of list during upgrade
+      package_list_update_command => "$(paths.path[zypper]) list-updates";
+      package_list_update_ifelapsed => $(update_interval);
+
+      package_patch_list_command => "$(paths.path[zypper]) patches";
+      package_installed_regex => "i.*";
+      package_list_name_regex    => "$(redhat_knowledge.rpm_name_regex)";
+      package_list_version_regex => "$(redhat_knowledge.rpm_version_regex)";
+      package_list_arch_regex    => "$(redhat_knowledge.rpm_arch_regex)";
+
+      package_patch_installed_regex => ".*Installed.*|.*Not Applicable.*";
+      package_patch_name_regex    => "[^|]+\|\s+([^\s]+).*";
+      package_patch_version_regex => "[^|]+\|[^|]+\|\s+([^\s]+).*";
+
+      package_name_convention => "$(name)";
+      package_add_command => "$(paths.path[zypper]) --non-interactive install";
+      package_delete_command => "$(paths.path[zypper]) --non-interactive remove --force-resolution";
+      package_update_command => "$(paths.path[zypper]) --non-interactive update";
+      package_patch_command => "$(paths.path[zypper]) --non-interactive patch$"; # $ means no args
+      package_verify_command => "$(paths.path[zypper]) --non-interactive verify$";
 }
 
 bundle agent cfe_autorun_inventory_cmdb


### PR DESCRIPTION
- add a `update_interval` parameter to each inventory package body
- as long at the patch and package list are missing, keep trying to regenerate them
- as soon as they are present, go to the 1-week update interval
- add a SUSE `inventory_zypper` method to do package and patch updates on SUSE
