### PR TITLE
Fix path to npm, pip and getfacl

### DIFF
--- a/lib/3.5/paths.cf
+++ b/lib/3.5/paths.cf
@@ -59,9 +59,11 @@ bundle common paths
       #
 
     !(freebsd|darwin|smartos)::
-      "path[getfacl]"  string => "/usr/bin/getfacl";
       "path[npm]"      string => "/usr/bin/npm";
       "path[pip]"      string => "/usr/bin/pip";
+
+    !(freebsd|darwin)::
+      "path[getfacl]"  string => "/usr/bin/getfacl";
 
     freebsd|darwin::
       "path[npm]"      string => "/usr/local/bin/npm";

--- a/lib/3.6/paths.cf
+++ b/lib/3.6/paths.cf
@@ -83,9 +83,11 @@ bundle common paths
       "path[git]"      string => "/usr/bin/git";
 
     !(freebsd|darwin|smartos)::
-      "path[getfacl]"  string => "/usr/bin/getfacl";
       "path[npm]"      string => "/usr/bin/npm";
       "path[pip]"      string => "/usr/bin/pip";
+
+    !(freebsd|darwin)::
+      "path[getfacl]"  string => "/usr/bin/getfacl";
 
     freebsd|darwin::
       "path[npm]"      string => "/usr/local/bin/npm";

--- a/lib/3.7/paths.cf
+++ b/lib/3.7/paths.cf
@@ -83,9 +83,11 @@ bundle common paths
       "path[git]"      string => "/usr/bin/git";
 
     !(freebsd|darwin|smartos)::
-      "path[getfacl]"  string => "/usr/bin/getfacl";
       "path[npm]"      string => "/usr/bin/npm";
       "path[pip]"      string => "/usr/bin/pip";
+
+    !(freebsd|darwin)::
+      "path[getfacl]"  string => "/usr/bin/getfacl";
 
     freebsd|darwin::
       "path[npm]"      string => "/usr/local/bin/npm";


### PR DESCRIPTION
Set $(paths.path[npm]) and $(paths.path[pip]) to the correct path on darwin and freebsd
Set $(paths.path[getfacl]) to the correct path on freebsd
