### PR TITLE
Add a perms_dcp() copy_from body

### DIFF
--- a/lib/3.6/files.cf
+++ b/lib/3.6/files.cf
@@ -1348,6 +1348,17 @@ body copy_from perms_cp(from)
       preserve    => "true";
 }
 
+body copy_from perms_dcp(from)
+# @brief Copy a local file if it is different from the existing copy and
+# preserve file permissions on the local copy.
+#
+# @param from The path to the source file.
+{
+      source      => "$(from)";
+      preserve    => "true";
+      compare     => "digest";
+}
+
 body copy_from backup_local_cp(from)
 # @brief Copy a local file and  keep a backup of old versions.
 #

--- a/lib/3.7/files.cf
+++ b/lib/3.7/files.cf
@@ -1348,6 +1348,17 @@ body copy_from perms_cp(from)
       preserve    => "true";
 }
 
+body copy_from perms_dcp(from)
+# @brief Copy a local file if it is different from the existing copy and
+# preserve file permissions on the local copy.
+#
+# @param from The path to the source file.
+{
+      source      => "$(from)";
+      preserve    => "true";
+      compare     => "digest";
+}
+
 body copy_from backup_local_cp(from)
 # @brief Copy a local file and  keep a backup of old versions.
 #


### PR DESCRIPTION
This will add a new copy_from body to copy a local file if it is different from the existing copy and preserve file permissions on the local copy.

This can be used as a potential workaround for the issue that is documented in https://dev.cfengine.com/issues/2256
