### PR TITLE
Add package method for SmartOS pkg_add

### DIFF
--- a/lib/3.6/packages.cf
+++ b/lib/3.6/packages.cf
@@ -1247,6 +1247,36 @@ body package_method smartos
       package_update_command =>  "/opt/local/bin/pkgin -y install";
 }
 
+body package_method smartos_pkg_add(repo)
+# @brief SmartOS pkg_add installation package method
+#
+# This package method interacts with SmartOS pkg_add to install from local
+# or remote repositories. It is slightly different than the FreeBSD pkg_add.
+#
+# This example installs "perl5" from a remote repository.
+#
+# ```cf3
+# ----------------------------
+# packages:
+#   "perl5"
+#     package_policy   =>  "add",
+#     package_method   =>  smartos_pkg_add("http://pkg.example.com/packages/");
+#
+# ```
+{
+      package_changes => "individual";
+      package_list_command => "/opt/local/sbin/pkg_info";
+      package_list_name_regex    => "([^\s]+)\-[0-9]+.*\s";
+      package_list_version_regex => "[^\s]+\-([0-9][^\s]+)\s";
+
+      package_installed_regex => ".*"; # all reported are installed
+
+      package_add_command => "/usr/bin/env PKG_PATH=$(repo) /opt/local/sbin/pkg_add";
+
+      package_delete_command => "/opt/local/sbin/pkg_delete";
+      package_update_command => "/usr/bin/env PKG_PATH=$(repo) /opt/local/sbin/pkg_add";
+}
+
 body package_method opencsw
 # @depends common_knowledge
 # @brief OpenCSW (Solaris software packages) method

--- a/lib/3.7/packages.cf
+++ b/lib/3.7/packages.cf
@@ -1247,6 +1247,36 @@ body package_method smartos
       package_update_command =>  "/opt/local/bin/pkgin -y install";
 }
 
+body package_method smartos_pkg_add(repo)
+# @brief SmartOS pkg_add installation package method
+#
+# This package method interacts with SmartOS pkg_add to install from local
+# or remote repositories. It is slightly different than the FreeBSD pkg_add.
+#
+# This example installs "perl5" from a remote repository:
+#
+# ```cf3
+# ----------------------------
+# packages:
+#   "perl5"
+#     package_policy   =>  "add",
+#     package_method   =>  smartos_pkg_add("http://pkg.example.com/packages/");
+#
+# ```
+{
+      package_changes => "individual";
+      package_list_command => "/opt/local/sbin/pkg_info";
+      package_list_name_regex    => "([^\s]+)\-[0-9]+.*\s";
+      package_list_version_regex => "[^\s]+\-([0-9][^\s]+)\s";
+
+      package_installed_regex => ".*"; # all reported are installed
+
+      package_add_command => "/usr/bin/env PKG_PATH=$(repo) /opt/local/sbin/pkg_add";
+
+      package_delete_command => "/opt/local/sbin/pkg_delete";
+      package_update_command => "/usr/bin/env PKG_PATH=$(repo) /opt/local/sbin/pkg_add";
+}
+
 body package_method opencsw
 # @depends common_knowledge
 # @brief OpenCSW (Solaris software packages) method


### PR DESCRIPTION
This package method interacts with SmartOS pkg_add to install from local or remote repositories. It is slightly different than the FreeBSD `pkg_add`.

 This example installs `perl5` from a remote repository.

     packages:
      "perl5"
      package_policy   =>  "add",
      package_method   =>  smartos_pkg_add("http://pkg.example.com/packages/");

 This example installs `perl5` from a local package cache.

     packages:
      "perl5"
      package_policy   =>  "add",
      package_method   =>  smartos_pkg_add("/opt/custom/packages");