### PR TITLE
reduce the amount of monitoring probes down to 33% or less

### DIFF
--- a/lib/3.6/reports.cf
+++ b/lib/3.6/reports.cf
@@ -56,12 +56,7 @@ body report_data_select default_data_select_host
 {
       metatags_include => { "inventory", "report" };
       metatags_exclude => { "noreport" };
-      monitoring_include => { "cpu.*",
-                              "mem_total",
-                              "mem_free",
-                              "mem_cached",
-                              "mem_swap",
-                              "mem_freeswap",
+      monitoring_include => { "cpu",
                               "loadavg",
                               "diskfree" };
 }


### PR DESCRIPTION
 To save hub reporting load.

Please cherry-pick to 3.6.x for inclusion in 3.6.1.
