### PR TITLE
Fix pkgin parsing of package list

### DIFF
--- a/lib/3.5/packages.cf
+++ b/lib/3.5/packages.cf
@@ -1018,8 +1018,8 @@ body package_method smartos
 {
       package_changes => "bulk";
       package_list_command => "/opt/local/bin/pkgin list";
-      package_list_name_regex    => "(.*)\-[0-9]+.*";
-      package_list_version_regex => ".*\-([0-9][^\s]+).*";
+      package_list_name_regex    => "([^\s]+)\-[0-9]+.*\s";
+      package_list_version_regex => "[^\s]+\-([0-9][^\s]+)\s";
 
       package_installed_regex => ".*"; # all reported are installed
 

--- a/lib/3.6/packages.cf
+++ b/lib/3.6/packages.cf
@@ -1195,8 +1195,8 @@ body package_method smartos
 {
       package_changes => "bulk";
       package_list_command => "/opt/local/bin/pkgin list";
-      package_list_name_regex    => "(.*)\-[0-9]+.*";
-      package_list_version_regex => ".*\-([0-9][^\s]+).*";
+      package_list_name_regex    => "([^\s]+)\-[0-9]+.*\s";
+      package_list_version_regex => "[^\s]+\-([0-9][^\s]+)\s";
 
       package_installed_regex => ".*"; # all reported are installed
 

--- a/lib/3.7/packages.cf
+++ b/lib/3.7/packages.cf
@@ -1195,8 +1195,8 @@ body package_method smartos
 {
       package_changes => "bulk";
       package_list_command => "/opt/local/bin/pkgin list";
-      package_list_name_regex    => "(.*)\-[0-9]+.*";
-      package_list_version_regex => ".*\-([0-9][^\s]+).*";
+      package_list_name_regex    => "([^\s]+)\-[0-9]+.*\s";
+      package_list_version_regex => "[^\s]+\-([0-9][^\s]+)\s";
 
       package_installed_regex => ".*"; # all reported are installed
 


### PR DESCRIPTION
Previously the smartos package method would incorrectly parse some lines if they had strings that looked like package name/version pairs.

E.g.:

```
# pkgin ls | grep py27-cairo
py27-cairo-1.10.0nb2 Python bindings for cairo (python-2.x version)
```

Would be parsed like the following:

```
2014-07-09T21:56:46+0000  verbose: /default/pkg/packages/'py27-cairo'[0]: Comparing [available] package (py27-cairo-1.10.0nb2,2.x,default) to [==] with given (py27-cairo,*,*) [name,version,arch]
```

That is, the package name was assumed to be `py27-cairo-1.0.0nb2` and the package version was assumed to be `2.x`. This would cause cfengine to always assume the package needs installing.

This update will correctly parse package names and versions even when the comment contains a string that looks like package name/version pairs.
