### PR TITLE
classic_services: chkconfig needs to default to baseinit[service]

### DIFF
--- a/lib/3.6/services.cf
+++ b/lib/3.6/services.cf
@@ -603,7 +603,13 @@ bundle agent classic_services(service,state)
   commands:
     using_chkconfig::
       "$(paths.chkconfig) $(service) $(chkconfig_mode)"
-      classes => kept_successful_command;
+      classes    => kept_successful_command,
+      ifvarclass => not(isvariable("baseinit[$(service)]"));
+
+      "$(paths.chkconfig) $(baseinit[$(service)]) $(chkconfig_mode)"
+      classes    => kept_successful_command,
+      ifvarclass => and(isvariable("baseinit[$(service)]"));
+
 
   processes:
 

--- a/lib/3.7/services.cf
+++ b/lib/3.7/services.cf
@@ -603,7 +603,12 @@ bundle agent classic_services(service,state)
   commands:
     using_chkconfig::
       "$(paths.chkconfig) $(service) $(chkconfig_mode)"
-      classes => kept_successful_command;
+      classes    => kept_successful_command,
+      ifvarclass => not(isvariable("baseinit[$(service)]"));
+
+      "$(paths.chkconfig) $(baseinit[$(service)]) $(chkconfig_mode)"
+      classes    => kept_successful_command,
+      ifvarclass => and(isvariable("baseinit[$(service)]"));
 
   processes:
 


### PR DESCRIPTION
```
notice: Q: ".../chkconfig nrpe": nrpe: unknown service
notice: Q: ".../chkconfig ntpd": ntpd: unknown service
```

Fixes a bug where `chkconfig` looks for `$(service)` even if `baseinit[$(service)]` is defined.
