### PR TITLE
Fix: services promises repair on change

### DIFF
--- a/lib/3.6/services.cf
+++ b/lib/3.6/services.cf
@@ -200,7 +200,6 @@ bundle agent standard_services(service,state)
 
     chkconfig.have_init.((start.!running)|((stop|restart|reload).running)).non_disabling::
       "$(init) $(state)"
-      classes => kept_successful_command,
       contain => silent;
 
     sysvservice.non_disabling::


### PR DESCRIPTION
This fixes promise reporting for service changes for init.d. Prior to this
starting a service was seen as kept, when it should have been a repair.
Backporting from master

Ref: https://dev.cfengine.com/issues/5625
