### PR TITLE
Break up .gitignore and correct its syntax.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,22 +1,4 @@
-cf_promises_*
+/cf_promises_*
 
-# acceptance tests
-tests/acceptance/*.log
-tests/acceptance/testall.env
-tests/acceptance/.succeeded
-tests/acceptance/workdir
-tests/acceptance/mock-package-manager
-tests/acceptance/mock-package-manager.exe
-tests/acceptance/xml-c14nize
-tests/acceptance//xml-c14nize.exe
-tests/acceptance/dnswrapper.so
-tests/*/*.xml
-tests/*/xml.tmp
-tests/*/xml_tmp_*
-tests/*/*.trs
-
-# copied from core
-tests/acceptance/*.cf.sub
-
-# ignore vim dotfiles
+# vim
 .*.sw[po]

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,18 @@
+*.xml
+xml.tmp
+xml_tmp_*
+*.trs
+
+# acceptance tests
+/acceptance/*.log
+/acceptance/testall.env
+/acceptance/.succeeded
+/acceptance/workdir
+/acceptance/mock-package-manager
+/acceptance/mock-package-manager.exe
+/acceptance/xml-c14nize
+/acceptance//xml-c14nize.exe
+/acceptance/dnswrapper.so
+
+# copied from core
+/acceptance/*.cf.sub


### PR DESCRIPTION
Use leading / to indicate paths relative to the present directory,
move all the bits for tests/ into that sub-directory.

Provoked by discussion with @tzz.
