### PR TITLE
Make workdir relocatable.

### DIFF
--- a/cfe_internal/CFE_hub_specific.cf
+++ b/cfe_internal/CFE_hub_specific.cf
@@ -143,7 +143,7 @@ bundle edit_line apache_sudoer
 
     linux::
 
-      "$(def.cf_apache_user) ALL=(ALL) NOPASSWD:/var/cfengine/bin/cf-runagent *"
+      "$(def.cf_apache_user) ALL=(ALL) NOPASSWD:$(sys.bindir)/cf-runagent *"
       comment => "Add Apache user to run passwordless sudo cf-runagent",
       handle => "apache_sudoer_insert_lines";
 
@@ -174,7 +174,7 @@ bundle agent cfe_internal_webserver(state)
 
     am_policy_hub.on::
 
-      ".*/var/cfengine/httpd/bin/httpd.*"
+      ".*$(sys.workdir)/httpd/bin/httpd.*"
       restart_class => "start_cfe_httpd",
       comment => "Check if CFE httpd process exists or not",
       handle => "cfe_internal_webserver_processes_start_cfe_httpd";
@@ -185,7 +185,7 @@ bundle agent cfe_internal_webserver(state)
 
     start_cfe_httpd::
 
-      "LD_LIBRARY_PATH=/var/cfengine/lib:$LD_LIBRARY_PATH /var/cfengine/httpd/bin/apachectl start"
+      "LD_LIBRARY_PATH=$(sys.workdir)/lib:$LD_LIBRARY_PATH $(sys.workdir)/httpd/bin/apachectl start"
       comment => "Start CFE httpd process if not exist",
       classes => kept_successful_command,
       handle => "cfe_internal_webserver_commands_start_cfe_httpd",
@@ -216,13 +216,13 @@ bundle agent cfe_internal_httpd_related
 
     am_policy_hub::
 
-      "/var/cfengine/httpd/conf/httpd.conf"
+      "$(sys.workdir)/httpd/conf/httpd.conf"
       comment => "Change TCP port on CFEngine httpd configuration",
       handle => "cfe_internal_httpd_related_files_httpd_conf",
       edit_line => change_port("$(tcp_port)"),
       classes => if_repaired("restart_cfe_httpd");
 
-      "/var/cfengine/httpd/htdocs/application/config/appsettings.php"
+      "$(sys.workdir)/httpd/htdocs/application/config/appsettings.php"
       comment => "Add TCP port to MP setting",
       handle => "cfe_internal_httpd_related_files_appsettings_php",
       edit_line => change_appsettings("$(tcp_port)");
@@ -233,7 +233,7 @@ bundle agent cfe_internal_httpd_related
 
     restart_cfe_httpd::
 
-      "LD_LIBRARY_PATH=/var/cfengine/lib:$LD_LIBRARY_PATH /var/cfengine/httpd/bin/apachectl restart"
+      "LD_LIBRARY_PATH=$(sys.workdir)/lib:$LD_LIBRARY_PATH $(sys.workdir)/httpd/bin/apachectl restart"
       comment => "Restart CFEngine httpd if there is a change on configuration",
       classes => kept_successful_command,
       handle => "cfe_internal_httpd_related_commands_apachectl_restart",
@@ -298,11 +298,11 @@ bundle agent cfe_internal_php_runalerts
 
     any::
 
-      "runalerts_script" string => "/var/cfengine/bin/runalerts.sh",
+      "runalerts_script" string => "$(sys.workdir)/bin/runalerts.sh",
       comment => "location of php runalerts script",
       handle => "cfe_internal_php_runalerts_vars_runalerts_script";
 
-      "runalerts_stampfiles_dir" string => "/var/cfengine/httpd/php",
+      "runalerts_stampfiles_dir" string => "$(sys.workdir)/httpd/php",
       comment => "location of runalerts stamp file directory",
       handle => "cfe_internal_php_runalerts_var_runalerts_stampfiles_dir";
 
@@ -419,12 +419,12 @@ bundle edit_line my_php_runalerts_script(v1,v2,sdir,stime)
 
 while true; do
   touch $(sdir)/runalerts_$(cfe_internal_php_runalerts.sql[name])
- if [ -f /var/cfengine/httpd/php/runalerts_$(cfe_internal_php_runalerts.sql[name]) ]; then
-  /var/cfengine/httpd/php/bin/php /var/cfengine/httpd/htdocs/index.php cli_tasks runalerts $(cfe_internal_php_runalerts.sql[limit]) $(cfe_internal_php_runalerts.sql[running]) $(cfe_internal_php_runalerts.sql[name]) >/dev/null 2>&1
+ if [ -f $(sys.workdir)/httpd/php/runalerts_$(cfe_internal_php_runalerts.sql[name]) ]; then
+  $(sys.workdir)/httpd/php/bin/php $(sys.workdir)/httpd/htdocs/index.php cli_tasks runalerts $(cfe_internal_php_runalerts.sql[limit]) $(cfe_internal_php_runalerts.sql[running]) $(cfe_internal_php_runalerts.sql[name]) >/dev/null 2>&1
  fi
   touch $(sdir)/runalerts_$(cfe_internal_php_runalerts.sketch[name])
