### PR TITLE
Change: Guard acl from being evaluated on windows

### DIFF
--- a/controls/cf_serverd.cf
+++ b/controls/cf_serverd.cf
@@ -92,6 +92,7 @@ bundle server access_rules()
       comment => "Grant access to plugins directory",
       admit => { @(def.acl) };
 
+    !windows::
       "$(def.cf_runagent_shell)"
       handle => "server_access_grant_access_shell_cmd",
       comment => "Grant access to shell for cfruncommand",


### PR DESCRIPTION
def.cf_runagent_shell is not used on windows, and having the acl in place
produces unwanted event log entries.

Ref: https://dev.cfengine.com/issues/6555
