### PR TITLE
Fix paths to ping on FreeBSD 9.3 and later

### DIFF
--- a/lib/3.5/paths.cf
+++ b/lib/3.5/paths.cf
@@ -158,13 +158,18 @@ bundle common paths
       "path[grep]"     string => "/usr/bin/grep";
       "path[ls]"       string => "/bin/ls";
       "path[netstat]"  string => "/usr/bin/netstat";
-      "path[ping]"     string => "/usr/bin/ping";
       "path[perl]"     string => "/usr/bin/perl";
       "path[printf]"   string => "/usr/bin/printf";
       "path[sed]"      string => "/usr/bin/sed";
       "path[sort]"     string => "/usr/bin/sort";
       "path[tr]"       string => "/usr/bin/tr";
       "path[realpath]" string => "/bin/realpath";
+
+    netbsd|freebsd.!(freebsd_9_3|freebsd_10|freebsd_11)::
+      "path[ping]"     string => "/usr/bin/ping";
+      
+    freebsd_9_3|freebsd_10|freebsd_11::
+      "path[ping]"     string => "/sbin/ping";
 
     freebsd::
 

--- a/lib/3.6/paths.cf
+++ b/lib/3.6/paths.cf
@@ -207,7 +207,6 @@ bundle common paths
     freebsd_9_3|freebsd_10|freebsd_11::
   
       "path[ping]"     string => "/sbin/ping";
-      "path[sysctl]"   string => "/sbin/sysctl";
   
     freebsd|netbsd::
 

--- a/lib/3.6/paths.cf
+++ b/lib/3.6/paths.cf
@@ -194,13 +194,21 @@ bundle common paths
       "path[grep]"     string => "/usr/bin/grep";
       "path[ls]"       string => "/bin/ls";
       "path[netstat]"  string => "/usr/bin/netstat";
-      "path[ping]"     string => "/usr/bin/ping";
       "path[perl]"     string => "/usr/bin/perl";
       "path[printf]"   string => "/usr/bin/printf";
       "path[sed]"      string => "/usr/bin/sed";
       "path[sort]"     string => "/usr/bin/sort";
       "path[tr]"       string => "/usr/bin/tr";
 
+    freebsd.!(freebsd_9_3|freebsd_10|freebsd_11)|netbsd|openbsd::
+  
+      "path[ping]"     string => "/usr/bin/ping";
+  
+    freebsd_9_3|freebsd_10|freebsd_11::
+  
+      "path[ping]"     string => "/sbin/ping";
+      "path[sysctl]"   string => "/sbin/sysctl";
+  
     freebsd|netbsd::
 
       "path[cksum]"    string => "/usr/bin/cksum";

--- a/lib/3.7/paths.cf
+++ b/lib/3.7/paths.cf
@@ -194,13 +194,20 @@ bundle common paths
       "path[grep]"     string => "/usr/bin/grep";
       "path[ls]"       string => "/bin/ls";
       "path[netstat]"  string => "/usr/bin/netstat";
-      "path[ping]"     string => "/usr/bin/ping";
       "path[perl]"     string => "/usr/bin/perl";
       "path[printf]"   string => "/usr/bin/printf";
       "path[sed]"      string => "/usr/bin/sed";
       "path[sort]"     string => "/usr/bin/sort";
       "path[tr]"       string => "/usr/bin/tr";
 
+    freebsd.!(freebsd_9_3|freebsd_10|freebsd_11)|netbsd|openbsd::
+  
+      "path[ping]"     string => "/usr/bin/ping";
+      
+    freebsd_9_3|freebsd_10|freebsd_11::
+  
+      "path[ping]"     string => "/sbin/ping";  
+  
     freebsd|netbsd::
 
       "path[cksum]"    string => "/usr/bin/cksum";

--- a/lib/3.7/paths.cf
+++ b/lib/3.7/paths.cf
@@ -207,7 +207,6 @@ bundle common paths
     freebsd_9_3|freebsd_10|freebsd_11::
   
       "path[ping]"     string => "/sbin/ping";
-      "path[sysctl]"   string => "/sbin/sysctl";
   
     freebsd|netbsd::
 

--- a/lib/3.7/paths.cf
+++ b/lib/3.7/paths.cf
@@ -206,7 +206,8 @@ bundle common paths
       
     freebsd_9_3|freebsd_10|freebsd_11::
   
-      "path[ping]"     string => "/sbin/ping";  
+      "path[ping]"     string => "/sbin/ping";
+      "path[sysctl]"   string => "/sbin/sysctl";
   
     freebsd|netbsd::
 


### PR DESCRIPTION
FreeBSD relocated ping to /sbin/ping for 9.3, 10.x, 11.x. 

Will need to be addressed again in June when 8.4 goes end of life, reversing behavior so that `/sbin/ping` is the default and `/usr/bin/ping` is the exception for FreeBSD.