### PR TITLE
Add: conveniance bundle to run a bundle if its defined

### DIFF
--- a/lib/3.6/bundles.cf
+++ b/lib/3.6/bundles.cf
@@ -378,3 +378,35 @@ bundle agent cmerge(name, varlist)
       "$(name)" data => mergedata($(name), $(varlist)), policy => "free"; # iterates!
       "$(name)_str" string => format("%S", $(name)),    policy => "free";
 }
+
+bundle agent run_ifdefined(namespace, mybundle)
+# @brief bundle to maybe run another bundle dynamically
+# @param namespace the namespace, usually `$(this.namespace)`
+# @param mybundle the bundle to maybe run
+#
+# This bundle simply is a way to run another bundle only if it's defined.
+#
+# **Example:**
+#
+# ```cf3
+# bundle agent run
+# {
+#   methods:
+#       # does nothing if bundle "runthis" is not defined
+#       "go" usebundle => run_ifdefined($(this.namespace), runthis);
+# }
+# ```
+{
+  vars:
+      "bundlesfound" slist => bundlesmatching("^$(namespace):$(mybundle)$");
+      "count" int => length(bundlesfound);
+
+  methods:
+      "any"
+      usebundle  => $(bundlesfound),
+      ifvarclass => strcmp(1, $(count));
+
+  reports:
+    verbose_mode::
+      "$(this.bundle): found matching bundles $(bundlesfound) for namespace '$(namespace)' and bundle '$(mybundle)'";
+}


### PR DESCRIPTION
Sometimes you don't know if a bundle is defined in your policy. Maybe because
you are using dynamic inputs. This bundle makes it easy to activate a bundle
if it happens to be defined.
