### PR TITLE
Add: Software update directory for aix 6.1 powerpc

### DIFF
--- a/cfe_internal/CFE_hub_specific.cf
+++ b/cfe_internal/CFE_hub_specific.cf
@@ -40,6 +40,7 @@ bundle agent cfe_internal_update_folders
       "dirs" slist => {
                         "aix_5_powerpc",
                         "aix_6_powerpc",
+                        "aix_6.1_powerpc",
                         "aix_7_powerpc",
                         "ubuntu_8_i686",
                         "ubuntu_8_x86_64",


### PR DESCRIPTION
Ref: https://dev.cfengine.com/issues/6583

In order for the binary upgrade policy in `update/update_bins.cf` to work for
aix the specific aix version is needed.
