### PR TITLE
Change: Move mailto and mailfrom settings to def.cf

### DIFF
--- a/controls/cf_execd.cf
+++ b/controls/cf_execd.cf
@@ -15,8 +15,8 @@ body executor control
       splaytime  => "4";
 
     cfengine_internal_agent_email::
-      mailto     => "root@$(def.domain)";
-      mailfrom   => "root@$(sys.uqhost).$(def.domain)";
+      mailto     => "$(def.mailto)";
+      mailfrom   => "$(def.mailfrom)";
       smtpserver => "localhost";
 
     any::

--- a/def.cf
+++ b/def.cf
@@ -21,6 +21,10 @@ bundle common def
       comment => "Define a global domain for all hosts",
       handle => "common_def_vars_domain";
 
+      # Mail settings used by body executor control found in controls/cf_execd.cf
+      "mailto" string => "root@$(def.domain)";
+      "mailfrom" string => "root@$(sys.uqhost).$(def.domain)";
+
       # List here the IP masks that we grant access to on the server
 
       "acl"     slist => {


### PR DESCRIPTION
This should make  policy framework upgrades slightly easier by limiting the
number of shipped files users are required to touch.

Pick from master
