### PR TITLE
Change: Update paths.cf

### DIFF
--- a/lib/3.5/paths.cf
+++ b/lib/3.5/paths.cf
@@ -158,13 +158,18 @@ bundle common paths
       "path[grep]"     string => "/usr/bin/grep";
       "path[ls]"       string => "/bin/ls";
       "path[netstat]"  string => "/usr/bin/netstat";
-      "path[ping]"     string => "/usr/bin/ping";
       "path[perl]"     string => "/usr/bin/perl";
       "path[printf]"   string => "/usr/bin/printf";
       "path[sed]"      string => "/usr/bin/sed";
       "path[sort]"     string => "/usr/bin/sort";
       "path[tr]"       string => "/usr/bin/tr";
       "path[realpath]" string => "/bin/realpath";
+
+    netbsd|freebsd.!(freebsd_9_3|freebsd_10|freebsd_11)::
+      "path[ping]"     string => "/usr/bin/ping";
+      
+    freebsd_9_3|freebsd_10|freebsd_11::
+      "path[ping]"     string => "/sbin/ping";
 
     freebsd::
 

--- a/lib/3.6/paths.cf
+++ b/lib/3.6/paths.cf
@@ -194,13 +194,20 @@ bundle common paths
       "path[grep]"     string => "/usr/bin/grep";
       "path[ls]"       string => "/bin/ls";
       "path[netstat]"  string => "/usr/bin/netstat";
-      "path[ping]"     string => "/usr/bin/ping";
       "path[perl]"     string => "/usr/bin/perl";
       "path[printf]"   string => "/usr/bin/printf";
       "path[sed]"      string => "/usr/bin/sed";
       "path[sort]"     string => "/usr/bin/sort";
       "path[tr]"       string => "/usr/bin/tr";
 
+    freebsd.!(freebsd_9_3|freebsd_10|freebsd_11)|netbsd|openbsd::
+  
+      "path[ping]"     string => "/usr/bin/ping";
+  
+    freebsd_9_3|freebsd_10|freebsd_11::
+  
+      "path[ping]"     string => "/sbin/ping";
+  
     freebsd|netbsd::
 
       "path[cksum]"    string => "/usr/bin/cksum";


### PR DESCRIPTION
Fix path[ping] for FreeBSD 9.3, 10.x, 11.x

(cherry picked from commit c2f10044c4e78223835161fe00dc5ed5ed5e3660)

Conflicts:
lib/3.7/paths.cf Clearly not in the 3.6 branch