### PR TITLE
Change: Fix default mailfrom

### DIFF
--- a/controls/cf_execd.cf
+++ b/controls/cf_execd.cf
@@ -16,7 +16,7 @@ body executor control
 
     cfengine_internal_agent_email::
       mailto     => "root@$(def.domain)";
-      mailfrom   => "root@$(sys.host).$(def.domain)";
+      mailfrom   => "root@$(sys.uqhost).$(def.domain)";
       smtpserver => "localhost";
 
     any::


### PR DESCRIPTION
Cherry pick from master

Ref: https://dev.cfengine.com/issues/6567

$(sys.host) is ambiguous and the old usage may produce a mailfrom of 
root@foo.example.org.example.org for host "foo" in domain "example.org".
