### PR TITLE
Perform daily maintenance on monitoring table

### DIFF
--- a/cfe_internal/CFE_cfengine.cf
+++ b/cfe_internal/CFE_cfengine.cf
@@ -64,7 +64,7 @@ bundle agent cfe_internal_management
       handle => "cfe_internal_truncate_events",
       comment => "To run CFE truncate to pending";
 
-    postgresql_maintenance::
+    postgresql_full_maintenance|postgresql_monitoring_maintenance::
 
       "hub" usebundle => cfe_internal_postgresql_maintenance,
       handle => "cfe_internal_management_postgresql_maintenance",

--- a/cfe_internal/CFE_hub_specific.cf
+++ b/cfe_internal/CFE_hub_specific.cf
@@ -594,11 +594,12 @@ bundle agent cfe_internal_postgresql_maintenance
 {
   vars:
 
-    any::
+      "postgres_vacuum_options" string => ifelse("postgresql_full_maintenance", "--full --dbname=cfdb", "--full --dbname=cfdb --table=__monitoringmg");
+      "maintenance_type" string => ifelse("postgresql_full_maintenance", "full", "monitoring_only");
 
-      "vacuumdb_cmd" string => "$(sys.bindir)/vacuumdb --full cfdb",
-      comment => "Command for cleaning a PostgreSQL database",
-      handle => "cfe_internal_postgresql_maintenance_vars_vacuum_cmd";
+      "vacuumdb_cmd" string => "$(sys.bindir)/vacuumdb $(postgres_vacuum_options)",
+      comment => "Command for cleaning a PostgreSQL database - $(maintenance_type)",
+      handle => "cfe_internal_postgresql_maintenance_vars_vacuum_cmd_$(maintenance_type)";
 
       #
 
@@ -607,12 +608,12 @@ bundle agent cfe_internal_postgresql_maintenance
     any::
 
       "cf-hub"      signals => { "term" },
-      comment => "Terminate cf-hub while doing PostgreSQL maintenance",
-      handle => "cfe_internal_postgresql_maintenance_processes_term_cf_hub";
+      comment => "Terminate cf-hub while doing $(maintenance_type) PostgreSQL maintenance",
+      handle => "cfe_internal_postgresql_$(maintenance_type)_maintenance_processes_term_cf_hub";
 
       "cf-consumer" signals => { "kill" },
       comment => "Kill cf-consumer while doing PostgreSQL maintenance",
-      handle => "cfe_internal_postgresql_maintenance_processes_kill_cf_consumer";
+      handle => "cfe_internal_postgresql_$(maintenance_type)_maintenance_processes_kill_cf_consumer";
 
       #
 
@@ -621,6 +622,6 @@ bundle agent cfe_internal_postgresql_maintenance
     any::
 
       "$(vacuumdb_cmd)"
-      comment => "Run vacuumdb command",
-      handle => "cfe_internal_postgresql_maintenance_commands_run_vacuumdb_cmd";
+      comment => "Run $(maintenance_type) vacuumdb command",
+      handle => "cfe_internal_postgresql_maintenance_commands_run_vacuumdb_cmd_$(maintenance_type)";
 }

--- a/def.cf
+++ b/def.cf
@@ -183,8 +183,10 @@ bundle common def
       # pre-defined to every Sunday at 2 a.m.
       # This can be changed later on.
 
-      "postgresql_maintenance" expression => "am_policy_hub.enterprise.Sunday.Hr02.Min00_05";
+      "postgresql_full_maintenance" expression => "policy_server.enterprise.Sunday.Hr02.Min00_05";
 
+      # Vacuum monitoring_mg table every day (except Sunday, when vacuum is run on entire db)
+      "postgresql_monitoring_maintenance" expression => "policy_server.enterprise.!Sunday.Hr02.Min00_05";
 }
 
 bundle common inventory_control


### PR DESCRIPTION
Monitoring data showed ~200% fragmentation in our tests due to frequent updates. Perform vacuum full on this table on a daily basis until a better solution is found.

This pull request modifies the pre-existing weekly full db vacuum bundle to include daily vacuuming of the monitoring table.

Redmine #5262
