### PR TITLE
Add synchronization of configuration for HA hubs.

### DIFF
--- a/cfe_internal/ha/ha.cf
+++ b/cfe_internal/ha/ha.cf
@@ -48,14 +48,20 @@ bundle agent ha_hub_sync_config_data
 {
  files:
   "$(sys.workdir)/httpd/htdocs/application/config/cf_robot.php"
-     copy_from => u_rcp("$(sys.workdir)/httpd/htdocs/application/config/cf_robot.php", $(sys.hub_active_ip)),
-     comment => "",
+     copy_from => no_backup_scp("$(sys.workdir)/httpd/htdocs/application/config/cf_robot.php", $(sys.hub_active_ip)),
+     comment => "Synchronize cf_robot configuration",
      handle => "ha_sync_robot_config";
 
- "$(sys.workdir)/share/GUI/application/config/appsettings.php"
-     copy_from => u_rcp("$(sys.workdir)/share/GUI/application/config/appsettings.php", $(sys.hub_active_ip)),
-     comment => "",
+  "$(sys.workdir)/share/GUI/application/config/appsettings.php"
+     copy_from => no_backup_scp("$(sys.workdir)/share/GUI/application/config/appsettings.php", $(sys.hub_active_ip)),
+     comment => "Synchronize appsetings configuration",
      handle => "ha_sync_appsettings_config";
+
+  "/opt/cfengine/notification_scripts"
+      copy_from => no_backup_scp("/opt/cfengine/notification_scripts", $(sys.hub_active_ip)),
+      comment => "Copy MP notification scripts",
+      handle => "ha_copy_notification_scripts",
+      depth_search => recurse("1");
 }
 
 bundle agent ha_hub_copy_hubs_keys

--- a/controls/cf_serverd.cf
+++ b/controls/cf_serverd.cf
@@ -103,6 +103,27 @@ bundle server access_rules()
       comment => "Grant access to ppkeys for HA hubs",
       admit => { @(def.policy_servers) };
 
+      # Allow slave hub to synchronize cf_robot and appsettings content.
+      # Files are containing configuration that must be the same on all hubs.
+      "$(sys.workdir)/httpd/htdocs/application/config/cf_robot.php"
+      handle => "server_access_grant_access_cf_robot",
+      comment => "Grant access to cf_robot file for HA hubs",
+      admit => { @(def.policy_servers) };
+
+      "$(sys.workdir)/share/GUI/application/config/appsettings.php"
+      handle => "server_access_grant_access_appsettings",
+      comment => "Grant access to appsettings for HA hubs",
+      admit => { @(def.policy_servers) };
+      
+      # Allow access to notification_scripts directory so passive hub
+      # will be able to synchronize its content. Once passive hub will
+      # be promoted to act as a master all the custom scripts will be
+      # accessible.
+      "/opt/cfengine/notification_scripts"
+      handle => "server_access_grant_access_notification scripts",
+      comment => "Grant access tonotification scripts",
+      admit => { @(def.policy_servers) };
+
       # When HA is enabled clients are updating active hub IP address
       # using data stored in master_hub.dat file.
       "$(sys.workdir)/state/master_hub.dat"


### PR DESCRIPTION
Synchronize notification_scripts directory to copy notifications scripts
form active to passive hubs.
DON'T use u_rcp for copying files from one hub to another.
Allow access to needed configuration files for all hubs in HA installation.
