### PR TITLE
Ensure permissions to comply with ones from postinstall script

### DIFF
--- a/cfe_internal/CFE_knowledge.cf
+++ b/cfe_internal/CFE_knowledge.cf
@@ -186,3 +186,4 @@ body file_select cfe_internal_exclude_index_html
   leaf_name => { "index.html" };
   file_result => "!leaf_name";
 }
+


### PR DESCRIPTION
- root owns most of files/directories in docroot
- remove knowledge_files which is not used anywhere
- pl files should have execution bit
