### PR TITLE
don't include monitoring by default in reporting

### DIFF
--- a/lib/3.6/reports.cf
+++ b/lib/3.6/reports.cf
@@ -56,9 +56,7 @@ body report_data_select default_data_select_host
 {
       metatags_include => { "inventory", "report" };
       metatags_exclude => { "noreport" };
-      monitoring_include => { "cpu",
-                              "loadavg",
-                              "diskfree" };
+      monitoring_include => { "" };
 }
 
 body report_data_select default_data_select_policy_hub


### PR DESCRIPTION
(cherry picked from commit 2505e794751ca9086e81336bb6cb9357a2227da4)

Conflicts:
    lib/3.7/reports.cf
