### PR TITLE
Change: Do not define demidecode variables on rhel4

### DIFF
--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -339,12 +339,6 @@ bundle agent cfe_autorun_inventory_dmidecode
     have_dmidecode::
       "decoder" string => "$(inventory_control.dmidecoder)";
 
-    have_dmidecode.(redhat_4|redhat_3)::
-      "dmi[$(dmivars)]" string => "Unsupported",
-      meta => { "inventory", "attribute_name=$(dmidefs[$(dmivars)])" },
-      comment => "Old versions of dmidecode do not provide a reliable way to
-                  extract strings";
-
     have_dmidecode.!(redhat_4|redhat_3)::
       "dmi[$(dmivars)]" string => execresult("$(decoder) -s $(dmivars)",
                                              "useshell"),


### PR DESCRIPTION
Ref: https://dev.cfengine.com/issues/6302#note-8

For consistency in reporting (and a small decrease in storage space required)
it is better to not define inventory variables that are unsupported.
