### PR TITLE
tests/acceptance/lib/bundles/run_ifdefined.cf: new test

### DIFF
--- a/tests/acceptance/lib/bundles/run_ifdefined.cf
+++ b/tests/acceptance/lib/bundles/run_ifdefined.cf
@@ -1,0 +1,26 @@
+#######################################################
+#
+# Test bundle run_ifdefined
+#
+#######################################################
+
+body common control
+{
+      inputs => { '../../default.cf.sub' };
+      bundlesequence  => { default("$(this.promise_filename)") };
+}
+
+#######################################################
+
+bundle agent check
+{
+  methods:
+      "any" usebundle => run_ifdefined($(this.namespace), no_such_check_tester);
+      "any" usebundle => run_ifdefined($(this.namespace), check_tester);
+}
+
+bundle agent check_tester
+{
+  methods:
+      "any" usebundle => dcs_pass($(this.promise_filename));
+}


### PR DESCRIPTION
Acceptance test for `run_ifdefined`.  Untested.

You need to edit the plucking rules in core.git, regenerate `plucked.cf.sub`, then do `make copy` in the `tests/acceptance` directory for this to work.  Fun.  Only then should you merge, or your acceptance tests will croak :)
