### PR TITLE
Redmine #6865: Fix broken package promise as a result of inventory.

### DIFF
--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -468,7 +468,7 @@ body package_method inventory_apt_get(update_interval)
       package_list_update_ifelapsed => $(update_interval);
 
       # Target a specific release, such as backports
-      package_add_command => "$(debian_knowledge.call_apt_get) $(debian_knowledge.dpkg_options) --yes install";
+      package_add_command => "$(debian_knowledge.call_apt_get) --help >/dev/null 2>&1 ; /bin/true";
       package_list_update_command => "$(debian_knowledge.call_apt_get) update";
       package_delete_command => "$(debian_knowledge.call_apt_get) $(debian_knowledge.dpkg_options) --yes -q remove";
       package_update_command =>  "$(debian_knowledge.call_apt_get) $(debian_knowledge.dpkg_options) --yes install";
@@ -519,7 +519,7 @@ body package_method inventory_yum_rpm(update_interval)
       package_patch_version_regex => "$(redhat_knowledge.patch_version_regex)";
       package_patch_arch_regex    => "$(redhat_knowledge.patch_arch_regex)";
 
-      package_add_command    => "$(redhat_knowledge.call_yum) $(redhat_knowledge.yum_options) -y install";
+      package_add_command    => "$(redhat_knowledge.call_yum) --help >/dev/null 2>&1 ; /bin/true";
       package_update_command => "$(redhat_knowledge.call_yum) $(redhat_knowledge.yum_options) -y update";
       package_patch_command  => "$(redhat_knowledge.call_yum) $(redhat_knowledge.yum_options) -y update";
       package_delete_command => "$(rpm_knowledge.call_rpm) -e --nodeps";
@@ -576,7 +576,7 @@ body package_method inventory_zypper(update_interval)
       package_patch_version_regex => "[^|]+\|[^|]+\|\s+([^\s]+).*";
 
       package_name_convention => "$(name)";
-      package_add_command => "$(suse_knowledge.call_zypper) --non-interactive install";
+      package_add_command => "$(suse_knowledge.call_zypper) --help >/dev/null 2>&1 ; /bin/true";
       package_delete_command => "$(suse_knowledge.call_zypper) --non-interactive remove --force-resolution";
       package_update_command => "$(suse_knowledge.call_zypper) --non-interactive update";
       package_patch_command => "$(suse_knowledge.call_zypper) --non-interactive patch$"; # $ means no args

--- a/tests/acceptance/17_packages/unsafe/package-inventory.cf
+++ b/tests/acceptance/17_packages/unsafe/package-inventory.cf
@@ -1,0 +1,66 @@
+bundle common test_meta
+{
+  vars:
+      "description" string => "Test that package inventory is generated properly using package managers";
+      "story_id" string => "5513";
+      "covers" string => "operational_repaired";
+}
+
+body common control
+{
+    inputs => { "../../dcs.cf.sub",
+                "../../../../$(sys.local_libdir)/stdlib.cf",
+                "../../../../$(sys.local_libdir)/packages.cf",
+                "../../../../inventory/any.cf",
+                "packages-info.cf.sub",
+              };
+    bundlesequence => { default($(this.promise_files)) };
+}
+
+bundle agent init
+{
+  meta:
+      "test_skip_needs_work" string => "!redhat.!debian";
+      # RedHat 4 RPM has a bug which corrupts the RPM DB during our tests, so it is untestable.
+      "test_skip_unsupported" string => "redhat_4";
+
+  methods:
+      "any" usebundle => clear_packages;
+      "any" usebundle => install_package("$(p.name[1])", "$(p.version[1])");
+      "any" usebundle => install_package("$(p.name[3])", "$(p.version[$(p.latest_version)])");
+}
+
+bundle agent test
+{
+  methods:
+      "any" usebundle => inventory_autorun;
+}
+
+bundle agent check
+{
+  vars:
+      "inst" string => "$(sys.workdir)/state/software_packages.csv";
+      "inst_expr" string => "^($(p.name[1])|$(p.name[2])|$(p.name[3])),.*";
+      "inst_matches" int => countlinesmatching("$(inst_expr)", "$(inst)");
+
+      "upd" string => "$(sys.workdir)/state/software_patches_avail.csv";
+      "upd_expr" string => "^($(p.name[1])|$(p.name[2])|$(p.name[3])),.*";
+      "upd_matches" int => countlinesmatching("$(upd_expr)", "$(upd)");
+
+  classes:
+      # Should match all packages except the second one.
+      "inst_ok" expression => strcmp("$(inst_matches)", "2");
+      # Should only match the first package.
+      "upd_ok" expression => strcmp("$(upd_matches)", "1");
+
+      "ok" and => { "inst_ok", "upd_ok" };
+
+  reports:
+    DEBUG::
+      "Install matches: $(inst_matches)";
+      "Update matches: $(upd_matches)";
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}


### PR DESCRIPTION
We don't need to install the package, we only need to make sure that
the package list as been generated. However, we want to include the
package manager name, so that the list of packages is named correctly.
Hence the "<mgr> --help ; /bin/true".