### PR TITLE
Add path to ethtool on debian, redhat, archlinux and suse

### DIFF
--- a/lib/3.5/paths.cf
+++ b/lib/3.5/paths.cf
@@ -103,6 +103,7 @@ bundle common paths
       "path[dmidecode]"         string => "/usr/bin/dmidecode";
       "path[echo]"              string => "/usr/bin/echo";
       "path[egrep]"             string => "/usr/bin/egrep";
+      "path[ethtool]"           string => "/usr/bin/ethtool";
       "path[find]"              string => "/usr/bin/find";
       "path[free]"              string => "/usr/bin/free";
       "path[grep]"              string => "/usr/bin/grep";
@@ -247,6 +248,7 @@ bundle common paths
       "path[domainname]"    string => "/bin/domainname";
       "path[echo]"          string => "/bin/echo";
       "path[egrep]"         string => "/bin/egrep";
+      "path[ethtool]"       string => "/usr/sbin/ethtool";
       "path[find]"          string => "/usr/bin/find";
       "path[grep]"          string => "/bin/grep";
       "path[hostname]"      string => "/bin/hostname";
@@ -334,6 +336,7 @@ bundle common paths
       "path[domainname]"    string => "/bin/domainname";
       "path[echo]"          string => "/bin/echo";
       "path[egrep]"         string => "/bin/egrep";
+      "path[ethtool]"       string => "/sbin/ethtool";
       "path[find]"          string => "/usr/bin/find";
       "path[grep]"          string => "/bin/grep";
       "path[hostname]"      string => "/bin/hostname";
@@ -400,6 +403,7 @@ bundle common paths
       "path[domainname]"    string => "/bin/domainname";
       "path[echo]"          string => "/bin/echo";
       "path[egrep]"         string => "/usr/bin/egrep";
+      "path[ethtool]"       string => "/usr/sbin/ethtool";
       "path[find]"          string => "/usr/bin/find";
       "path[free]"          string => "/usr/bin/free";
       "path[grep]"          string => "/usr/bin/grep";

--- a/lib/3.6/paths.cf
+++ b/lib/3.6/paths.cf
@@ -141,6 +141,7 @@ bundle common paths
       "path[dmidecode]"         string => "/usr/bin/dmidecode";
       "path[echo]"              string => "/usr/bin/echo";
       "path[egrep]"             string => "/usr/bin/egrep";
+      "path[ethtool]"           string => "/usr/bin/ethtool";
       "path[find]"              string => "/usr/bin/find";
       "path[free]"              string => "/usr/bin/free";
       "path[grep]"              string => "/usr/bin/grep";
@@ -266,6 +267,7 @@ bundle common paths
       "path[domainname]"    string => "/bin/domainname";
       "path[echo]"          string => "/bin/echo";
       "path[egrep]"         string => "/bin/egrep";
+      "path[ethtool]"       string => "/usr/sbin/ethtool";
       "path[find]"          string => "/usr/bin/find";
       "path[grep]"          string => "/bin/grep";
       "path[hostname]"      string => "/bin/hostname";
@@ -353,6 +355,7 @@ bundle common paths
       "path[domainname]"    string => "/bin/domainname";
       "path[echo]"          string => "/bin/echo";
       "path[egrep]"         string => "/bin/egrep";
+      "path[ethtool]"       string => "/sbin/ethtool";
       "path[find]"          string => "/usr/bin/find";
       "path[grep]"          string => "/bin/grep";
       "path[hostname]"      string => "/bin/hostname";
@@ -419,6 +422,7 @@ bundle common paths
       "path[domainname]"    string => "/bin/domainname";
       "path[echo]"          string => "/bin/echo";
       "path[egrep]"         string => "/usr/bin/egrep";
+      "path[ethtool]"       string => "/usr/sbin/ethtool";
       "path[find]"          string => "/usr/bin/find";
       "path[free]"          string => "/usr/bin/free";
       "path[grep]"          string => "/usr/bin/grep";

--- a/lib/3.7/paths.cf
+++ b/lib/3.7/paths.cf
@@ -141,6 +141,7 @@ bundle common paths
       "path[dmidecode]"         string => "/usr/bin/dmidecode";
       "path[echo]"              string => "/usr/bin/echo";
       "path[egrep]"             string => "/usr/bin/egrep";
+      "path[ethtool]"           string => "/usr/bin/ethtool";
       "path[find]"              string => "/usr/bin/find";
       "path[free]"              string => "/usr/bin/free";
       "path[grep]"              string => "/usr/bin/grep";
@@ -266,6 +267,7 @@ bundle common paths
       "path[domainname]"    string => "/bin/domainname";
       "path[echo]"          string => "/bin/echo";
       "path[egrep]"         string => "/bin/egrep";
+      "path[ethtool]"       string => "/usr/sbin/ethtool";
       "path[find]"          string => "/usr/bin/find";
       "path[grep]"          string => "/bin/grep";
       "path[hostname]"      string => "/bin/hostname";
@@ -353,6 +355,7 @@ bundle common paths
       "path[domainname]"    string => "/bin/domainname";
       "path[echo]"          string => "/bin/echo";
       "path[egrep]"         string => "/bin/egrep";
+      "path[ethtool]"       string => "/sbin/ethtool";
       "path[find]"          string => "/usr/bin/find";
       "path[grep]"          string => "/bin/grep";
       "path[hostname]"      string => "/bin/hostname";
@@ -419,6 +422,7 @@ bundle common paths
       "path[domainname]"    string => "/bin/domainname";
       "path[echo]"          string => "/bin/echo";
       "path[egrep]"         string => "/usr/bin/egrep";
+      "path[ethtool]"       string => "/usr/sbin/ethtool";
       "path[find]"          string => "/usr/bin/find";
       "path[free]"          string => "/usr/bin/free";
       "path[grep]"          string => "/usr/bin/grep";


### PR DESCRIPTION
I need to use ethtool on debian and centos to determine if an interface supports hardware timestamping. Since the path to this binary differs on each distribution of linux I added it to $(paths.path)
