### PR TITLE
Cleanup cf-consumer restart during daily maintenance

### DIFF
--- a/cfe_internal/CFE_hub_specific.cf
+++ b/cfe_internal/CFE_hub_specific.cf
@@ -630,7 +630,15 @@ bundle agent cfe_internal_postgresql_maintenance
       comment => "Command for cleaning a PostgreSQL database - $(maintenance_type)",
       handle => "cfe_internal_postgresql_maintenance_vars_vacuum_cmd_$(maintenance_type)";
 
+      "cf_consumer_pid" string => readfile("$(sys.workdir)/cf-consumer.pid", 0),
+      comment => "Read cf-consumer.pid for the main cf-consumer PID",
+      handle => "cfe_internal_postgresql_maintenance_cf_consumer_pid";
       #
+
+  classes:
+      "cf_consumer_pid_correct" expression => isvariable("cf_consumer_pid"),
+      comment => "Check if cf-consumer pid is correct",
+      handle => "cfe_internal_cf_consumer_pid_correct";
 
   processes:
 
@@ -640,7 +648,9 @@ bundle agent cfe_internal_postgresql_maintenance
       comment => "Terminate cf-hub while doing $(maintenance_type) PostgreSQL maintenance",
       handle => "cfe_internal_postgresql_$(maintenance_type)_maintenance_processes_term_cf_hub";
 
+    cf_consumer_pid_correct::
       "cf-consumer" signals => { "kill" },
+      process_select => by_pid("$(cf_consumer_pid)"),
       comment => "Kill cf-consumer while doing PostgreSQL maintenance",
       handle => "cfe_internal_postgresql_$(maintenance_type)_maintenance_processes_kill_cf_consumer";
 

--- a/lib/3.5/processes.cf
+++ b/lib/3.5/processes.cf
@@ -77,6 +77,16 @@ body process_select by_owner(u)
 
 ##
 
+body process_select by_pid(pid)
+# @brief Select a process matching the given PID
+# @param pid PID of the process to be matched
+{
+      pid => irange("$(pid)","$(pid)");
+      process_result => "pid";
+}
+
+##
+
 body process_count any_count(cl)
 
 {

--- a/lib/3.6/processes.cf
+++ b/lib/3.6/processes.cf
@@ -83,6 +83,14 @@ body process_select by_owner(u)
       process_result => "process_owner";
 }
 
+body process_select by_pid(pid)
+# @brief Select a process matching the given PID
+# @param pid PID of the process to be matched
+{
+      pid => irange("$(pid)","$(pid)");
+      process_result => "pid";
+}
+
 ##
 
 body process_count any_count(cl)

--- a/lib/3.7/processes.cf
+++ b/lib/3.7/processes.cf
@@ -83,6 +83,14 @@ body process_select by_owner(u)
       process_result => "process_owner";
 }
 
+body process_select by_pid(pid)
+# @brief Select a process matching the given PID
+# @param pid PID of the process to be matched
+{
+      pid => irange("$(pid)","$(pid)");
+      process_result => "pid";
+}
+
 ##
 
 body process_count any_count(cl)


### PR DESCRIPTION
Read cf-consumer.pid to kill the parent cf-consumer process. This will automatically kill all the child processes - no need to match all cf-consumer processes and kill them one by one.

Redmine: 6303
