### PR TITLE
Escape the dots in def.domain where used in def.acl

### DIFF
--- a/def.cf
+++ b/def.cf
@@ -22,6 +22,8 @@ bundle common def
       handle => "common_def_vars_domain";
 
       # List here the IP masks that we grant access to on the server
+      "escaped_domain" string => escape("$(domain)"),
+      comment => "Escaped version of domain for use in regexes";
 
       "acl"     slist => {
                            # Allow everything in my own domain.
@@ -29,7 +31,7 @@ bundle common def
                            # Note that this:
                            # 1. requires def.domain to be correctly set
                            # 2. will cause a DNS lookup for every access
-                           ".*$(def.domain)",
+                           ".*\.$(escaped_domain)",
 
                            # Assume /16 LAN clients to start with
                            "$(sys.policy_hub)/16",


### PR DESCRIPTION
I saw
`admit_hostnames: .*intra.cfengine.com`
in my hub's report of what it would grant access to.  The dot at the
start is clearly intended as a regex so I must suppose the later dots
are treated as such, too.  So the owner of `YYYintraXcfengine.com` can
get at my hub; this probably isn't prudent.  So escape the dots in the
domain and put an (escaped) dot before it, so that only hosts within
the specified domain are granted access.
