### PR TITLE
fix the mysterious moving install location on solaris

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,14 @@ ifeq ($(DESTDIR),)
 endif
 
 UNAME := $(shell uname)
+REL := $(shell uname -r)
 
 ifeq ($(UNAME), SunOS)
-INSTALL = /usr/local/bin/install
+	ifneq ($(REL), 5.11)
+	INSTALL = /usr/sbin/install
+	else
+	INSTALL = /opt/csw/gnu/install
+	endif
 else
 INSTALL = /usr/bin/install
 endif


### PR DESCRIPTION
The install location appears to have moved for Solaris 10. Solaris 8, 9 and 10 it's in /usr/sbin/install and Solaris 11 it's in /opt/csw/gnu/install. Updated the Makefile to reflect this.
