### PR TITLE
Add: Select files by symlink target

### DIFF
--- a/lib/3.5/files.cf
+++ b/lib/3.5/files.cf
@@ -1475,6 +1475,15 @@ body file_select filetypes_older_than(filetypes, days)
       file_result => "file_types.mtime";
 }
 
+body file_select symlinked_to(target)
+# @brief Select symlinks that point to $(target)
+# @param target The file the symlink should point to in order to be selected
+{
+  file_types  => { "symlink" };
+  issymlinkto => { "$(target)" };
+  file_result => "issymlinkto";
+}
+
 ##-------------------------------------------------------
 ## changes
 ##-------------------------------------------------------

--- a/lib/3.6/files.cf
+++ b/lib/3.6/files.cf
@@ -1845,6 +1845,15 @@ body file_select filetypes_older_than(filetypes, days)
       file_result => "file_types.mtime";
 }
 
+body file_select symlinked_to(target)
+# @brief Select symlinks that point to $(target)
+# @param target The file the symlink should point to in order to be selected
+{
+  file_types  => { "symlink" };
+  issymlinkto => { "$(target)" };
+  file_result => "issymlinkto";
+}
+
 ##-------------------------------------------------------
 ## changes
 ##-------------------------------------------------------

--- a/lib/3.7/files.cf
+++ b/lib/3.7/files.cf
@@ -1845,6 +1845,15 @@ body file_select filetypes_older_than(filetypes, days)
       file_result => "file_types.mtime";
 }
 
+body file_select symlinked_to(target)
+# @brief Select symlinks that point to $(target)
+# @param target The file the symlink should point to in order to be selected
+{
+  file_types  => { "symlink" };
+  issymlinkto => { "$(target)" };
+  file_result => "issymlinkto";
+}
+
 ##-------------------------------------------------------
 ## changes
 ##-------------------------------------------------------


### PR DESCRIPTION
This body allows selection of symlinks based on their target. This can be
useful if you want to make a promise about a symlink only if it points to a
specific location. For example deleting an old symlink.