### PR TITLE
Fixed gentoo package list regex

### DIFF
--- a/lib/3.5/packages.cf
+++ b/lib/3.5/packages.cf
@@ -1471,8 +1471,8 @@ body package_method generic
     gentoo::
       package_changes => "individual";
       package_list_command => "/bin/sh -c '/bin/ls -d /var/db/pkg/*/* | cut -c 13-'";
-      package_list_name_regex => ".*/([^\s]+)-\d.*";
-      package_list_version_regex => ".*/[^\s]+-(\d.*)";
+      package_list_name_regex => "([^/]+/(?:(?!-\d).)+)-\d.*";
+      package_list_version_regex => "[^/]+/(?:(?!-\d).)+-(\d.*)";
       package_installed_regex => ".*";                          # all reported are installed
       package_name_convention => "$(name)";
       package_list_update_command => "/bin/true";               # I prefer manual syncing

--- a/lib/3.6/packages.cf
+++ b/lib/3.6/packages.cf
@@ -1708,8 +1708,8 @@ body package_method generic
     gentoo::
       package_changes => "individual";
       package_list_command => "/bin/sh -c '/bin/ls -d /var/db/pkg/*/* | cut -c 13-'";
-      package_list_name_regex => ".*/([^\s]+)-\d.*";
-      package_list_version_regex => ".*/[^\s]+-(\d.*)";
+      package_list_name_regex => "([^/]+/(?:(?!-\d).)+)-\d.*";
+      package_list_version_regex => "[^/]+/(?:(?!-\d).)+-(\d.*)";
       package_installed_regex => ".*";                          # all reported are installed
       package_name_convention => "$(name)";
       package_list_update_command => "/bin/true";               # I prefer manual syncing

--- a/lib/3.7/packages.cf
+++ b/lib/3.7/packages.cf
@@ -1708,8 +1708,8 @@ body package_method generic
     gentoo::
       package_changes => "individual";
       package_list_command => "/bin/sh -c '/bin/ls -d /var/db/pkg/*/* | cut -c 13-'";
-      package_list_name_regex => ".*/([^\s]+)-\d.*";
-      package_list_version_regex => ".*/[^\s]+-(\d.*)";
+      package_list_name_regex => "([^/]+/(?:(?!-\d).)+)-\d.*";
+      package_list_version_regex => "[^/]+/(?:(?!-\d).)+-(\d.*)";
       package_installed_regex => ".*";                          # all reported are installed
       package_name_convention => "$(name)";
       package_list_update_command => "/bin/true";               # I prefer manual syncing


### PR DESCRIPTION
Hello,

I have been using this modified regex for my gentoo boxes for quite some time and thought it was about time I tried to contribute something to this great tool.

The original regex doesn't match packages full names, which is unfortunate since if you omit the first part of a package name there are duplicates in the portage tree. For example dev-libs/mpc (A library for multiprecision complex arithmetic) and media-sound/mpc (Music player daemon cli client).

I don't know how widely cfengine is used on gentoo and as this change will break promises for people relying on the former regex to install packages this pull request might get rejected. But the current implementation has a flaw, so I leave this matter into the capable hands and good judgment of cfengine maintainers.

Have a nice day!
