### PR TITLE
Change: Move environment variable definition to def.cf

### DIFF
--- a/controls/cf_agent.cf
+++ b/controls/cf_agent.cf
@@ -32,10 +32,6 @@ body agent control
 
     debian::
 
-      environment => {
-                       "DEBIAN_FRONTEND=noninteractive",
-                       # "APT_LISTBUGS_FRONTEND=none",
-                       # "APT_LISTCHANGES_FRONTEND=none",
-      };
+      environment => { @(def.environment_vars) };
 
 }

--- a/def.cf
+++ b/def.cf
@@ -55,6 +55,18 @@ bundle common def
       },
       comment => "Define from which machines keys can be trusted";
 
+
+  debian::
+      "environment_vars"
+        handle => "common_def_vars_environment_vars",
+        comment => "Environment variables of the agent process. The values
+                    of environment variables are inherited by child commands.",
+        slist => {
+                   "DEBIAN_FRONTEND=noninteractive",
+                  # "APT_LISTBUGS_FRONTEND=none",
+                  # "APT_LISTCHANGES_FRONTEND=none",
+                 };
+
       # End change #
 
   cfengine_3_5::


### PR DESCRIPTION
This should make setting environment variables a bit more visible (being 
alongside many other settings a user commonly changes). And it will hopefully
make policy framework upgrades easier as it will hopefully decrease the number
of default files a user has to touch to make their customizations.

Ref: https://dev.cfengine.com/issues/6736
