### PR TITLE
cmd_repair fix to be backward compatible

### DIFF
--- a/lib/3.5/common.cf
+++ b/lib/3.5/common.cf
@@ -205,6 +205,7 @@ body classes if_ok_cancel(x)
 
 body classes cmd_repair(code,cl)
 {
+      kept_returncodes => { "0" };
       repaired_returncodes => { "$(code)" };
       promise_repaired => { "$(cl)" };
 }

--- a/lib/3.6/common.cf
+++ b/lib/3.6/common.cf
@@ -248,6 +248,7 @@ body classes cmd_repair(code,cl)
 #
 # **See also:** `repaired_returncodes`
 {
+      kept_returncodes => { "0" };
       repaired_returncodes => { "$(code)" };
       promise_repaired => { "$(cl)" };
 }

--- a/lib/3.7/common.cf
+++ b/lib/3.7/common.cf
@@ -248,6 +248,7 @@ body classes cmd_repair(code,cl)
 #
 # **See also:** `repaired_returncodes`
 {
+      kept_returncodes => { "0" };
       repaired_returncodes => { "$(code)" };
       promise_repaired => { "$(cl)" };
 }


### PR DESCRIPTION
I got a lot messages when upgraded to cfengine 3.6 that promise was fail...ed, due the fact
that return code '0' is not seen has promise kept. That is why i added kept_returncode
statement to be backwards compatible
