### PR TITLE
Add: Feature to disable checking of cf_promises_validated

### DIFF
--- a/update.cf
+++ b/update.cf
@@ -129,6 +129,23 @@ bundle common update_def
 
       "cfengine_internal_preserve_permissions" expression => "!any";
 
+      # Disable checking of cf_promises_validated before updating clients.
+      # Disabling checking of cf_promises_validated ensures that remote agents
+      # will **always** scan all of masterfiles for any changes and update
+      # accordingly. This is not recommended as it both removes a safety
+      # mechanism that checks for policy to be valid before allowing clients to
+      # download updates, and the increased load on the hub will affect
+      # scalability. Consider using time_based, select_class, or dist based classes
+      # instead of any to retain some of the benefits. **DISABLE WITH CAUTION**
+
+      "cfengine_internal_disable_cf_promises_validated"
+        expression => "!any",
+        comment => "When cf_promises_validated is disabled remote agents will
+                   always scan all of masterfiles for changes. Disabling this
+                   is not recomended as it will increase the load on the policy
+                   server and increases the possibility for remote agents to
+                   recieve broken policy.";
+
 }
 
 body classes u_kept_successful_command

--- a/update/update_policy.cf
+++ b/update/update_policy.cf
@@ -114,6 +114,11 @@ bundle agent cfe_internal_update_policy
 
       "have_bindir_$(optional_agents)" expression => fileexists("$(dir_bin)/$(optional_agents)");
 
+      "validated_updates_ready"
+        expression => "cfengine_internal_disable_cf_promises_validated",
+        comment => "If cf_promises_validated is disabled, then updates are
+                    always considered validated.";
+
     any::
 
       "have_ppkeys"   expression => fileexists("$(ppkeys_file)"),


### PR DESCRIPTION
Ref: https://dev.cfengine.com/issues/6688

Make it easy to have clients always scan for any changes and update 
accordingly.
