### PR TITLE
update.cf: add .sh .pl .py .rb extensions to default input_name_patterns

### DIFF
--- a/update.cf
+++ b/update.cf
@@ -40,6 +40,7 @@ bundle common update_def
 {
   vars:
       "input_name_patterns" slist => { ".*.cf",".*.dat",".*.txt", ".*.conf", ".*.mustache",
+                                       "*.sh", "*.pl", "*.py", "*.rb",
                                        "cf_promises_release_id" },
       comment => "Filename patterns to match when updating the policy (see update/update_policy.cf)",
       handle => "common_def_vars_input_name_patterns";


### PR DESCRIPTION
see https://dev.cfengine.com/issues/5814
