### PR TITLE
Remove: Deprecated cf-hub control attributes

### DIFF
--- a/controls/cf_hub.cf
+++ b/controls/cf_hub.cf
@@ -13,8 +13,6 @@ body hub control
 
     am_policy_hub::
 
-      # export_zenoss => "/var/www/reports/summary.z";
-      # federation => { "host1", "host2" };
       # exclude_hosts => { "192.168.12.21", "10.10", "10.12.*" };
 
       # cf-hub collects up reports from registered hosts every 5 minutes.


### PR DESCRIPTION
These attributes are deprecated, removing their comments to reduce confusion.
