### PR TITLE
Redmine#5339: update packages and patches directly

### DIFF
--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -354,166 +354,71 @@ bundle agent cfe_autorun_inventory_packages
 {
   classes:
       "have_patches" or => { "community_edition", # not in Community
-                             fileexists("$(sys.workdir)/state/software_patches_avail.csv") };
+                             fileexists($(patches_file)) };
 
-      "have_inventory" and => { "have_patches",
-                                fileexists("$(sys.workdir)/state/software_packages.csv"),
-      };
+      "have_packages" expression => fileexists($(packages_file));
+
+      "knows_inventory" or => { "debian", "redhat", "suse" };
 
   vars:
       # if we have the patches, 7 days; otherwise keep trying
-      "refresh" string => ifelse("have_inventory", "10080",
-                                 "0");
+      "packages_refresh" string => ifelse("have_packages", "10080",
+                                          "knows_inventory.!have_packages", "0",
+                                          "5040"); # for the generic case: try 3.5 days
+
+      # if we have the patches, 7 days; otherwise keep trying
+      "patches_refresh" string => ifelse("have_patches", "10080",
+                                         "knows_inventory.!have_patches", "0",
+                                         "5040"); # for the generic case: try 3.5 days
+
+      "patches_file" string => "$(sys.workdir)/state/software_patches_avail.csv";
+      "packages_file" string => "$(sys.workdir)/state/software_packages.csv";
+
+  commands:
+    knows_inventory.debian::
+      "/usr/bin/dpkg-query -f '$(const.dollar){binary:Package},$(const.dollar){Version},$(const.dollar){Architecture},dpkg\n' -W | $(paths.sort) > '$(packages_file)'"
+      contain => in_shell,
+      action => if_elapsed($(packages_refresh));
+
+      "$(debian_knowledge.call_apt_get) --just-print dist-upgrade | $(paths.perl) -n -e 'print if s/Inst\s+(\S+).+\((\S+).+\[(\S+)\].+/$1,$2,$3,dpkg/' | $(paths.sort) > '$(patches_file)'"
+      contain => in_shell,
+      action => if_elapsed($(patches_refresh));
+
+    knows_inventory.(redhat|suse)::
+      "$(redhat_knowledge.call_rpm) -qa --qf '%{name},%{arch},%{version}-%{release},rpm\n' | $(paths.sort) > '$(packages_file)'"
+      contain => in_shell,
+      action => if_elapsed($(packages_refresh));
+
+    knows_inventory.redhat::
+      "$(redhat_knowledge.call_yum) $(redhat_knowledge.yum_options) check-update | $(paths.perl) -n -e 'print if s/([^.]+)\.(\S+)\s+(\S+).+/$1,$3,$2,rpm/' | $(paths.sort) > '$(patches_file)'"
+      contain => in_shell,
+      action => if_elapsed($(patches_refresh));
+
+    knows_inventory.suse::
+      # TODO: SUSE parsing
+      "$(paths.zypper) list-updates | $(paths.perl) -n -e 'print if s/TODO/$1,$2,$3,rpm/' | $(paths.sort) > '$(patches_file)'"
+      contain => in_shell,
+      action => if_elapsed($(patches_refresh));
 
   packages:
-    debian::
-      "cfe_internal_non_existing_package"
-      package_policy => "add",
-      package_method => inventory_apt_get($(refresh));
 
-    redhat::
-      "cfe_internal_non_existing_package"
-      package_policy => "add",
-      package_method => inventory_yum_rpm($(refresh));
-
-    suse::
-      "cfe_internal_non_existing_package"
-      package_policy => "add",
-      package_method => inventory_zypper($(refresh));
-
-    gentoo::
-      "cfe_internal_non_existing_package"
-      package_policy => "add",
-      package_method => emerge;
-
-    !redhat.!debian.!gentoo.!suse::
+    !knows_inventory::
       "cfe_internal_non_existing_package"
       package_policy => "add",
       package_method => generic;
 
   reports:
     inform_mode::
-      "$(this.bundle): refresh interval is $(refresh)";
+      "$(this.bundle): patches refresh interval is $(patches_refresh)";
+      "$(this.bundle): packages refresh interval is $(packages_refresh)";
+    inform_mode.knows_inventory::
+      "$(this.bundle): we can generate the inventory files directly.";
+    inform_mode.!knows_inventory::
+      "$(this.bundle): we generate the inventory files with the generic method.";
     inform_mode.have_inventory::
       "$(this.bundle): we have the inventory files.";
     inform_mode.!have_inventory::
       "$(this.bundle): we don't have the inventory files.";
