### PR TITLE
Fix smartos paths for npm and pip

### DIFF
--- a/lib/3.5/paths.cf
+++ b/lib/3.5/paths.cf
@@ -184,6 +184,10 @@ bundle common paths
       "path[sort]"     string => "/usr/bin/sort";
       "path[tr]"       string => "/usr/bin/tr";
 
+    smartos::
+      "path[npm]"      string => "/opt/local/bin/npm";
+      "path[pip]"      string => "/opt/local/bin/pip";
+
     solaris::
 
       "path[awk]"      string => "/usr/bin/awk";

--- a/lib/3.6/paths.cf
+++ b/lib/3.6/paths.cf
@@ -221,6 +221,10 @@ bundle common paths
       "path[sort]"     string => "/usr/bin/sort";
       "path[tr]"       string => "/usr/bin/tr";
 
+    smartos::
+      "path[npm]"      string => "/opt/local/bin/npm";
+      "path[pip]"      string => "/opt/local/bin/pip";
+
     solaris::
 
       "path[awk]"      string => "/usr/bin/awk";

--- a/lib/3.7/paths.cf
+++ b/lib/3.7/paths.cf
@@ -221,6 +221,10 @@ bundle common paths
       "path[sort]"     string => "/usr/bin/sort";
       "path[tr]"       string => "/usr/bin/tr";
 
+    smartos::
+      "path[npm]"      string => "/opt/local/bin/npm";
+      "path[pip]"      string => "/opt/local/bin/pip";
+
     solaris::
 
       "path[awk]"      string => "/usr/bin/awk";


### PR DESCRIPTION
The default paths for `pip` and `npm` do not exist on SmartOS.
