### PR TITLE
    Adjust Diagnostics table name in hub maintenance policy to changes i...

### DIFF
--- a/lib/3.6/cfe_internal.cf
+++ b/lib/3.6/cfe_internal.cf
@@ -127,7 +127,7 @@ bundle agent cfe_internal_hub_maintain
                                                      },
                                                      {
                                                          "report": "diagnostics",
-                                                         "table": "__Diagnostics",
+                                                         "table": "Diagnostics",
                                                          "history_length_days": 1,
                                                          "time_key": "TimeStamp"
                                                      }


### PR DESCRIPTION
...n 3.6.2.

```
'__Diagnostics' --> 'Diagnostics'

Redmine: #6609
```
