### PR TITLE
services autorun: new facility, off by default, to auto-run services/autorun/*.cf

### DIFF
--- a/def.cf
+++ b/def.cf
@@ -156,6 +156,10 @@ bundle common def
 
       ### Enable special features policies. Set to "any" to enable.
 
+      # Auto-load files in "services/auto" and run bundles tagged "autorun".
+      # Disabled by default!
+      "services_autorun" expression => "!any";
+
       # Internal CFEngine log files rotation
       "cfengine_internal_rotate_logs" expression => "any";
 

--- a/promises.cf
+++ b/promises.cf
@@ -15,6 +15,10 @@ body common control
                           def,
                           cfe_internal_hub_vars,
 
+                          # autorun system
+                          services_autorun,
+                          $(services_autorun.bundle),
+
                          # Design Center
                           cfsketch_run,
 
@@ -49,7 +53,10 @@ body common control
                  # Reports
                   @(cfengine_reports.inputs),
 
-                 # Add update files to build Knowledge Map relationship
+                  # autorun system
+                  @(services_autorun.inputs),
+
+                  # Add update files to build Knowledge Map relationship
                   "update/update_bins.cf",
                   "update/cfe_internal_dc_workflow.cf",
                   "update/cfe_internal_local_git_remote.cf",
@@ -178,6 +185,23 @@ bundle common cfengine_reports
     verbose_mode::
       "$(this.bundle): defining inputs='$(inputs)'";
 }
+
+bundle common services_autorun
+{
+  vars:
+    cfengine_3_5||!services_autorun::
+      "inputs" slist => { };
+      "bundle" string => "services_autorun"; # run self
+
+    !cfengine_3_5.services_autorun::
+      "inputs" slist => { "services/autorun.cf" };
+      "bundle" string => "autorun"; # run loaded bundle
+
+  reports:
+    verbose_mode::
+      "$(this.bundle): defining inputs='$(inputs)'";
+}
+
 ###############################################################################
 #
 # bundle agent service_catalogue

--- a/services/autorun.cf
+++ b/services/autorun.cf
@@ -1,0 +1,18 @@
+body file control
+{
+      inputs => { @(autorun.inputs) };
+}
+
+bundle agent autorun
+{
+  vars:
+      "inputs" slist => findfiles("$(this.promise_dirname)/autorun/*.cf");
+      "bundles" slist => bundlesmatching(".*", "autorun");
+
+  methods:
+      "autorun" usebundle => $(bundles);
+
+  reports:
+    verbose_mode::
+      "$(this.bundle): found bundle $(bundles) with tag 'autorun'";
+}

--- a/services/autorun/hello.cf
+++ b/services/autorun/hello.cf
@@ -1,0 +1,9 @@
+bundle agent hello_world_autorun
+{
+  meta:
+      "tags" slist => { "autorun" };
+
+  reports:
+    verbose_mode::
+      "$(this.bundle): Hello, this is an automatically loaded bundle";
+}


### PR DESCRIPTION
enabled with `cf-agent -D services_autorun` or editing `def.cf`
