### PR TITLE
Add path to dscl for Darwin

### DIFF
--- a/lib/3.5/paths.cf
+++ b/lib/3.5/paths.cf
@@ -296,6 +296,7 @@ bundle common paths
       "path[diff]"          string => "/usr/bin/diff";
       "path[dig]"           string => "/usr/bin/dig";
       "path[domainname]"    string => "/bin/domainname";
+      "path[dscl]"          string => "/usr/bin/dscl";
       "path[echo]"          string => "/bin/echo";
       "path[egrep]"         string => "/usr/bin/egrep";
       "path[find]"          string => "/usr/bin/find";

--- a/lib/3.6/paths.cf
+++ b/lib/3.6/paths.cf
@@ -315,6 +315,7 @@ bundle common paths
       "path[diff]"          string => "/usr/bin/diff";
       "path[dig]"           string => "/usr/bin/dig";
       "path[domainname]"    string => "/bin/domainname";
+      "path[dscl]"          string => "/usr/bin/dscl";
       "path[echo]"          string => "/bin/echo";
       "path[egrep]"         string => "/usr/bin/egrep";
       "path[find]"          string => "/usr/bin/find";

--- a/lib/3.7/paths.cf
+++ b/lib/3.7/paths.cf
@@ -315,6 +315,7 @@ bundle common paths
       "path[diff]"          string => "/usr/bin/diff";
       "path[dig]"           string => "/usr/bin/dig";
       "path[domainname]"    string => "/bin/domainname";
+      "path[dscl]"          string => "/usr/bin/dscl";
       "path[echo]"          string => "/bin/echo";
       "path[egrep]"         string => "/usr/bin/egrep";
       "path[find]"          string => "/usr/bin/find";


### PR DESCRIPTION
dscl is a command line utility to interact with directory service nodes on mac os x. When running cfengine on mac os x, it would be helpful to be able to reference this command to do things like change user shells or edit various keys.

Since this command only exists in mac os x, I was debating if its worth adding to the stdlib, but if the path ever changes in alter versions of mac os x, it will be nice to only have to change it in one place.
