### PR TITLE
Improve inline documentation

### DIFF
--- a/lib/3.6/files.cf
+++ b/lib/3.6/files.cf
@@ -415,7 +415,7 @@ bundle edit_line set_variable_values_ini(tab, sectionName)
 # @param sectionName The section in the file within which values should be
 # modified
 #
-# **See also:** `set_variable_values_ini()`
+# **See also:** `manage_variable_values_ini()`
 {
   vars:
       "index" slist => getindices("$(tab)[$(sectionName)]");


### PR DESCRIPTION
Updating a self referential "see also" section to point to something useful.

(cherry picked from commit 9dae71e64c5aeadffcf7c7eeafa27fd4b692aaf9)

Conflicts:
lib/3.7/files.cf