-}
-
-body package_method inventory_apt_get(update_interval)
-# @depends debian_knowledge
-# @brief APT installation package method for inventory purposes only
-# @param update_interval how often to update the package and patch list
-#
-# This package method is a copy of the yum_rpm method just for
-# inventory purposes.
-#
-# This package method interacts with the APT package manager through
-# `apt-get`.  It will never run "apt-get update" but is otherwise
-# exactly like the `apt_get` package method and *may* use the network
-# to install packages, as APT may decide.
-{
-      package_changes => "bulk";
-      package_list_command => "$(debian_knowledge.call_dpkg) -l";
-      package_list_name_regex => "$(debian_knowledge.list_name_regex)";
-      package_list_version_regex => "$(debian_knowledge.list_version_regex)";
-      package_installed_regex => ".i.*"; # packages that have been uninstalled may be listed
-      package_name_convention => "$(name)=$(version)";
-
-      # set it to "0" to avoid caching of list during upgrade
-      package_list_update_ifelapsed => $(update_interval);
-
-      # Target a specific release, such as backports
-      package_add_command => "$(debian_knowledge.call_apt_get) $(debian_knowledge.dpkg_options) --yes install";
-      package_list_update_command => "$(debian_knowledge.call_apt_get) update";
-      package_delete_command => "$(debian_knowledge.call_apt_get) $(debian_knowledge.dpkg_options) --yes -q remove";
-      package_update_command =>  "$(debian_knowledge.call_apt_get) $(debian_knowledge.dpkg_options) --yes install";
-      package_patch_command =>  "$(debian_knowledge.call_apt_get) $(debian_knowledge.dpkg_options) --yes install";
-      package_verify_command => "$(debian_knowledge.call_dpkg) -s";
-      package_noverify_returncode => "1";
-
-      package_patch_list_command => "$(debian_knowledge.call_apt_get) --just-print dist-upgrade";
-      package_patch_name_regex => "$(debian_knowledge.patch_name_regex)";
-      package_patch_version_regex => "$(debian_knowledge.patch_version_regex)";
-
-      # make correct version comparisons
-      package_version_less_command => "$(debian_knowledge.dpkg_compare_less)";
-      package_version_equal_command => "$(debian_knowledge.dpkg_compare_equal)";
-}
-
-body package_method inventory_yum_rpm(update_interval)
-# @depends common_knowledge redhat_knowledge redhat_knowledge
-# @brief Yum+RPM installation method for inventory purposes only
-# @param update_interval how often to update the package and patch list
-#
-# This package method is a copy of the yum_rpm method just for
-# inventory purposes.
-#
-# It will never run "yum update" but is otherwise exactly like the
-# `yum_rpm()` package method and *may* use the network to install
-# packages, as Yum may decide.
-{
-      package_changes => "bulk";
-      package_list_command => "$(redhat_knowledge.call_rpm) -qa --qf '%{name}.%{arch} %{version}-%{release}\n'";
-      package_patch_list_command => "$(redhat_knowledge.call_yum) $(redhat_knowledge.yum_options) check-update";
-
-      package_list_name_regex    => "$(redhat_knowledge.rpm3_name_regex)";
-      package_list_version_regex => "$(redhat_knowledge.rpm3_version_regex)";
-      package_list_arch_regex    => "$(redhat_knowledge.rpm3_arch_regex)";
-
-      package_installed_regex => ".*";
-      package_name_convention => "$(name)-$(version).$(arch)";
-
-      # just give the package name to rpm to delete, otherwise it gets "name.*" (from package_name_convention above)
-      package_delete_convention => "$(name)";
-
-      # set it to "0" to avoid caching of list during upgrade
-      package_list_update_command => "$(redhat_knowledge.call_yum) $(redhat_knowledge.yum_options) check-update";
-      package_list_update_ifelapsed => $(update_interval);
-
-      package_patch_name_regex    => "([^.]+).*";
-      package_patch_version_regex => "[^\s]\s+([^\s]+).*";
-      package_patch_arch_regex    => "[^.]+\.([^\s]+).*";
-
-      package_add_command    => "$(redhat_knowledge.call_yum) $(redhat_knowledge.yum_options) -y install";
-      package_update_command => "$(redhat_knowledge.call_yum) $(redhat_knowledge.yum_options) -y update";
-      package_patch_command  => "$(redhat_knowledge.call_yum) $(redhat_knowledge.yum_options) -y update";
-      package_delete_command => "$(redhat_knowledge.call_rpm) -e --nodeps";
-      package_verify_command => "$(redhat_knowledge.call_rpm) -V";
-}
-
-body package_method inventory_zypper(update_interval)
-# @depends common_knowledge redhat_knowledge
-# @brief SUSE zypper installation method for inventory purposes only
-# @param update_interval how often to update the package and patch list
-#
-# This package method is a copy of the SUSE zypper method just for
-# inventory purposes.
-{
-      package_changes => "bulk";
-
-      package_list_command => "$(paths.path[rpm]) -qa --queryformat \"i | repos | %{name} | %{version}-%{release} | %{arch}\n\"";
-
-      # set it to "0" to avoid caching of list during upgrade
-      package_list_update_command => "$(paths.path[zypper]) list-updates";
-      package_list_update_ifelapsed => $(update_interval);
-
-      package_patch_list_command => "$(paths.path[zypper]) patches";
-      package_installed_regex => "i.*";
-      package_list_name_regex    => "$(redhat_knowledge.rpm_name_regex)";
-      package_list_version_regex => "$(redhat_knowledge.rpm_version_regex)";
-      package_list_arch_regex    => "$(redhat_knowledge.rpm_arch_regex)";
-
-      package_patch_installed_regex => ".*Installed.*|.*Not Applicable.*";
-      package_patch_name_regex    => "[^|]+\|\s+([^\s]+).*";
-      package_patch_version_regex => "[^|]+\|[^|]+\|\s+([^\s]+).*";
-
-      package_name_convention => "$(name)";
-      package_add_command => "$(paths.path[zypper]) --non-interactive install";
-      package_delete_command => "$(paths.path[zypper]) --non-interactive remove --force-resolution";
-      package_update_command => "$(paths.path[zypper]) --non-interactive update";
-      package_patch_command => "$(paths.path[zypper]) --non-interactive patch$"; # $ means no args
-      package_verify_command => "$(paths.path[zypper]) --non-interactive verify$";
 }
 
 bundle agent cfe_autorun_inventory_cmdb


### PR DESCRIPTION
see https://cfengine.com/dev/issues/5339

On Red Hat, Debian, and SUSE: Implement direct updates of the patches and packages inventory files.  Use generic on others.

All tested except patches on SUSE.
