### PR TITLE
Updating test cases to not relay on ordering of getindices any more.

### DIFF
--- a/tests/acceptance/lib/files/set_line_based_variable_values.cf
+++ b/tests/acceptance/lib/files/set_line_based_variable_values.cf
@@ -49,7 +49,7 @@ bundle agent test
 bundle agent check
 {
   methods:
-      "any" usebundle => dcs_check_diff("$(G.testfile).actual",
-                                            "$(G.testfile).expected",
-                                            "$(this.promise_filename)");
+      "any" usebundle => sorted_check_diff("$(G.testfile).actual",
+                                           "$(G.testfile).expected",
+                                           "$(this.promise_filename)");
 }

--- a/tests/acceptance/lib/files/set_variable_values.cf
+++ b/tests/acceptance/lib/files/set_variable_values.cf
@@ -47,7 +47,7 @@ bundle agent test
 bundle agent check
 {
   methods:
-      "any" usebundle => dcs_check_diff("$(G.testfile).actual",
-                                            "$(G.testfile).expected",
-                                            "$(this.promise_filename)");
+      "any" usebundle => sorted_check_diff("$(G.testfile).actual",
+                                           "$(G.testfile).expected",
+                                           "$(this.promise_filename)");
 }


### PR DESCRIPTION
(cherry picked from commit c47c9a2ced0dcd935f408b0a8e002ee0d085e424)
