### PR TITLE
Inventory/windows

### DIFF
--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -334,6 +334,9 @@ bundle agent cfe_autorun_inventory_dmidecode
       "dmi[processor-version]" string => $(processor_array[1]),
       meta => { "inventory", "attribute_name=CPU model" };
 
+      "dmi[system-manufacturer]" string => $(system_array[1]),
+      meta => { "inventory", "attribute_name=System manufacturer" };
+
 
   classes:
       "have_dmidecode" expression => fileexists($(inventory_control.dmidecoder));
@@ -346,6 +349,11 @@ bundle agent cfe_autorun_inventory_dmidecode
        "processor_match" expression => regextract(".*Name\W+(.*)",
                                                   execresult("gwmi -query 'SELECT Name FROM WIN32_PROCESSOR'", "powershell"),
                                                   "processor_array");
+
+       "system_match" expression => regextract(".*Manufacturer\W+(.*)",
+                                               execresult("gwmi -query 'SELECT Manufacturer FROM WIN32_COMPUTERSYSTEM'", "powershell"),
+                                               "system_array");
+
 
   reports:
     inform_mode::


### PR DESCRIPTION
Add the following attributes on Windows:
- BIOS vendor
- BIOS version
- CPU model
- System manufacturer

Depends on gwmi and powershell, which seems to be installed by default on Windows 2008 and 2012.

Please backport to 3.6.x for inclusion in 3.6.1.

Redmine 6378.
