### PR TITLE
Fix: Mission Portal Port Assignment from policy

### DIFF
--- a/cfe_internal/CFE_hub_specific.cf
+++ b/cfe_internal/CFE_hub_specific.cf
@@ -249,7 +249,7 @@ bundle edit_line change_port(p)
 
     any::
 
-      "^Listen(\s+)(?!$(p)).*"
+      "^\s*Listen(\s+)(?!$(p)$).*$"
       comment => "Match Listen line and replace",
       handle => "cfe_internal_change_port_edit_line_listen_port",
       replace_with => value("Listen $(p)");
@@ -274,16 +274,16 @@ bundle edit_line change_appsettings(p)
   replace_patterns:
 
     original_config::
-      "\s+\$config\['rest_server'\]\s+=\s+\$protocol\s+\.\s+\$_SERVER\['SERVER_NAME'\]\s+\.\s+'(?!/api).*"
+      "\s+\$config\['rest_server'\]\s+=\s+\$protocol\s+\.\s+'localhost'\s+\.\s+'(?!/api).*"
       comment => "Match a line and replace",
       handle => "cfe_internal_change_appsetting_replace_patterns_port_80",
-      replace_with => value("    $config['rest_server'] = $protocol . $_SERVER['SERVER_NAME'] . '/api';");
+      replace_with => value("    $config['rest_server'] = $protocol . 'localhost' . '/api';");
 
     !original_config::
-      "\s+\$config\['rest_server'\]\s+=\s+\$protocol\s+\.\s+\$_SERVER\['SERVER_NAME'\]\s+\.\s+'(?!\:$(p)/api).*"
+      "\s+\$config\['rest_server'\]\s+=\s+\$protocol\s+\.\s+'localhost'\s+\.\s+'(?!\:$(p)/api).*"
       comment => "Match a line and replace",
       handle => "cfe_internal_change_appsetting_replace_patterns_not_port_80",
-      replace_with => value("    $config['rest_server'] = $protocol . $_SERVER['SERVER_NAME'] . ':$(p)/api';");
+      replace_with => value("    $config['rest_server'] = $protocol . 'localhost' . ':$(p)/api';");
 
 }
 


### PR DESCRIPTION
The policy to ensure the correct port is set if not 80 needed to be updated
after the appsettings.php file was updated.

Additionally this fixes a weak regular expression when setting the port in
httpd.conf

Ref: https://dev.cfengine.com/issues/6910