### PR TITLE
Add: Local user inventory module

### DIFF
--- a/def.cf
+++ b/def.cf
@@ -224,6 +224,18 @@ bundle common inventory_control
       "mtab" string => "/etc/mtab";
       "proc" string => "/proc";
 
+      # Note: This controls local user discovery, by affects the inventory
+      # interface by proxy. If you would like to report on local user details
+      # but only expose a limtied set to the inventory interface please let us
+      # know.
+      "inventory_local_users_password_last_change_whitelist" -> { "handle:disable_inventory_local_users_whitelist" }
+        slist => { "root" },
+	      comment => "This list of usernames will be used as a white list and
+		                will restrict local user discovery to report the details
+		                only for these users. An empty list will result in all
+		                local users being reported and added to the inventory
+                    interface.";
+
   classes:
       # setting this disables all the inventory modules except package_refresh
       "disable_inventory" expression => "!any";
@@ -275,6 +287,35 @@ bundle common inventory_control
       # disable_inventory is not set
       "disable_inventory_cmdb" expression => "any";
 
+      # by default disable the local user discovery if the general
+      # inventory is disabled
+      "disable_inventory_local_users_discover" expression => "disable_inventory";
+
+      # by default disable reporting of encrypted passwords discovered by
+      # `cfe_autorun_inventory_local_users_discover`, even if disable_inventory
+      # is not set.
+      "disable_inventory_local_users_discover_report_encrypted_password" expression => "any";
+
+      # by default disable the local user inventory if the general
+      # inventory is disabled
+      "disable_inventory_local_users" expression => "disable_inventory";
+
+      # by default disable the locked local user inventory
+      "disable_inventory_local_users_locked" expression => "disable_inventory_local_users";
+
+      # by default disable the local user days since password change
+      "disable_inventory_local_users_password_last_change"
+        expression => "any";
+
+      # by default disable the local users with empty password inventory
+      "disable_inventory_local_users_password_empty" expression => "disable_inventory_local_users";
+
+      # Filter local user inventory based on whitelist if if the list has any content.
+      # by default the whitelist contains only "root" and will not collect other local users.
+      "disable_inventory_local_users_whitelist"
+        handle => "disable_inventory_local_users_whitelist",
+        expression => islessthan( length("inventory_local_users_password_last_change_whitelist"), 1);
+
   reports:
     verbose_mode.disable_inventory::
       "$(this.bundle): All inventory modules disabled";
@@ -294,4 +335,12 @@ bundle common inventory_control
       "$(this.bundle): package_refresh module enabled";
     verbose_mode.!disable_inventory_cmdb::
       "$(this.bundle): CMDB module enabled";
+    verbose_mode.!disable_inventory_local_users_discovery::
+      "$(this.bundle): Local users discovery enabled";
+    verbose_mode.!disable_inventory_local_users::
+      "$(this.bundle): Local users locked module enabled";
+    verbose_mode.!disable_inventory_local_users_locked::
+      "$(this.bundle): Local users locked module enabled";
+    verbose_mode.!disable_inventory_local_users_password_last_change::
+      "$(this.bundle): Local users days since password change module enabled";
 }

--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -42,6 +42,26 @@ bundle agent inventory_autorun
       "dmidecode" usebundle => cfe_autorun_inventory_dmidecode(),
       handle => "cfe_internal_autorun_inventory_dmidecode";
 
+    !disable_inventory_local_users_discover::
+      "local_users" usebundle => cfe_autorun_inventory_local_users_discover(),
+      handle => "cfe_internal_autorun_discovery_local_users";
+
+    !disable_inventory_local_users::
+      "local_users_locked" usebundle => inventory_local_users(),
+      handle => "cfe_internal_autorun_inventory_local_users";
+
+    !disable_inventory_local_users_locked::
+      "local_users_locked" usebundle => inventory_local_users_locked(),
+      handle => "cfe_internal_autorun_inventory_local_users_locked";
+
+    !disable_inventory_local_users_password_last_change::
+      "local_users_password_last_change" usebundle => inventory_local_users_password_last_change(),
+      handle => "cfe_internal_autorun_inventory_local_users_password_last_change";
+
+    !disable_inventory_local_users_password_empty::
+      "local_users_password_empty" usebundle => inventory_local_users_password_empty(),
+      handle => "cfe_internal_autorun_inventory_local_users_password_empty";
+
     any::
       "listening ports" usebundle => cfe_autorun_inventory_listening_ports(),
       handle => "cfe_internal_autorun_listening_ports";
