### PR TITLE
Change: Move smtpserver setting for cf_execd to def

### DIFF
--- a/controls/cf_execd.cf
+++ b/controls/cf_execd.cf
@@ -17,7 +17,7 @@ body executor control
     cfengine_internal_agent_email::
       mailto     => "$(def.mailto)";
       mailfrom   => "$(def.mailfrom)";
-      smtpserver => "localhost";
+      smtpserver => "$(def.smtpserver)";
 
     any::
 

--- a/def.cf
+++ b/def.cf
@@ -24,6 +24,7 @@ bundle common def
       # Mail settings used by body executor control found in controls/cf_execd.cf
       "mailto" string => "root@$(def.domain)";
       "mailfrom" string => "root@$(sys.uqhost).$(def.domain)";
+      "smtpserver" string => "localhost";
 
       # List here the IP masks that we grant access to on the server
 


### PR DESCRIPTION
mailto and mailfrom are already in def. It makes sense to keep the smtpserver
with them. This is intended to make policy framework upgrades slightly easier.

Pick from master
