### PR TITLE
Add: Path to wc for debain and redhat

### DIFF
--- a/lib/3.5/paths.cf
+++ b/lib/3.5/paths.cf
@@ -266,6 +266,7 @@ bundle common paths
       "path[sed]"           string => "/bin/sed";
       "path[sort]"          string => "/bin/sort";
       "path[test]"          string => "/usr/bin/test";
+      "path[wc]"            string => "/usr/bin/wc";
       "path[wget]"          string => "/usr/bin/wget";
       "path[tr]"            string => "/usr/bin/tr";
       "path[realpath]"      string => "/usr/bin/realpath";
@@ -357,6 +358,7 @@ bundle common paths
       "path[sort]"          string => "/usr/bin/sort";
       "path[test]"          string => "/usr/bin/test";
       "path[tr]"            string => "/usr/bin/tr";
+      "path[wc]"            string => "/usr/bin/wc";
       "path[wget]"          string => "/usr/bin/wget";
       "path[realpath]"      string => "/usr/bin/realpath";
 

--- a/lib/3.6/paths.cf
+++ b/lib/3.6/paths.cf
@@ -286,6 +286,7 @@ bundle common paths
       "path[sort]"          string => "/bin/sort";
       "path[test]"          string => "/usr/bin/test";
       "path[tr]"            string => "/usr/bin/tr";
+      "path[wc]"            string => "/usr/bin/wc";
       "path[wget]"          string => "/usr/bin/wget";
       "path[realpath]"      string => "/usr/bin/realpath";
 
@@ -376,6 +377,7 @@ bundle common paths
       "path[sort]"          string => "/usr/bin/sort";
       "path[test]"          string => "/usr/bin/test";
       "path[tr]"            string => "/usr/bin/tr";
+      "path[wc]"            string => "/usr/bin/wc";
       "path[wget]"          string => "/usr/bin/wget";
       "path[realpath]"      string => "/usr/bin/realpath";
 


### PR DESCRIPTION
wc is a commonly used utility. Having it in the stdlib can help make some
policy more portable.

picked from master
