### PR TITLE
Truncate over-long strings of 9s.

### DIFF
--- a/lib/3.6/packages.cf
+++ b/lib/3.6/packages.cf
@@ -1832,19 +1832,19 @@ bundle agent package_latest(package)
     debian::
       "$(package)"
       package_policy => "addupdate",
-      package_version => "9999999999",
+      package_version => "999999999",
       package_method => apt_get_permissive;
 
     redhat::
       "$(package)"
       package_policy => "addupdate",
-      package_version => "9999999999",
+      package_version => "999999999",
       package_method => yum_rpm_permissive;
 
     suse::
       "$(package)"
       package_policy => "addupdate",
-      package_version => "9999999999",
+      package_version => "999999999",
       package_method => zypper;
 
     !debian.!redhat.!suse::

--- a/lib/3.7/packages.cf
+++ b/lib/3.7/packages.cf
@@ -1832,19 +1832,19 @@ bundle agent package_latest(package)
     debian::
       "$(package)"
       package_policy => "addupdate",
-      package_version => "9999999999",
+      package_version => "999999999",
       package_method => apt_get_permissive;
 
     redhat::
       "$(package)"
       package_policy => "addupdate",
-      package_version => "9999999999",
+      package_version => "999999999",
       package_method => yum_rpm_permissive;
 
     suse::
       "$(package)"
       package_policy => "addupdate",
-      package_version => "9999999999",
+      package_version => "999999999",
       package_method => zypper;
 
     !debian.!redhat.!suse::

--- a/update/update_processes.cf
+++ b/update/update_processes.cf
@@ -379,5 +379,5 @@ body classes u_always_forever(theclass)
       repair_failed => { $(theclass) };
       repair_denied => { $(theclass) };
       repair_timeout => { $(theclass) };
-      persist_time => 99999999999;
+      persist_time => 999999999;
 }


### PR DESCRIPTION
We use long strings of 9s as bounding values for integers.  On 32-bit
values, if those long strings exceed 999999999 the resulting int wraps
and is smaller, so don't use more than nine 9s in a row.
