### PR TITLE
services: promises should be repaired when they make changes

### DIFF
--- a/lib/3.6/services.cf
+++ b/lib/3.6/services.cf
@@ -192,7 +192,6 @@ bundle agent standard_services(service,state)
 
     chkconfig.have_init.((start.!running)|(stop.running)).non_disabling::
       "$(init) $(state)"
-      classes => kept_successful_command,
       contain => silent;
 
     sysvservice.non_disabling::

--- a/lib/3.7/services.cf
+++ b/lib/3.7/services.cf
@@ -192,7 +192,6 @@ bundle agent standard_services(service,state)
 
     chkconfig.have_init.((start.!running)|(stop.running)).non_disabling::
       "$(init) $(state)"
-      classes => kept_successful_command,
       contain => silent;
 
     sysvservice.non_disabling::


### PR DESCRIPTION
 This fixes init.d services.
We might have tests assuming they are always kept, which they should not be.

See Redmine #5625.
