### PR TITLE
update.cf,def.cf: Add cfengine_internal_preserve_permissions class

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,19 @@ Turn this on (set to `any`) to delete any files in your
 Note it has a duplicate in `def.cf`, see below. If they are not
 synchronized, you will get unexpected behavior.
 
+##### cfengine_internal_preserve_permissions
+
+Off by default.
+
+Turn this on (set to `any`) to preserve the permissions of the policy
+server's masterfiles when they are copied.
+
+**This may result in FUNCTIONALITY LOSS if your scripts lose their
+exec bits unexpectedly**
+
+Note it has a duplicate in `def.cf`, see below. If they are not
+synchronized, you will get unexpected behavior.
+
 ### def.cf
 
 After `update.cf` is configured, you can configure the main `def.cf` policy.
@@ -192,6 +205,11 @@ Duplicate of the one in `update.cf`. They should be set in unison or
 you will get unexpected behavior.
 
 ##### cfengine_internal_purge_policies
+
+Duplicate of the one in `update.cf`. They should be set in unison or
+you will get unexpected behavior.
+
+##### cfengine_internal_preserve_permissions
 
 Duplicate of the one in `update.cf`. They should be set in unison or
 you will get unexpected behavior.

--- a/def.cf
+++ b/def.cf
@@ -179,6 +179,14 @@ bundle common def
 
       "cfengine_internal_purge_policies" expression => "!any";
 
+      # Preserve permissions of the policy server's masterfiles.
+      # you can also request it from the command line with
+      # -Dcfengine_internal_preserve_permissions
+
+      # NOTE THAT THIS CLASS ALSO NEEDS TO BE SET IN update.cf
+
+      "cfengine_internal_preserve_permissions" expression => "!any";
+
       # Allow the hub to edit sudoers in order for the Apache user to
       # run passwordless sudo cf-runagent. Enable this if you want the
       # Mission Portal to be able to troubleshoot failed Design Center

--- a/update.cf
+++ b/update.cf
@@ -100,6 +100,14 @@ bundle common update_def
 
       "cfengine_internal_purge_policies" expression => "!any";
 
+      # Preserve permissions of the policy server's masterfiles.
+      # you can also request it from the command line with
+      # -Dcfengine_internal_preserve_permissions
+
+      # NOTE THAT THIS CLASS ALSO NEEDS TO BE SET IN def.cf
+
+      "cfengine_internal_preserve_permissions" expression => "!any";
+
 }
 
 body classes u_kept_successful_command

--- a/update/update_policy.cf
+++ b/update/update_policy.cf
@@ -319,6 +319,9 @@ body copy_from u_rcp(from,server)
 
     cfengine_internal_purge_policies::
       purge => "true";
+
+    cfengine_internal_preserve_permissions::
+      preserve => "true";
 }
 
 #########################################################


### PR DESCRIPTION
see https://dev.cfengine.com/issues/5848

Please review, adds new `cfengine_internal_preserve_permissions` class as discussed in help-cfengine
