### PR TITLE
Fix 3.6.0 compatibility.

### DIFF
--- a/lib/3.6/bundles.cf
+++ b/lib/3.6/bundles.cf
@@ -401,10 +401,13 @@ bundle agent run_ifdefined(namespace, mybundle)
       "bundlesfound" slist => bundlesmatching("^$(namespace):$(mybundle)$");
       "count" int => length(bundlesfound);
 
+  classes:
+      "runidentified" expression => strcmp(1, $(count));
+
   methods:
       "any"
       usebundle  => $(bundlesfound),
-      ifvarclass => strcmp(1, $(count));
+      ifvarclass => "runidentified";
 
   reports:
     verbose_mode::


### PR DESCRIPTION
3.6.0 agents are complaining about wrong type returned by strcmp function
taken by ifvarclass.
(cherry picked from commit 67a5d9949b9647926c33ce735419fa3d3ab7c585)
