### PR TITLE
Change: Tighten reference to runlog

### DIFF
--- a/def.cf
+++ b/def.cf
@@ -115,7 +115,7 @@ bundle common def
     any::
       "base_log_files" slist =>
       {
-        "$(sys.workdir)/cf3.$(sys.host).runlog",
+        "$(sys.workdir)/cf3.$(sys.uqhost).runlog",
         "$(sys.workdir)/promise_summary.log",
       };
 


### PR DESCRIPTION
Using sys.host to identify the correct runlog is error prone as sys.host is
ambiguous and may be either the short or long hostname. The runlog file is
always named for the shorthostname so we should use sys.uqhost when
referencing it or it may grow without bound.

Ref: https://dev.cfengine.com/issues/6563#change-34318