@@ -604,6 +624,345 @@ bundle agent inventory_cmdb_load(file)
       "$(this.bundle): Could not read the CMDB data from $(file)";
 }
 
+bundle agent cfe_autorun_inventory_local_users_discover
+# @brief Discover local user information
+#
+# This bundle does local user discovery by parsing /etc/passwd and /etc/shadow
+# on linux and unix systems. The variables populated by this discovery are
+# reported back to Mission Portal, but they are not inventoried by default.
+# The companion bundles inventory_local_users_* if enabled will report the
+# variables with inventory tags to populate the inventory.
+#
+# **See Also:**
+# * `inventory_local_users_password_last_change`
+# * `inventory_local_users`
+# * `inventory_local_users_locked`
+# * `inventory_local_users_password_empty`
+{
+  vars:
+    linux::
+      "shadow_data" data => data_readstringarray("$(paths.shadow)", "", ":", 500, 10240);
+      "passwd_data" data => data_readstringarray("/etc/passwd", "", ":", 500, 10240);
+
+
+      "all_local_users"
+        slist => getindices("passwd_data"),
+        meta => { "report" };
+
+      "all_local_users_str"
+        string => join(", ", all_local_users),
+        comment => "Having a combined string of users is useful for debug reports";
+
+      "all_local_users_canonified_map[$(all_local_users)]"
+        string => canonify($(all_local_users));
+
+      "all_local_users_canonified_list"
+        slist => maplist("$(local_users_canonified_list[$(this)])", "local_users"),
+        comment => "A canonified list is useful when dealing with variables
+                    because user names may contain characters that are invalid
+                    in variable names";
+
+      "date_last_password_change[$(all_local_users)]"
+        string => "$(shadow_data[$(all_local_users)][1])",
+        meta => { "report", "derived_from=$(paths.shadow)" };
+
+      "min_password_age[$(all_local_users)]"
+        string => "$(shadow_data[$(all_local_users)][2])",
+        meta => { "report", "derived_from=$(paths.shadow)" };
+
+      "max_password_age[$(all_local_users)]"
+        string => "$(shadow_data[$(all_local_users)][3])",
+        meta => { "report", "derived_from=$(paths.shadow)" };
+
+      "password_warning_period[$(all_local_users)]"
+        string => "$(shadow_data[$(all_local_users)][4])",
+        meta => { "report", "derived_from=$(paths.shadow)" };
+
+      "password_inactivity_period[$(all_local_users)]"
+        string => "$(shadow_data[$(all_local_users)][5])",
+        meta => { "report", "derived_from=$(paths.shadow)" };
+
+      "account_expiration_date[$(all_local_users)]"
+        string => "$(shadow_data[$(all_local_users)][6])",
+        meta => { "report", "derived_from=$(paths.shadow)" };
+
+      "numeric_user_id[$(all_local_users)]"
+        string => "$(passwd_data[$(all_local_users)][1])",
+        meta => { "report", "derived_from=/etc/passwd" };
+
+      "numeric_group_id[$(all_local_users)]"
+        string => "$(passwd_data[$(all_local_users)][2])",
+        meta => { "report", "derived_from=/etc/passwd" };
+
+      "comment[$(all_local_users)]"
+        string => "$(passwd_data[$(all_local_users)][3])",
+        meta => { "report", "derived_from=/etc/passwd" };
+
+      "home_directory[$(all_local_users)]"
+        string => "$(passwd_data[$(all_local_users)][4])",
+        meta => { "report", "derived_from=/etc/passwd" };
+
+      "shell[$(all_local_users)]"
+        string => "$(passwd_data[$(all_local_users)][5])",
+        meta => { "report", "derived_from=/etc/passwd" };
+
+    linux.!disable_inventory_local_users_discover_report_encrypted_password::
+      "encrypted_password[$(all_local_users)]"
+        string => "$(shadow_data[$(all_local_users)][0])",
+        meta => { "report" };
+
+    linux.disable_inventory_local_users_discover_report_encrypted_password::
+      "encrypted_password[$(all_local_users)]"
+        string => "$(shadow_data[$(all_local_users)][0])";
+
+  classes:
+    linux::
+      "$(all_local_users)_password_locked"
+        expression => regcmp( "^!.*", "$(encrypted_password[$(all_local_users)])" ),
+        scope => "namespace",
+        meta => { "report" },
+        comment => "A password field starting with exclimation point is a locked account";
+
+      "$(all_local_users)_password_empty"
+        expression => regcmp( "", "$(encrypted_password[$(all_local_users)])" ),
+        scope => "namespace",
+        meta => { "report" },
+        comment => "An empty password field may allow passwordless login, it
+                    depends on the application reading the shadow file.";
+
+      "$(all_local_users)_password_valid_hash"
+        expression => regcmp( "\Q$\E(1|2a|5|6)\$.*", "$(encrypted_password[$(all_local_users)])" ),
+        scope => "namespace",
+        meta => { "report" },
+        comment => "If the hashed password matches this regex then we think we
+                    have a valid password hash. Note: It may or may not be
+                    valid for the speicifc platform. For example EL5 does not
+                    support sha512 hashed passwords (hashes starting with $6$).";
+
+      "$(all_local_users)_password_invalid_hash"
+        not => "$(all_local_users_canonified_map[$(all_local_users)])_password_valid_hash",
+        scope => "namespace",
+        meta => { "report" },
+        comment => "If the password has is not valid it must be invalid. This
+                    could mean locked, empty or otherwise invalid.";
+
+  reports:
+    inform_mode|verbose_mode::
+      "$(this.bundle): Discovered: '$(all_local_users_str)'";
+      "$(this.bundle): Last Password Change Date: '$(all_local_users)'='$(date_last_password_change[$(all_local_users)])'";
+      "$(this.bundle): Min Password Age: '$(all_local_users)'='$(min_password_age[$(all_local_users)])'";
+      "$(this.bundle): Max Password Age: '$(all_local_users)'='$(max_password_age[$(all_local_users)])'";
+      "$(this.bundle): Password Warning Period: '$(all_local_users)'='$(password_warning_period[$(all_local_users)])'";
+      "$(this.bundle): Password Inactivity Period: '$(all_local_users)'='$(password_inactivity_period[$(all_local_users)])'";
+      "$(this.bundle): Account Expiration Date: '$(all_local_users)'='$(account_expiration_date[$(all_local_users)])'";
+      "$(this.bundle): Numeric User ID: '$(all_local_users)'='$(numeric_user_id[$(all_local_users)])'";
+      "$(this.bundle): Username/Comment: '$(all_local_users)'='$(comment[$(all_local_users)])'";
+      "$(this.bundle): Home Directory: '$(all_local_users)'='$(home_directory[$(all_local_users)])'";
+      "$(this.bundle): Shell: '$(all_local_users)'='$(shell[$(all_local_users)])'";
+
+      "$(this.bundle): '$(all_local_users)' account is locked"
+        ifvarclass => "$(all_local_users_canonified_list)_password_locked";
+
+      "$(this.bundle): '$(all_local_users)' password is empty"
+        ifvarclass => "$(all_local_users_canonified_map[$(all_local_users)])_password_empty";
+
+      "$(this.bundle): '$(all_local_users)' password appears valid"
+        ifvarclass => "$(all_local_users_canonified_map[$(all_local_users)])_password_valid_hash";
+
+      "$(this.bundle): '$(all_local_users)' password appears invalid"
+        ifvarclass => "$(all_local_users_canonified_map[$(all_local_users)])_password_invalid_hash";
+}
+
+bundle agent inventory_local_users
+# @brief Inventory local users on the system
+#
+# This bundle reports back the inventory of local users as discovered in
+# `cfe_autorun_inventory_local_users_discover`.
+# **See Also:**
+# * `inventory_local_users_password_last_change`
+# * `inventory_local_users_locked`
+# * `inventory_local_users_password_empty`
+
+{
+  vars:
+    linux::
+      "local_users"
+        slist => { @(cfe_autorun_inventory_local_users_discover.all_local_users) },
+        meta => {
+                  "inventory",
+                  "attribute_name=Local users",
+                  "derived_from=bundle:cfe_autorun_inventory_local_users_discover",
+                };
+
+  reports:
+    inform_mode|verbose_mode::
+      "$(this.bundle): Adding $(local_users) to Local User Inventory";
+}
+
+bundle agent inventory_local_users_locked
+# @brief Inventory local user accounts that are locked (have ! as the first
+# character of the hashed passwword field)
+#
+# This bundle inventories local user accounts that appear to be locked as
+# discovered in `cfe_autorun_inventory_local_users_discover`. An account is
+# considered locked if the first character of the encrypted password field in
+# $(paths.shadow) is '!'.
+#
+# **See Also:**
+# * `inventory_local_users_password_last_change`
+# * `inventory_local_users`
+# * `inventory_local_users_password_empty`
+{
+  vars:
+    linux::
+      "local_users"
+        slist => { @(cfe_autorun_inventory_local_users_discover.all_local_users) };
+
+      "locked[$(local_users)]"
+        string => "TRUE",
+        ifvarclass => "$(cfe_autorun_inventory_local_users_discover.all_local_users_canonified_map[$(local_users)])_password_locked",
+        comment => "We need to build an intermediary array of the locked users so
+                    that we can report a unified list for inventory";
+
+      "tmp_locked_users"
+        #slist   => sort(getindices("locked"), "lex"),
+        slist   => getindices("locked"),
+        comment => "intermediary list so that we can filter out cf_null";
+
+    have_locked_users::
+      "locked_users"
+         meta    => {
+                     "inventory",
+                     "attribute_name=Local users with locked accounts",
+                     "derived_from=bundle:cfe_autorun_inventory_local_users_discover" },
+         slist => { @(tmp_locked_users) },
+        comment => "Report on the list of locked users so that they show up in
+                    Mission Portal inventory.";
+
+  classes:
+    linux::
+      "have_locked_users" expression => isgreaterthan(length("tmp_locked_users"), 0);
+
+  reports:
+    inform_mode|verbose_mode::
+      "$(this.bundle): '$(locked_users)' account appears locked"
+        ifvarclass => "have_locked_users";
+}
+
+bundle agent inventory_local_users_password_last_change
+# @brief Inventory local user accounts and the days since their last password change
+#
+# This bundle inventories the number of days since a users password has been
+# changed as discovered in `cfe_autorun_inventory_local_users_discover`.
+#
+# **Note:** Local uses without valid password hashes will not be considered.
+#
+# **See Also:**
+# * `inventory_local_users`
+# * `inventory_local_users_locked`
+# * `inventory_local_users_password_empty`
+{
+  vars:
+    linux::
+      "now" int => now();
+      "days_since_epoch" string => eval( "$(now)/24/3600", "math", "infix" );
+
+      "all_local_users" slist => { @(cfe_autorun_inventory_local_users_discover.all_local_users) };
+      "whitelist" slist => { @(inventory_control.inventory_local_users_password_last_change_whitelist) };
+
+      "local_users"
+        slist => intersection( "all_local_users", "whitelist" ),
+        ifvarclass => "!disable_inventory_local_users_whitelist",
+        handle => "cfe_autorun_inventory_local_users_discover_local_users_whitelist",
+        comment => "Only filter the local users to report if the whitelist is requested";
+
+      "local_users"
+        slist => { @(all_local_users) },
+        ifvarclass => "disable_inventory_local_users_whitelist",
+        handle => "cfe_autorun_inventory_local_users_discover_local_users_all",
+        comment => "If inventory of local users is not requested to be filtered
+                    then we will proceed with all";
+
+      "days_since_pw_change[$(local_users)]"
+        string => format("%d", eval( "$(days_since_epoch)-$(cfe_autorun_inventory_local_users_discover.date_last_password_change[$(local_users)])", "math", "infix" ) ),
+        ifvarclass => "$(cfe_autorun_inventory_local_users_discover.all_local_users_canonified_map[$(local_users)])_password_valid_hash",
+        meta => {
+                  "report",
+                  "derived_from=bundle:cfe_autorun_inventory_local_users_discover",
+                 };
+
+    # We guard this so that we do not end up with an entry in the inventory interface that includes cf_null
+    have_password_changes::
+      "pw_change_date[$(local_users)]"
+        #string => format("%d", eval( "$(now) - days_since_pw_change[$(local_users)])", "math", "infix" )),
+        string => "$(cfe_autorun_inventory_local_users_discover.date_last_password_change[$(local_users)])",
+        ifvarclass => "$(cfe_autorun_inventory_local_users_discover.all_local_users_canonified_map[$(local_users)])_password_valid_hash",
+        meta => {
+                  "inventory",
+                  "attribute_name=Date $(local_users) password last changed",
+                  "derived_from=bundle:cfe_autorun_inventory_local_users_discover",
+                 };
+
+  classes:
+   "have_password_changes" expression => isgreaterthan(length("local_users"), 0);
+
+  reports:
+    inform_mode|verbose_mode::
+      "$(this.bundle): Entered";
+      "$(this.bundle): days since $(local_users) password change = $(days_since_pw_change[$(local_users)]"
+        ifvarclass => "$(cfe_autorun_inventory_local_users_discover.all_local_users_canonified_map[$(local_users)])_password_valid_hash";
+      "$(this.bundle): Have password change for $(local_users)";
+      "$(this.bundle): Adding last password change date for '$(local_users)' to inventory since the user has a valid password hash and is not restricted by the whitelist"
+        ifvarclass => "$(cfe_autorun_inventory_local_users_discover.all_local_users_canonified_map[$(local_users)])_password_valid_hash";
+}
+
+bundle agent inventory_local_users_password_empty
+# @brief Inventory local user accounts that that have empty passwords
+#
+# This bundle inventories local user accounts that have empty passwords
+# discovered in `cfe_autorun_inventory_local_users_discover`.
+#
+# **See Also:**
+# * `inventory_local_users_password_last_change`
+# * `inventory_local_users`
+# * `inventory_local_users_locked`
+{
+  vars:
+    linux::
+      "local_users"
+        slist => { @(cfe_autorun_inventory_local_users_discover.all_local_users) };
+
+      "empty[$(local_users)]"
+        string => "TRUE",
+        ifvarclass => "$(cfe_autorun_inventory_local_users_discover.all_local_users_canonified_map[$(local_users)])_password_empty",
+        comment => "We need to build an intermediary array of the empty users so
+                    that we can report a unified list for inventory";
+
+      "tmp_empty_users"
+        #slist   => sort(getindices("locked"), "lex"),
+        slist   => getindices("empty"),
+        comment => "intermediary list so that we can filter out cf_null";
+
+    # We guard this so that we do not end up with an entry in the inventory interface that includes cf_null
+    have_empty_password_users::
+      "empty_users"
+        slist   => getindices("empty"),
+        meta    => {
+                     "inventory",
+                     "attribute_name=Local users with empty passwords",
+                     "derived_from=bundle:cfe_autorun_inventory_local_users_discover" },
+        comment => "Report on the list of users with empty passwords so that they show up in
+                    Mission Portal inventory. Empty passwords may be a security risk";
+
+  classes:
+    linux::
+      "have_empty_password_users" expression => isgreaterthan(length("tmp_empty_users"), 0);
+
+  reports:
+    inform_mode|verbose_mode::
+      "$(this.bundle): '$(empty_users)' password appears empty"
+        ifvarclass => "have_empty_password_users";
+}
 body copy_from inventory_cmdb_copy_from
 # @brief Copy from the CMDB source
 {


### PR DESCRIPTION
The local user inventory module parses and reports local user information as
discovered in /etc/passwd and /etc/shadow. Additional bundles are provided to
augment the Mission Portal Inventory UI with interesting information such as
all local users, users with locked accounts, and users that have emtpy
passwords.

All local user information is collected for reporting. Additionaly inventory
item for users last password change data is availbale, but disabled by default
until we get epoch time formatting in Mission Portal.

Ref: https://dev.cfengine.com/issues/6213