### PR TITLE
Add: Policy to ensure there is recoverable space for PG repairs

### DIFF
--- a/cfe_internal/CFE_cfengine.cf
+++ b/cfe_internal/CFE_cfengine.cf
@@ -7,6 +7,27 @@
 # and/or recommendation is needed.
 #
 ##################################################################
+
+bundle common cfe_internal_file_control
+# @brief Specify additional files needed for CFEngine self management
+{
+  meta:
+      "description"
+        string => "Specify additional files needed for CFEngine self management";
+
+  vars:
+      "inputs"
+        slist => {
+                   "$(this.promise_dirname)/postgres/pg_data_space_buffer.cf",
+                 };
+}
+
+body file control
+# @brief Include additional files needed for CFEngine self management
+{
+  inputs => { @(cfe_internal_file_control.inputs) };
+}
+
 ##################################################################
 #
 # cfe_internal_management
@@ -50,6 +71,11 @@ bundle agent cfe_internal_management
       "hub" usebundle => cfe_internal_php_runalerts,
       handle => "cfe_internal_management_php_runalerts",
       comment => "To run PHP runalerts to check bundle status on SQL and Sketch";
+
+      "hub" usebundle => cfe_internal:pg_data_space_buffer,
+      handle => "cfe_internal_pg_data_space_buffer",
+      comment => "Ensure there is some reserved space in case of full disk and
+                 database repair is required";
 
     # As passive hub is supposed to run read-only PostgreSQL instance 
     # doing maintenance makes no sense and is not possible at all.

--- a/cfe_internal/postgres/pg_data_space_buffer.cf
+++ b/cfe_internal/postgres/pg_data_space_buffer.cf
@@ -1,0 +1,33 @@
+body file control
+{
+  namespace => "cfe_internal";
+}
+
+bundle agent pg_data_space_buffer
+{
+  meta:
+    "description"
+      string => "In case of full disk and database corruption we want to be
+                 sure that we have some available space to perform emergency
+                 database maintainance. This policy ensures that some files
+                 that are OK to delete are present.";
+
+    "ref"
+      slist => { "zendesk#1519", "redmine#6665" };
+
+  vars:
+    "pg_data_dir" string => "$(sys.workdir)/state/pg/data";
+    "buffer_files" slist => { "ok_to_delete_0", "ok_to_delete_1", "ok_to_delete_3" };
+    "buffer_file_sizeM" string => "100";
+    "dd" string => "$(default:paths.dd)";
+
+  classes:
+    "buffer_$(buffer_files)_exists"
+      expression => fileexists("$(pg_data_dir)/$(buffer_files)");
+
+  commands:
+    "$(dd)"
+      args => "if=/dev/zero of=$(pg_data_dir)/$(buffer_files) bs=1M count=$(buffer_file_sizeM)",
+      comment => "$($(this.bundle)_meta.description)",
+      ifvarclass => not("buffer_$(buffer_files)_exists");
+}

--- a/lib/3.6/paths.cf
+++ b/lib/3.6/paths.cf
@@ -100,6 +100,7 @@ bundle common paths
     linux::
       "path[lsattr]"        string => "/usr/bin/lsattr";
       "path[tar]"           string => "/bin/tar";
+      "path[dd]"           string => "/bin/dd";
 
     aix::
 

--- a/lib/3.7/paths.cf
+++ b/lib/3.7/paths.cf
@@ -100,6 +100,7 @@ bundle common paths
     linux::
       "path[lsattr]"        string => "/usr/bin/lsattr";
       "path[tar]"           string => "/bin/tar";
+      "path[dd]"           string => "/bin/dd";
 
     aix::
 


### PR DESCRIPTION
Ref: https://dev.cfengine.com/issues/6665

Note: This policy uses namespace. namespace was available in 3.5, but this is
the first time namespace has been introduced to the masterfiles policy
framework. It would cause issues for clients older than 3.5. I do not have to
use namespace, so let me know if you think I should change it.
