### PR TITLE
Ignore masterfiles/test-driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ stamp-h1
 /missing
 /revision
 /ylwrap
+/test-driver
 
 # Misc.
 /cf_promises_*


### PR DESCRIPTION
It's created by something during builds, probably thanks to
@kacfengine's recent changes to use autotools.