- if [ -f /var/cfengine/httpd/php/runalerts_$(cfe_internal_php_runalerts.sketch[name]) ]; then
-  /var/cfengine/httpd/php/bin/php /var/cfengine/httpd/htdocs/index.php cli_tasks runalerts $(cfe_internal_php_runalerts.sketch[limit]) $(cfe_internal_php_runalerts.sketch[running]) $(cfe_internal_php_runalerts.sketch[name]) >/dev/null 2>&1
+ if [ -f $(sys.workdir)/httpd/php/runalerts_$(cfe_internal_php_runalerts.sketch[name]) ]; then
+  $(sys.workdir)/httpd/php/bin/php $(sys.workdir)/httpd/htdocs/index.php cli_tasks runalerts $(cfe_internal_php_runalerts.sketch[limit]) $(cfe_internal_php_runalerts.sketch[running]) $(cfe_internal_php_runalerts.sketch[name]) >/dev/null 2>&1
  fi
  sleep $(stime)
 done"

--- a/cfe_internal/cfengine_processes.cf
+++ b/cfe_internal/cfengine_processes.cf
@@ -148,7 +148,7 @@ bundle agent cfe_internal_enable
       "/etc/rc.conf"
       comment => "cfengine libraries should be enabled in rc.conf if appropriate",
       handle => "cfe_internal_enable_files_rc_conf_freebsd_1",
-      edit_line => append_if_no_line("[ -e /var/cfengine/lib ] && /sbin/ldconfig -m /var/cfengine/lib");
+      edit_line => append_if_no_line("[ -e $(sys.workdir)/lib ] && /sbin/ldconfig -m $(sys.workdir)/lib");
 
       "/etc/rc.conf"
       comment => "cfengine should be enabled in rc.conf",

--- a/controls/cf_execd.cf
+++ b/controls/cf_execd.cf
@@ -36,17 +36,17 @@ body executor control
       exec_command => "$(sys.cf_agent) -f \"$(sys.update_policy_path)\" & $(sys.cf_agent) -Dcf_execd_initiated";
 
     hpux.cfengine_3_5::
-      exec_command => "SHLIB_PATH=\"/var/cfengine/lib-twin\" $(sys.cf_twin) -f \"$(sys.workdir)/inputs/update.cf\" ; $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "SHLIB_PATH=\"$(sys.workdir)/lib-twin\" $(sys.cf_twin) -f \"$(sys.workdir)/inputs/update.cf\" ; $(sys.cf_agent) -Dcf_execd_initiated";
     hpux.!cfengine_3_5::
       exec_command => "$(sys.cf_agent) -f \"$(sys.update_policy_path)\" ; $(sys.cf_agent) -Dcf_execd_initiated";
 
     aix.cfengine_3_5::
-      exec_command => "LIBPATH=\"/var/cfengine/lib-twin\" $(sys.cf_twin) -f \"$(sys.workdir)/inputs/update.cf\" ; $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "LIBPATH=\"$(sys.workdir)/lib-twin\" $(sys.cf_twin) -f \"$(sys.workdir)/inputs/update.cf\" ; $(sys.cf_agent) -Dcf_execd_initiated";
     aix.!cfengine_3_5::
       exec_command => "$(sys.cf_agent) -f \"$(sys.update_policy_path)\" ; $(sys.cf_agent) -Dcf_execd_initiated";
 
     !(windows|hpux|aix).cfengine_3_5::
-      exec_command => "LD_LIBRARY_PATH=\"/var/cfengine/lib-twin\" $(sys.cf_twin) -f \"$(sys.workdir)/inputs/update.cf\" ; $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "LD_LIBRARY_PATH=\"$(sys.workdir)/lib-twin\" $(sys.cf_twin) -f \"$(sys.workdir)/inputs/update.cf\" ; $(sys.cf_agent) -Dcf_execd_initiated";
     !(windows|hpux|aix).!cfengine_3_5::
       exec_command => "$(sys.cf_agent) -f \"$(sys.update_policy_path)\" ; $(sys.cf_agent) -Dcf_execd_initiated";
 

--- a/update.cf
+++ b/update.cf
@@ -54,7 +54,7 @@ bundle common update_def
       "masterfiles_perms_mode" string => "0600",
       handle => "common_def_vars_masterfiles_perms_mode";
 
-      "dc_scripts" string => "/var/cfengine/httpd/htdocs/api/dc-scripts",
+      "dc_scripts" string => "$(sys.workdir)/httpd/htdocs/api/dc-scripts",
       comment => "Directory where design center scripts are located on Enterprise Hub";
 
       "DCWORKFLOW" string => "/opt/cfengine",
@@ -100,7 +100,7 @@ bundle common update_def
       # you can also request it from the command line with
       # -Dcfengine_internal_masterfiles_update
 
