### PR TITLE
Change: Only update cf-upgrade when needed

### DIFF
--- a/update/update_bins.cf
+++ b/update/update_bins.cf
@@ -292,20 +292,6 @@ bundle agent cfe_internal_update_bins
       perms => u_m("0644"),
       ifvarclass => "solarisx86|solaris";
 
-      "$(sys.workdir)/bin/cf-upgrade"
-      comment => "Copy cf-upgrade binary from policy hub for i386 linux",
-      handle => "cfe_internal_update_bins_files_cf_upgrade_i386_linux",
-      copy_from => u_rcp("$(master_software_location)/cf-upgrade/linux.i386/cf-upgrade", @(update_def.policy_servers)),
-      perms => u_m("0755"),
-      ifvarclass => "linux.i686";
-
-      "$(sys.workdir)/bin/cf-upgrade"
-      comment => "Copy cf-upgrade binary from policy hub for x86_64 linux",
-      handle => "cfe_internal_update_bins_files_cf_upgrade_x86_64_linux",
-      copy_from => u_rcp("$(master_software_location)/cf-upgrade/linux.x86_64/cf-upgrade", @(update_def.policy_servers)),
-      perms => u_m("0755"),
-      ifvarclass => "linux.x86_64";
-
       "$(backup_script)"
       comment => "Create a backup script for cf-upgrade",
       handle => "cfe_internal_update_bins_files_backup_script",
@@ -329,6 +315,26 @@ bundle agent cfe_internal_update_bins
       depth_search => u_recurse("1"),  # Nova updates should be in root dir
       action => u_immediate,
       classes => u_if_repaired("bin_newpkg");
+
+    !am_policy_hub.enterprise.trigger_upgrade.(cfengine_3_6_0|cfengine_3_6_1)::
+      "$(sys.workdir)/bin/cf-upgrade"
+      handle => "cfe_internal_update_bins_files_cf_upgrade_i386_linux",
+      copy_from => u_rcp("$(master_software_location)/cf-upgrade/linux.i386/cf-upgrade", @(update_def.policy_servers)),
+      perms => u_m("0755"),
+      ifvarclass => "linux.i686",
+      comment => "The cf-upgrade binary that shipped with 3.6.0 and 3.6.1 was
+                  broken, we need to download a working copy so that upgrades
+                  will work on i386 linux";
+
+      "$(sys.workdir)/bin/cf-upgrade"
+      comment => "Copy cf-upgrade binary from policy hub for x86_64 linux",
+      handle => "cfe_internal_update_bins_files_cf_upgrade_x86_64_linux",
+      copy_from => u_rcp("$(master_software_location)/cf-upgrade/linux.x86_64/cf-upgrade", @(update_def.policy_servers)),
+      perms => u_m("0755"),
+      ifvarclass => "linux.x86_64",
+      comment => "The cf-upgrade binary that shipped with 3.6.0 and 3.6.1 was
+                  broken, we need to download a working copy so that upgrades
+                  will work on x86_64 linux";
 
     bin_update_success.enterprise.trigger_upgrade::
 


### PR DESCRIPTION
The cf-upgrade binary was broken on 3.6.0 and 3.6.1. The policy to download a
working cf-upgrade binary from the hub is unnecessary when running newer
versions. This change suppresses a promise not kept when performing upgrades
in some cases and reduces unnecessary work.
