### PR TITLE
Fix broken expansion of 3.5 HA bundles in bundlesequence

### DIFF
--- a/lib/3.5/cfe_internal.cf
+++ b/lib/3.5/cfe_internal.cf
@@ -65,3 +65,13 @@ bundle agent cfe_internal_hub_maintain
       handle => "cfe_internal_start_hub_start_maintenance",
       action => bg("60","60");
 }
+
+bundle common cfengine_enterprise_hub_ha
+{
+  vars:
+    "classification_bundles"
+        slist => { };
+
+    "management_bundles"
+        slist => { };
+}


### PR DESCRIPTION
@(cfengine_enterprise_hub_ha.classification_bundles) and
@(cfengine_enterprise_hub_ha.management_bundles) were reported as
undefined when using 3.5 agent.
(cherry picked from commit 06c0dfb2597084e6716d1b0ad35ae3903fe11a5d)
