### PR TITLE
Guard reading of cf-consumer.pid using `readfile()` by enterprise and hub classes

### DIFF
--- a/cfe_internal/CFE_hub_specific.cf
+++ b/cfe_internal/CFE_hub_specific.cf
@@ -630,15 +630,13 @@ bundle agent cfe_internal_postgresql_maintenance
       comment => "Command for cleaning a PostgreSQL database - $(maintenance_type)",
       handle => "cfe_internal_postgresql_maintenance_vars_vacuum_cmd_$(maintenance_type)";
 
+    policy_server.enterprise.!cfengine_3_5::
       "cf_consumer_pid" string => readfile("$(sys.workdir)/cf-consumer.pid", 0),
-      comment => "Read cf-consumer.pid for the main cf-consumer PID",
-      handle => "cfe_internal_postgresql_maintenance_cf_consumer_pid";
-      #
+      comment => "Read cf-consumer.pid for the main cf-consumer PID";
 
   classes:
       "cf_consumer_pid_correct" expression => isvariable("cf_consumer_pid"),
-      comment => "Check if cf-consumer pid is correct",
-      handle => "cfe_internal_cf_consumer_pid_correct";
+      comment => "Check if cf-consumer pid is correctly defined";
 
   processes:
 


### PR DESCRIPTION
This is necessary because class guards do not protect function evaluation when calling methods.

eg.

```
body common control
{
 bundlesequence => {"method1"};
 inputs => { "/var/cfengine/inputs/lib/3.6/stdlib.cf" };
}

bundle common def
{
 classes:
    "class1" expression => "policy_server.enterprise.!cfengine_3_5";
}

bundle agent method1
{
 methods:
  # This class guard is not retained while executing method2
  class1::
    "hub" usebundle => method2;
}

bundle agent method2
{
  vars:
# uncommenting this will show expected behavior
# class1::
    "data1" string => readfile("/tmp/non/existant", 0);
    "data2" string => readfile("/tmp/test", 0);

  classes:
   class1::
    "data_correct" expression => isvariable("data2");

  reports:
    data_correct::
    "data = $(data2)";
}

```

Check with:  `cf-promises -I`
