### PR TITLE
Packahge method pip needs to use pip_knowledge

### DIFF
--- a/lib/3.5/packages.cf
+++ b/lib/3.5/packages.cf
@@ -192,9 +192,9 @@ body package_method pip(flags)
 
       package_list_update_ifelapsed => "$(common_knowledge.list_update_ifelapsed)";
 
-      package_list_name_regex    => "$(pip_list_name_regex)";
-      package_list_version_regex => "$(pip_list_version_regex)";
-      package_installed_regex    => "$(pip_installed_regex)";
+      package_list_name_regex    => "$(pip_knowledge.pip_list_name_regex)";
+      package_list_version_regex => "$(pip_knowledge.pip_list_version_regex)";
+      package_installed_regex    => "$(pip_knowledge.pip_installed_regex)";
 
       package_name_convention   => "$(name)";
       package_delete_convention => "$(name)";

--- a/lib/3.6/packages.cf
+++ b/lib/3.6/packages.cf
@@ -302,9 +302,9 @@ body package_method pip(flags)
 
       package_list_update_ifelapsed => "$(common_knowledge.list_update_ifelapsed)";
 
-      package_list_name_regex    => "$(pip_list_name_regex)";
-      package_list_version_regex => "$(pip_list_version_regex)";
-      package_installed_regex    => "$(pip_installed_regex)";
+      package_list_name_regex    => "$(pip_knowledge.pip_list_name_regex)";
+      package_list_version_regex => "$(pip_knowledge.pip_list_version_regex)";
+      package_installed_regex    => "$(pip_knowledge.pip_installed_regex)";
 
       package_name_convention   => "$(name)";
       package_delete_convention => "$(name)";

--- a/lib/3.7/packages.cf
+++ b/lib/3.7/packages.cf
@@ -302,9 +302,9 @@ body package_method pip(flags)
 
       package_list_update_ifelapsed => "$(common_knowledge.list_update_ifelapsed)";
 
-      package_list_name_regex    => "$(pip_list_name_regex)";
-      package_list_version_regex => "$(pip_list_version_regex)";
-      package_installed_regex    => "$(pip_installed_regex)";
+      package_list_name_regex    => "$(pip_knowledge.pip_list_name_regex)";
+      package_list_version_regex => "$(pip_knowledge.pip_list_version_regex)";
+      package_installed_regex    => "$(pip_knowledge.pip_installed_regex)";
 
       package_name_convention   => "$(name)";
       package_delete_convention => "$(name)";


### PR DESCRIPTION
`body package_method pip` was not using `pip_knowledge`. This caused cfengine to attempt to install pip packages on every run because it could not match installed packages.
