### PR TITLE
Escape dots that are meant to be dots in regexes.

### DIFF
--- a/cfe_internal/CFE_knowledge.cf
+++ b/cfe_internal/CFE_knowledge.cf
@@ -127,7 +127,7 @@ body action aggregator
 
 body file_select knowledge_files
 {
-      leaf_name => { ".*.cf", ".*.html", ".*.png", ".*php", ".*css" };
+      leaf_name => { ".*\.cf", ".*\.html", ".*\.png", ".*php", ".*css" };
       file_result => "leaf_name";
 }
 

--- a/update.cf
+++ b/update.cf
@@ -42,9 +42,9 @@ body agent control
 bundle common update_def
 {
   vars:
-      "input_name_patterns" slist => { ".*.cf",".*.dat",".*.txt", ".*.conf", ".*.mustache",
-                                       ".*.sh", ".*.pl", ".*.py", ".*.rb",
-                                       "cf_promises_release_id" },
+      "input_name_patterns" slist => { ".*\.cf",".*\.dat",".*\.txt", ".*\.conf",
+                                       ".*\.sh", ".*\.pl", ".*\.py", ".*\.rb",
+                                       ".*\.mustache", "cf_promises_release_id" },
       comment => "Filename patterns to match when updating the policy (see update/update_policy.cf)",
       handle => "common_def_vars_input_name_patterns";
 


### PR DESCRIPTION
Various regexes were of form `".*.suffix"` where the first dot means
"any character at all" and the second actually means exactly the same
so is almost superfluous (the pattern `/.*./` is equivalent to `/.+/`),
except that it was clearly meant to mean "a dot"; to make it so,
escape it !

Oh - and I shuffled the order of a list to make it lay out nicer.
