### PR TITLE
Change: Remove def.domain from default acl

### DIFF
--- a/def.cf
+++ b/def.cf
@@ -34,7 +34,7 @@ bundle common def
                            # Note that this:
                            # 1. requires def.domain to be correctly set
                            # 2. will cause a DNS lookup for every access
-                           ".*$(def.domain)",
+                           # ".*$(def.domain)",
 
                            # Assume /16 LAN clients to start with
                            "$(sys.policy_hub)/16",


### PR DESCRIPTION
Accepting def.domain might be insecure and imply performance penalty in form
of DNS lookup. Redmine #5556

(cherry picked from commit d902e8b88b9bb5588814e8b9600126fb0d557c90)