### PR TITLE
Fix SUSE/suse spelling

### DIFF
--- a/cfe_internal/cfengine_processes.cf
+++ b/cfe_internal/cfengine_processes.cf
@@ -207,7 +207,7 @@ bundle agent cfe_internal_build_software_report
       package_policy => "add",
       package_method => apt;
 
-    SuSE::
+    (SuSE|suse)::
 
       "wget"
       comment => "Install packages from the list",

--- a/update/update_bins.cf
+++ b/update/update_bins.cf
@@ -315,7 +315,7 @@ body package_method u_generic(repo)
       package_delete_command     => "/usr/bin/dpkg --purge";
       package_update_command     => "/usr/bin/dpkg --force-confdef --force-confnew --install";
 
-    redhat|SuSE::
+    redhat|SuSE|suse::
 
       package_changes => "individual";
 
@@ -341,7 +341,7 @@ body package_method u_generic(repo)
 
     redhat::
       package_list_update_command => "/usr/bin/yum --quiet check-update";
-    SuSE::
+    SuSE|suse::
       package_list_update_command => "/usr/bin/zypper list-updates";
 
     windows::


### PR DESCRIPTION
It's SUSE the company and suse the class from 3.6 on.

Keep SuSE|suse for backwards-compatibility in
  cfe_internal/cfengine_processes.cf and update/update_bins.cf
