### PR TITLE
Change: Make paths bundle dynamic

### DIFF
--- a/lib/3.6/paths.cf
+++ b/lib/3.6/paths.cf
@@ -47,7 +47,7 @@
 # purchasing a commercial version of the software.#
 ###################################################
 
-bundle common paths
+bundle agent paths
 # @brief Defines an array `path` with common paths to standard binaries,
 # and classes for defined and existing paths.
 #
@@ -69,424 +69,69 @@ bundle common paths
 # ```
 {
   vars:
+      "PATH"
+        slist => {
+                    "/var/cfengine/bin",
+                    "/usr/local/sbin",
+                    "/usr/local/bin",
+                    "/usr/sbin",
+                    "/usr/bin",
+                    "/sbin",
+                    "/bin",
+                  };
 
-      #
-      # Common full pathname of commands for OS
-      #
+      "REV_PATH"
+        slist => reverse("PATH"),
+        comment => "We reverse the path so that the first listed path is what wins";
 
-    enterprise.(am_policy_hub|policy_server)::
-      "path[git]"
-        string => "$(sys.workdir)/bin/git",
-        comment => "CFEngine Enterprise Hub ships with its own git which is used internally";
+      "SEARCH_PATH" string => join(" ", "REV_PATH");
 
-    !(enterprise.(am_policy_hub|policy_server))::
-      "path[git]"      string => "/usr/bin/git";
+      "paths" slist => getindices("paths.path");
+      "c_paths_map[$(paths)]" string => canonify("$(paths)");
 
-    any::
-      "path[getfacl]"  string => "/usr/bin/getfacl";
-      "path[npm]"      string => "/usr/bin/npm";
-      "path[pip]"      string => "/usr/bin/pip";
-
-    _have_bin_env::
-      "path[env]"      string => "/bin/env";
-    !_have_bin_env::
-      "path[env]"      string => "/usr/bin/env";
-
-    _have_bin_systemctl::
-      "path[systemctl]"      string => "/bin/systemctl";
-    !_have_bin_systemctl::
-      "path[systemctl]"      string => "/usr/bin/systemctl";
-
-    linux::
-      "path[lsattr]"        string => "/usr/bin/lsattr";
-      "path[tar]"           string => "/bin/tar";
-
-    aix::
-
-      "path[awk]"      string => "/usr/bin/awk";
-      "path[bc]"       string => "/usr/bin/bc";
-      "path[cat]"      string => "/bin/cat";
-      "path[cksum]"    string => "/usr/bin/cksum";
-      "path[crontabs]" string => "/var/spool/cron/crontabs";
-      "path[cut]"      string => "/usr/bin/cut";
-      "path[dc]"       string => "/usr/bin/dc";
-      "path[df]"       string => "/usr/bin/df";
-      "path[diff]"     string => "/usr/bin/diff";
-      "path[dig]"      string => "/usr/bin/dig";
-      "path[echo]"     string => "/usr/bin/echo";
-      "path[egrep]"    string => "/usr/bin/egrep";
-      "path[find]"     string => "/usr/bin/find";
-      "path[grep]"     string => "/usr/bin/grep";
-      "path[ls]"       string => "/usr/bin/ls";
-      "path[netstat]"  string => "/usr/bin/netstat";
-      "path[ping]"     string => "/usr/bin/ping";
-      "path[perl]"     string => "/usr/bin/perl";
-      "path[printf]"   string => "/usr/bin/printf";
-      "path[sed]"      string => "/usr/bin/sed";
-      "path[sort]"     string => "/usr/bin/sort";
-      "path[tr]"       string => "/usr/bin/tr";
-
-    archlinux::
-
-      "path[awk]"               string => "/usr/bin/awk";
-      "path[bc]"                string => "/usr/bin/bc";
-      "path[cat]"               string => "/usr/bin/cat";
-      "path[cksum]"             string => "/usr/bin/cksum";
-      "path[crontab]"           string => "/usr/bin/crontab";
-      "path[cut]"               string => "/usr/bin/cut";
-      "path[dc]"                string => "/usr/bin/dc";
-      "path[df]"                string => "/usr/bin/df";
-      "path[diff]"              string => "/usr/bin/diff";
-      "path[dig]"               string => "/usr/bin/dig";
-      "path[dmidecode]"         string => "/usr/bin/dmidecode";
-      "path[echo]"              string => "/usr/bin/echo";
-      "path[egrep]"             string => "/usr/bin/egrep";
-      "path[ethtool]"           string => "/usr/bin/ethtool";
-      "path[find]"              string => "/usr/bin/find";
-      "path[free]"              string => "/usr/bin/free";
-      "path[grep]"              string => "/usr/bin/grep";
-      "path[hostname]"          string => "/usr/bin/hostname";
-      "path[init]"              string => "/usr/bin/init";
-      "path[iptables]"          string => "/usr/bin/iptables";
-      "path[iptables_save]"     string => "/usr/bin/iptables-save";
-      "path[iptables_restore]"  string => "/usr/bin/iptables-restore";
-      "path[ls]"                string => "/usr/bin/ls";
-      "path[lsof]"              string => "/usr/bin/lsof";
-      "path[netstat]"           string => "/usr/bin/netstat";
-      "path[ping]"              string => "/usr/bin/ping";
-      "path[perl]"              string => "/usr/bin/perl";
-      "path[printf]"            string => "/usr/bin/printf";
-      "path[sed]"               string => "/usr/bin/sed";
-      "path[sort]"              string => "/usr/bin/sort";
-      "path[test]"              string => "/usr/bin/test";
-      "path[top]"               string => "/usr/bin/top";
-      "path[tr]"                string => "/usr/bin/tr";
-      #
-      "path[pacman]"            string => "/usr/bin/pacman";
-      "path[yaourt]"            string => "/usr/bin/yaourt";
-      "path[useradd]"           string => "/usr/bin/useradd";
-      "path[groupadd]"          string => "/usr/bin/groupadd";
-      "path[ip]"                string => "/usr/bin/ip";
-      "path[ifconfig]"          string => "/usr/bin/ifconfig";
-      "path[journalctl]"        string => "/usr/bin/journalctl";
-      "path[netctl]"            string => "/usr/bin/netctl";
-
-    freebsd|netbsd|openbsd::
-
-      "path[awk]"      string => "/usr/bin/awk";
-      "path[bc]"       string => "/usr/bin/bc";
-      "path[cat]"      string => "/bin/cat";
-      "path[crontabs]" string => "/var/cron/tabs";
-      "path[cut]"      string => "/usr/bin/cut";
-      "path[dc]"       string => "/usr/bin/dc";
-      "path[df]"       string => "/bin/df";
-      "path[diff]"     string => "/usr/bin/diff";
-      "path[dig]"      string => "/usr/bin/dig";
-      "path[echo]"     string => "/bin/echo";
-      "path[egrep]"    string => "/usr/bin/egrep";
-      "path[find]"     string => "/usr/bin/find";
-      "path[grep]"     string => "/usr/bin/grep";
-      "path[ls]"       string => "/bin/ls";
-      "path[netstat]"  string => "/usr/bin/netstat";
-      "path[ping]"     string => "/usr/bin/ping";
-      "path[perl]"     string => "/usr/bin/perl";
-      "path[printf]"   string => "/usr/bin/printf";
-      "path[sed]"      string => "/usr/bin/sed";
-      "path[sort]"     string => "/usr/bin/sort";
-      "path[tr]"       string => "/usr/bin/tr";
-
-    freebsd|netbsd::
-
-      "path[cksum]"    string => "/usr/bin/cksum";
-      "path[realpath]" string => "/bin/realpath";
-
-    openbsd::
-
-      "path[cksum]"    string => "/bin/cksum";
-
-    smartos::
-      "path[npm]"      string => "/opt/local/bin/npm";
-      "path[pip]"      string => "/opt/local/bin/pip";
-
-    solaris::
-
-      "path[awk]"      string => "/usr/bin/awk";
-      "path[bc]"       string => "/usr/bin/bc";
-      "path[cat]"      string => "/usr/bin/cat";
-      "path[cksum]"    string => "/usr/bin/cksum";
-      "path[crontab]"  string => "/usr/bin/crontab";
-      "path[crontabs]" string => "/var/spool/cron/crontabs";
-      "path[curl]"     string => "/usr/bin/curl";
-      "path[cut]"      string => "/usr/bin/cut";
-      "path[dc]"       string => "/usr/bin/dc";
-      "path[df]"       string => "/usr/bin/df";
-      "path[diff]"     string => "/usr/bin/diff";
-      "path[dig]"      string => "/usr/sbin/dig";
-      "path[echo]"     string => "/usr/bin/echo";
-      "path[egrep]"    string => "/usr/bin/egrep";
-      "path[find]"     string => "/usr/bin/find";
-      "path[grep]"     string => "/usr/bin/grep";
-      "path[ls]"       string => "/usr/bin/ls";
-      "path[netstat]"  string => "/usr/bin/netstat";
-      "path[ping]"     string => "/usr/bin/ping";
-      "path[perl]"     string => "/usr/bin/perl";
-      "path[printf]"   string => "/usr/bin/printf";
-      "path[sed]"      string => "/usr/bin/sed";
-      "path[sort]"     string => "/usr/bin/sort";
-      "path[tr]"       string => "/usr/bin/tr";
-      "path[wget]"     string => "/usr/bin/wget";
-      #
-      "path[svcs]"     string => "/usr/bin/svcs";
-      "path[svcadm]"   string => "/usr/sbin/svcadm";
-      "path[svccfg]"   string => "/usr/sbin/svccfg";
-      "path[netadm]"   string => "/usr/sbin/netadm";
-      "path[dladm]"    string => "/usr/sbin/dladm";
-      "path[ipadm]"    string => "/usr/sbin/ipadm";
-      "path[pkg]"      string => "/usr/bin/pkg";
-      "path[pkginfo]"  string => "/usr/bin/pkginfo";
-      "path[pkgadd]"   string => "/usr/sbin/pkgadd";
-      "path[pkgrm]"    string => "/usr/sbin/pkgrm";
-      "path[zoneadm]"  string => "/usr/sbin/zoneadm";
-      "path[zonecfg]"  string => "/usr/sbin/zonecfg";
-
-    redhat::
-
-      "path[awk]"           string => "/bin/awk";
-      "path[bc]"            string => "/usr/bin/bc";
-      "path[cat]"           string => "/bin/cat";
-      "path[cksum]"         string => "/usr/bin/cksum";
-      "path[createrepo]"    string => "/usr/bin/createrepo";
-      "path[crontab]"       string => "/usr/bin/crontab";
-      "path[crontabs]"      string => "/var/spool/cron";
-      "path[curl]"          string => "/usr/bin/curl";
-      "path[cut]"           string => "/bin/cut";
-      "path[dc]"            string => "/usr/bin/dc";
-      "path[df]"            string => "/bin/df";
-      "path[diff]"          string => "/usr/bin/diff";
-      "path[dig]"           string => "/usr/bin/dig";
-      "path[domainname]"    string => "/bin/domainname";
-      "path[echo]"          string => "/bin/echo";
-      "path[egrep]"         string => "/bin/egrep";
-      "path[ethtool]"       string => "/usr/sbin/ethtool";
-      "path[find]"          string => "/usr/bin/find";
-      "path[free]"          string => "/usr/bin/free";
-      "path[grep]"          string => "/bin/grep";
-      "path[hostname]"      string => "/bin/hostname";
-      "path[init]"          string => "/sbin/init";
-      "path[iptables]"      string => "/sbin/iptables";
-      "path[iptables_save]" string => "/sbin/iptables-save";
-      "path[ls]"            string => "/bin/ls";
-      "path[lsof]"          string => "/usr/sbin/lsof";
-      "path[netstat]"       string => "/bin/netstat";
-      "path[nologin]"       string => "/sbin/nologin";
-      "path[ping]"          string => "/usr/bin/ping";
-      "path[perl]"          string => "/usr/bin/perl";
-      "path[printf]"        string => "/usr/bin/printf";
-      "path[sed]"           string => "/bin/sed";
-      "path[sort]"          string => "/bin/sort";
-      "path[test]"          string => "/usr/bin/test";
-      "path[tr]"            string => "/usr/bin/tr";
-      "path[wget]"          string => "/usr/bin/wget";
-      "path[realpath]"      string => "/usr/bin/realpath";
-
-      #
-      "path[chkconfig]" string => "/sbin/chkconfig";
-      "path[groupadd]"  string => "/usr/sbin/groupadd";
-      "path[groupdel]"  string => "/usr/sbin/groupdel";
-      "path[ifconfig]"  string => "/sbin/ifconfig";
-      "path[ip]"        string => "/sbin/ip";
-      "path[rpm]"       string => "/bin/rpm";
-      "path[service]"   string => "/sbin/service";
-      "path[svc]"       string => "/sbin/service";
-      "path[useradd]"   string => "/usr/sbin/useradd";
-      "path[userdel]"   string => "/usr/sbin/userdel";
-      "path[yum]"       string => "/usr/bin/yum";
-
-    darwin::
-      "path[awk]"           string => "/usr/bin/awk";
-      "path[bc]"            string => "/usr/bin/bc";
-      "path[cat]"           string => "/bin/cat";
-      "path[cksum]"         string => "/usr/bin/cksum";
-      "path[createrepo]"    string => "/usr/bin/createrepo";
-      "path[crontab]"       string => "/usr/bin/crontab";
-      "path[crontabs]"      string => "/usr/lib/cron/tabs";
-      "path[cut]"           string => "/usr/bin/cut";
-      "path[dc]"            string => "/usr/bin/dc";
-      "path[df]"            string => "/bin/df";
-      "path[diff]"          string => "/usr/bin/diff";
-      "path[dig]"           string => "/usr/bin/dig";
-      "path[domainname]"    string => "/bin/domainname";
-      "path[dscl]"          string => "/usr/bin/dscl";
-      "path[echo]"          string => "/bin/echo";
-      "path[egrep]"         string => "/usr/bin/egrep";
-      "path[find]"          string => "/usr/bin/find";
-      "path[grep]"          string => "/usr/bin/grep";
-      "path[hostname]"      string => "/bin/hostname";
-      "path[ls]"            string => "/bin/ls";
-      "path[lsof]"          string => "/usr/sbin/lsof";
-      "path[netstat]"       string => "/usr/sbin/netstat";
-      "path[ping]"          string => "/sbin/ping";
-      "path[perl]"          string => "/usr/bin/perl";
-      "path[printf]"        string => "/usr/bin/printf";
-      "path[sed]"           string => "/usr/bin/sed";
-      "path[sort]"          string => "/usr/bin/sort";
-      "path[test]"          string => "/bin/test";
-      "path[tr]"            string => "/usr/bin/tr";
-
-      #
-      "path[brew]"           string => "/usr/local/bin/brew";
-      "path[sudo]"           string => "/usr/bin/sudo";
-
-    debian::
-
-      "path[awk]"           string => "/usr/bin/awk";
-      "path[bc]"            string => "/usr/bin/bc";
-      "path[cat]"           string => "/bin/cat";
-      "path[chkconfig]"     string => "/sbin/chkconfig";
-      "path[cksum]"         string => "/usr/bin/cksum";
-      "path[createrepo]"    string => "/usr/bin/createrepo";
-      "path[crontab]"       string => "/usr/bin/crontab";
-      "path[crontabs]"      string => "/var/spool/cron/crontabs";
-      "path[curl]"          string => "/usr/bin/curl";
-      "path[cut]"           string => "/usr/bin/cut";
-      "path[dc]"            string => "/usr/bin/dc";
-      "path[df]"            string => "/bin/df";
-      "path[diff]"          string => "/usr/bin/diff";
-      "path[dig]"           string => "/usr/bin/dig";
-      "path[dmidecode]"     string => "/usr/sbin/dmidecode";
-      "path[domainname]"    string => "/bin/domainname";
-      "path[echo]"          string => "/bin/echo";
-      "path[egrep]"         string => "/bin/egrep";
-      "path[ethtool]"       string => "/sbin/ethtool";
-      "path[find]"          string => "/usr/bin/find";
-      "path[free]"          string => "/usr/bin/free";
-      "path[grep]"          string => "/bin/grep";
-      "path[hostname]"      string => "/bin/hostname";
-      "path[init]"          string => "/sbin/init";
-      "path[iptables]"      string => "/sbin/iptables";
-      "path[iptables_save]" string => "/sbin/iptables-save";
-      "path[ls]"            string => "/bin/ls";
-      "path[lsof]"          string => "/usr/bin/lsof";
-      "path[netstat]"       string => "/bin/netstat";
-      "path[nologin]"       string => "/usr/sbin/nologin";
-      "path[ping]"          string => "/bin/ping";
-      "path[perl]"          string => "/usr/bin/perl";
-      "path[printf]"        string => "/usr/bin/printf";
-      "path[sed]"           string => "/bin/sed";
-      "path[sort]"          string => "/usr/bin/sort";
-      "path[test]"          string => "/usr/bin/test";
-      "path[tr]"            string => "/usr/bin/tr";
-      "path[wget]"          string => "/usr/bin/wget";
-      "path[realpath]"      string => "/usr/bin/realpath";
-
-      #
-      "path[apt_cache]"           string => "/usr/bin/apt-cache";
-      "path[apt_config]"          string => "/usr/bin/apt-config";
-      "path[apt_get]"             string => "/usr/bin/apt-get";
-      "path[apt_key]"             string => "/usr/bin/apt-key";
-      "path[aptitude]"            string => "/usr/bin/aptitude";
-      "path[dpkg]"                string => "/usr/bin/dpkg";
-      "path[groupadd]"            string => "/usr/sbin/groupadd";
-      "path[ifconfig]"            string => "/sbin/ifconfig";
-      "path[ip]"                  string => "/sbin/ip";
-      "path[service]"             string => "/usr/sbin/service";
-      "path[svc]"                 string => "/usr/sbin/service";
-      "path[update_alternatives]" string => "/usr/bin/update-alternatives";
-      "path[update_rc_d]"         string => "/usr/sbin/update-rc.d";
-      "path[useradd]"             string => "/usr/sbin/useradd";
-
-    archlinux||darwin::
-
-      "path[sysctl]"        string => "/usr/bin/sysctl";
-
-    !(archlinux||darwin)::
-
-      "path[sysctl]"        string => "/sbin/sysctl";
-
-    !suse::
-      "path[logger]"        string => "/usr/bin/logger";
-
-    suse::
-
-      "path[awk]"           string => "/usr/bin/awk";
-      "path[bc]"            string => "/usr/bin/bc";
-      "path[cat]"           string => "/bin/cat";
-      "path[cksum]"         string => "/usr/bin/cksum";
-      "path[createrepo]"    string => "/usr/bin/createrepo";
-      "path[crontab]"       string => "/usr/bin/crontab";
-      "path[crontabs]"      string => "/var/spool/cron/tabs";
-      "path[curl]"          string => "/usr/bin/curl";
-      "path[cut]"           string => "/usr/bin/cut";
-      "path[dc]"            string => "/usr/bin/dc";
-      "path[df]"            string => "/bin/df";
-      "path[diff]"          string => "/usr/bin/diff";
-      "path[dig]"           string => "/usr/bin/dig";
-      "path[dmidecode]"     string => "/usr/sbin/dmidecode";
-      "path[domainname]"    string => "/bin/domainname";
-      "path[echo]"          string => "/bin/echo";
-      "path[egrep]"         string => "/usr/bin/egrep";
-      "path[ethtool]"       string => "/usr/sbin/ethtool";
-      "path[find]"          string => "/usr/bin/find";
-      "path[free]"          string => "/usr/bin/free";
-      "path[grep]"          string => "/usr/bin/grep";
-      "path[hostname]"      string => "/bin/hostname";
-      "path[init]"          string => "/sbin/init";
-      "path[iptables]"      string => "/usr/sbin/iptables";
-      "path[iptables_save]" string => "/usr/sbin/iptables-save";
-      "path[ls]"            string => "/bin/ls";
-      "path[lsof]"          string => "/usr/bin/lsof";
-      "path[netstat]"       string => "/bin/netstat";
-      "path[nologin]"       string => "/sbin/nologin";
-      "path[ping]"          string => "/bin/ping";
-      "path[perl]"          string => "/usr/bin/perl";
-      "path[printf]"        string => "/usr/bin/printf";
-      "path[sed]"           string => "/bin/sed";
-      "path[sort]"          string => "/usr/bin/sort";
-      "path[test]"          string => "/usr/bin/test";
-      "path[tr]"            string => "/usr/bin/tr";
-      "path[logger]"        string => "/bin/logger";
-      "path[wget]"          string => "/usr/bin/wget";
-
-      #
-      "path[chkconfig]"     string => "/sbin/chkconfig";
-      "path[groupadd]"      string => "/usr/sbin/groupadd";
-      "path[groupdel]"      string => "/usr/sbin/groupdel";
-      "path[groupmod]"      string => "/usr/sbin/groupmod";
-      "path[ifconfig]"      string => "/sbin/ifconfig";
-      "path[ip]"            string => "/sbin/ip";
-      "path[rpm]"           string => "/bin/rpm";
-      "path[service]"       string => "/sbin/service";
-      "path[useradd]"       string => "/usr/sbin/useradd";
-      "path[userdel]"       string => "/usr/sbin/userdel";
-      "path[usermod]"       string => "/usr/sbin/usermod";
-      "path[zypper]"        string => "/usr/bin/zypper";
-
-    linux|solaris::
-
-      "path[shadow]"       string => "/etc/shadow";
-
-    freebsd|openbsd|netbsd|darwin::
-
-      "path[shadow]"       string => "/etc/master.passwd";
-
-    aix::
-
-      "path[shadow]"       string => "/etc/security/passwd";
-
-    any::
-
-      "all_paths"     slist => getindices("path");
-      "$(all_paths)" string => "$(path[$(all_paths)])";
+      # Avoid *some* errors about illegal variable names, specifically those containing `-`.
+      # Unfortunately some packages contain other special characters that are
+      # invalid variable names. Specifically those with '+', for example
+      # 'c++filt' and 'mklost+found' Probably thise should be canonified at the module level of this bundle.
+      "$(c_paths_map[$(paths)])" string => "$(path[$(paths)])";
+      "paths_cache" string => "$(sys.workdir)/state/paths.cache";
+      "software_packages_cache" string => "$(sys.workdir)/state/software_packages.csv";
 
   classes:
-      "_have_bin_env" expression => fileexists("/bin/env");
-      "_have_bin_systemctl" expression => fileexists("/bin/systemctl");
+      # This class definition could be deprecated as paths are only defined if they exist anyway.
+      "_stdlib_has_path_$(paths)" expression => "any";
+      "_stdlib_path_exists_$(paths)" expression => "any";
 
-      "_stdlib_has_path_$(all_paths)"
-      expression => isvariable("$(all_paths)"),
-      comment    => "It's useful to know if a given path is defined";
+      "_refresh_paths_cache" expression => "software_packages_csv_repaired";
+      "have_paths_cache" expression => isplain($(paths_cache));
 
-      "_stdlib_path_exists_$(all_paths)"
-      expression => fileexists("$(path[$(all_paths)])"),
-      comment    => "It's useful to know if $(all_paths) exists on the filesystem as defined";
+  files:
+      "$(software_packages_cache)"
+        changes => detect_content_using("md5"),
+        classes => scoped_classes_generic("bundle", "software_packages_csv");
+
+  # using a command means that this cannot be a common bundle. Perhaps
+  # reconisder using findfiles, or this bundle needs to be listed first in the
+  # bundlesequence.
+
+  commands:
+    _refresh_paths_cache|!have_paths_cache::
+      # I used find because findfiles was slow and a bit clunky. Unfortunately
+      # find is not necessarily available on every platform. Additionally I was
+      # able to format the find output in a modual protocal format so it can be
+      # easily cached.
+      "/usr/bin/find"
+        args =>"$(SEARCH_PATH) -maxdepth 1 -type f -executable -fprintf $(paths_cache) '^context=paths\n=path[%f]=%p\n'",
+        comment => "Format the find commands output so that we end up with an
+                    array of bins and paths for easy reference from within
+                    policy.";
+
+      have_paths_cache::
+        "/bin/cat"
+          args => "$(paths_cache)",
+          module => "true";
+
+  reports:
+    DEBUG|DEBUG_paths::
+      "$(paths) = $(path[$(paths)])";
 }


### PR DESCRIPTION
DO NOT MERGE: THIS IS ONLY FOR CONSIDERATION AND FEEDBACK

Instead of having a list of each path that we want to know about we could find
bins based on a pre defined path, just like PATH behaves on the cli.

This is risky, possibly too risky. I am unsure if this is offset by making the
paths bundle more usable.

Additionally some bins have characters in the name that make them generate
erros. This could probably be worked around.

Currently this implementation relies on GNU find. That may be an unacceptable
dependancy.