-      # NOTE THAT ENABLING THIS BY DEFAULT *WILL* OVERWRITE THE HUB'S /var/cfengine/masterfiles
+      # NOTE THAT ENABLING THIS BY DEFAULT *WILL* OVERWRITE THE HUB'S $(sys.workdir)/masterfiles
 
       #"cfengine_internal_masterfiles_update" expression => "enterprise.!(cfengine_3_4|cfengine_3_5)";
       "cfengine_internal_masterfiles_update" expression => "!any";

--- a/update/update_bins.cf
+++ b/update/update_bins.cf
@@ -31,11 +31,11 @@ bundle agent cfe_internal_update_bins
       comment => "The Cfengine binary updates directory on the policy host",
       handle => "cfe_internal_update_bins_vars_master_software_location";
 
-      "local_software_dir"        string => translatepath("$(sys.workdir)/software_updates/$(sys.flavour)_$(sys.arch)"),
+      "local_software_dir"        string => translatepath("/var/cfengine/software_updates/$(sys.flavour)_$(sys.arch)"),
       comment => "Local directory containing binary updates for this host",
       handle => "cfe_internal_update_bins_vars_local_software_dir";
 
-      "local_update_log_dir"      string => translatepath("$(sys.workdir)/software_updates/update_log"),
+      "local_update_log_dir"      string => translatepath("/var/cfengine/software_updates/update_log"),
       comment => "Local directory to store update log for this host",
       handle => "cfe_internal_update_bins_vars_local_update_log_dir";
 
@@ -317,7 +317,7 @@ bundle agent cfe_internal_update_bins
       classes => u_if_repaired("bin_newpkg");
 
     !am_policy_hub.enterprise.trigger_upgrade.(cfengine_3_6_0|cfengine_3_6_1)::
-      "$(sys.workdir)/bin/cf-upgrade"
+      "$(sys.bindir)/cf-upgrade"
       handle => "cfe_internal_update_bins_files_cf_upgrade_i386_linux",
       copy_from => u_rcp("$(master_software_location)/cf-upgrade/linux.i386/cf-upgrade", @(update_def.policy_servers)),
       perms => u_m("0755"),
@@ -409,7 +409,7 @@ bundle edit_line u_backup_script
       "#!/bin/sh
 
 if [ $(const.dollar)1 = \"BACKUP\" ]; then
- tar cfz $(const.dollar)2 /var/cfengine > /dev/null
+ tar cfz $(const.dollar)2 $(sys.workdir) > /dev/null
 fi
 if [ $(const.dollar)1 = \"RESTORE\" ]; then
  tar xfz $(const.dollar)2
@@ -420,7 +420,7 @@ fi";
       "#!/bin/sh
 
 if [ $(const.dollar)1 = \"BACKUP\" ]; then
- tar cf $(const.dollar)2 /var/cfengine;  gzip $(const.dollar)2
+ tar cf $(const.dollar)2 $(sys.workdir);  gzip $(const.dollar)2
 fi
 if [ $(const.dollar)1 = \"RESTORE\" ]; then
  gunzip $(const.dollar)2.gz; tar xf $(const.dollar)2
@@ -453,7 +453,7 @@ bundle edit_line u_install_script
 pkgname=`pkginfo -d $(const.dollar)1 | awk '{print $(const.dollar)2}'`
 /usr/sbin/pkgrm -n -a $(cfe_internal_update_bins.admin_file) $pkgname
 /usr/sbin/pkgadd -n -a $(cfe_internal_update_bins.admin_file) -d $(const.dollar)1 all
-/var/cfengine/bin/cf-execd || true
+$(sys.workdir)/bin/cf-execd || true
 exit 0";
 
 }

--- a/update/update_policy.cf
+++ b/update/update_policy.cf
@@ -122,7 +122,7 @@ bundle agent cfe_internal_update_policy
     any::
 
       "have_ppkeys"   expression => fileexists("$(ppkeys_file)"),
-      comment => "Check for /var/cfengine/ppkeys/localhost.pub",
+      comment => "Check for $(sys.workdir)/ppkeys/localhost.pub",
       handle => "cfe_internal_update_policy_classes_have_ppkeys";
 
       "local_files_ok" expression => fileexists("$(file_check)"),

--- a/update/update_processes.cf
+++ b/update/update_processes.cf
@@ -18,7 +18,7 @@ bundle common cfe_internal_process_knowledge
   vars:
     !windows.cfengine_3_5::
 
-      "bindir"      string => "/var/cfengine/bin",
+      "bindir"      string => "$(sys.workdir)/bin",
       comment => "Use a real path";
 
     !windows.!cfengine_3_5::
@@ -113,7 +113,7 @@ bundle agent maintain_cfe_hub_process
     am_policy_hub::
 
       "files_ok" expression => fileexists("$(file_check)"),
-      comment => "Check for /var/cfengine/inputs/promises.cf",
+      comment => "Check for $(sys.workdir)/inputs/promises.cf",
       handle => "cfe_internal_maintain_cfe_hub_process_classes_files_ok";
 
       #


### PR DESCRIPTION
This commit changes most occurances of `/var/cfengine` with `$(sys.workdir)` and `/var/cfengine/bin` with `$(sys.bindir)`. This helps make the default policy set more useful when users compile cfengine with alternate workdir paths.