### PR TITLE
Enabling services with chkconfig fixed. Canonified classes where matched...

### DIFF
--- a/lib/3.6/services.cf
+++ b/lib/3.6/services.cf
@@ -137,6 +137,7 @@ bundle agent standard_services(service,state)
   vars:
       "call_systemctl" string => "$(paths.systemctl) --no-ask-password --global --system";
       "init" string => "/etc/init.d/$(service)";
+      "c_service" string => canonify("$(service)");
 
     start|restart|reload::
       "chkconfig_mode" string => "on";
@@ -171,7 +172,7 @@ bundle agent standard_services(service,state)
       comment => "We need to know if the service is configured to start at boot or not";
 
       # We redirect stderr and stdout to dev null so that we do not create noise in the logs
-      "chkconfig_$(service)_unregistered"
+      "chkconfig_$(c_service)_unregistered"
       not => returnszero("$(paths.chkconfig) --list $(service) &> /dev/null", "useshell"),
       comment => "We need to know if the service is registered with chkconfig so that we can
       perform other chkconfig operations, if the service is not registered it must be added.
@@ -257,7 +258,7 @@ bundle agent standard_services(service,state)
     chkconfig.start.!onboot::
       # Only chkconfig enable service if it's not already set to start on boot, and if its a registered chkconfig service
       "$(paths.chkconfig) $(service) $(chkconfig_mode)"
-      ifvarclass => canonify("!chkconfig_$(service)_unregistered"),
+      ifvarclass => "!chkconfig_$(service)_unregistered",
       classes => kept_successful_command,
       contain => silent;
 
@@ -288,10 +289,10 @@ bundle agent standard_services(service,state)
       "$(this.bundle): Service $(service) unit file is not loaded; doing nothing";
     inform_mode.chkconfig::
       "$(this.bundle): using chkconfig layer to $(state) $(service) (chkconfig mode $(chkconfig_mode))"
-        ifvarclass => canonify("!chkconfig_$(service)_unregistered");
+        ifvarclass => "!chkconfig_$(c_service)_unregistered";
     inform_mode.chkconfig::
       "$(this.bundle): skipping chkconfig layer to $(state) $(service) because $(service) is not registered with chkconfig (chkconfig --list $(service))"
-        ifvarclass => canonify("chkconfig_$(service)_unregistered");
+        ifvarclass => "chkconfig_$(c_service)_unregistered";
     inform_mode.sysvservice::
       "$(this.bundle): using System V service / Upstart layer to $(state) $(service)";
     inform_mode.smf::

--- a/lib/3.7/services.cf
+++ b/lib/3.7/services.cf
@@ -137,6 +137,7 @@ bundle agent standard_services(service,state)
   vars:
       "call_systemctl" string => "$(paths.systemctl) --no-ask-password --global --system";
       "init" string => "/etc/init.d/$(service)";
+      "c_service" string => canonify("$(service)");
 
     start|restart|reload::
       "chkconfig_mode" string => "on";
@@ -171,7 +172,7 @@ bundle agent standard_services(service,state)
       comment => "We need to know if the service is configured to start at boot or not";
 
       # We redirect stderr and stdout to dev null so that we do not create noise in the logs
-      "chkconfig_$(service)_unregistered"
+      "chkconfig_$(c_service)_unregistered"
       not => returnszero("$(paths.chkconfig) --list $(service) &> /dev/null", "useshell"),
       comment => "We need to know if the service is registered with chkconfig so that we can
       perform other chkconfig operations, if the service is not registered it must be added.
@@ -257,7 +258,7 @@ bundle agent standard_services(service,state)
     chkconfig.start.!onboot::
       # Only chkconfig enable service if it's not already set to start on boot, and if its a registered chkconfig service
       "$(paths.chkconfig) $(service) $(chkconfig_mode)"
-      ifvarclass => canonify("!chkconfig_$(service)_unregistered"),
+      ifvarclass => "!chkconfig_$(service)_unregistered",
       classes => kept_successful_command,
       contain => silent;
 
@@ -288,10 +289,10 @@ bundle agent standard_services(service,state)
       "$(this.bundle): Service $(service) unit file is not loaded; doing nothing";
     inform_mode.chkconfig::
       "$(this.bundle): using chkconfig layer to $(state) $(service) (chkconfig mode $(chkconfig_mode))"
-        ifvarclass => canonify("!chkconfig_$(service)_unregistered");
+        ifvarclass => "!chkconfig_$(c_service)_unregistered";
     inform_mode.chkconfig::
       "$(this.bundle): skipping chkconfig layer to $(state) $(service) because $(service) is not registered with chkconfig (chkconfig --list $(service))"
-        ifvarclass => canonify("chkconfig_$(service)_unregistered");
+        ifvarclass => "chkconfig_$(c_service)_unregistered";
     inform_mode.sysvservice::
       "$(this.bundle): using System V service / Upstart layer to $(state) $(service)";
     inform_mode.smf::


### PR DESCRIPTION
... against uncanonified classes.

In the chkconfig part of standard_services uncanonified classes (using the service name) are created if a service is not enabled with chkconfig. Those classes are matched against canonified classes. As a result, it never matches and services will not be enabled at boot time. This commit should fix the error. 
