### PR TITLE
Enterprsie reports are accumulated on the client till they are collected by

### DIFF
--- a/cfe_internal/CFE_cfengine.cf
+++ b/cfe_internal/CFE_cfengine.cf
@@ -77,6 +77,12 @@ bundle agent cfe_internal_management
       "any" usebundle => cfe_internal_log_rotation,
       handle => "cfe_internal_management_log_rotation",
       comment => "Rotate CFEngine logs so we dont fill the disk";
+
+    enable_cfe_internal_cleanup_agent_reports::
+      "any" usebundle => cfe_internal_cleanup_agent_reports,
+      handle => "cfe_internal_management_cleanup_agent_reports",
+      comment => "Remove accumulated reports if they grow too large in size";
+
 }
 
 ##################################################################

--- a/def.cf
+++ b/def.cf
@@ -138,6 +138,11 @@ bundle common def
         "$(sys.workdir)/httpd/logs/error_log", # Mission Portal
       };
 
+      "max_client_history_size" -> { "cf-hub", "CFEngine Enterprise" }
+        int => "50M",
+        comment => "The threshold of report diffs which will trigger purging of
+                    diff files.";
+
     enterprise.!am_policy_hub::
       # CFEngine's own log files
       "cfe_log_files" slist => { @(base_log_files), @(enterprise_log_files) };
@@ -225,6 +230,14 @@ bundle common def
       # Enable CFEngine Enterprise HA Policy
       "enable_cfengine_enterprise_hub_ha" expression => "!any";
       #"enable_cfengine_enterprise_hub_ha" expression => "enterprise_edition";
+
+      # Enable cleanup of agent report diffs when they exceed
+      # `def.max_client_history_size`
+      "enable_cfe_internal_cleanup_agent_reports" -> { "cf-hub", "CFEngine Enterprise" }
+        expression => "enterprise_edition",
+        comment => "If reports are not collected for an extended period of time
+                    the disk may fill up or cause additional collection
+                    issues.";
 }
 
 bundle common inventory_control

--- a/lib/3.5/cfe_internal.cf
+++ b/lib/3.5/cfe_internal.cf
@@ -75,3 +75,7 @@ bundle common cfengine_enterprise_hub_ha
     "management_bundles"
         slist => { };
 }
+
+bundle agent cfe_internal_cleanup_agent_reports {}
+# @ignore
+# @brief cleanup accumulated agent reports if they grow too large (do not apply for cfengine < 3.6.0)

--- a/lib/3.6/cfe_internal.cf
+++ b/lib/3.6/cfe_internal.cf
@@ -200,3 +200,25 @@ bundle agent cfe_internal_database_cleanup_diagnostics (settings)
       classes => kept_successful_command,
       handle => "cf_database_maintain_diagnostics_$(settings[$(index)][report])";
 }
+
+bundle agent cfe_internal_cleanup_agent_reports
+# @ignore
+# @brief cleanup accumulated agent reports if they grow too large
+{
+  classes:
+      "cfe_internal_purge_diff_reports"
+        expression => isgreaterthan("$(total_report_size)","$(def.max_client_history_size)"),
+        comment => "Determine if the current sum of report diffs exceeds the max desired";
+
+  vars:
+      "report_files" slist => findfiles("$(sys.workdir)/state/diff/*.diff");
+      "reports_size[$(report_files)]" int => filesize("$(report_files)");
+      "tmpmap" slist => maparray("$(this.v)", reports_size);
+      "total_report_size" real => sum(tmpmap);
+
+  files:
+    cfe_internal_purge_diff_reports::
+      "$(report_files)"
+        delete => tidy,
+        handle => "cf_cleanup_agent_reports_$(report_files)";
+}


### PR DESCRIPTION
cf-hub.

In case if not collecting the reports for extended period of time, they may
consume too much space, this policy will purge accumulated "diff" reports if
the exceed 50MB in total size. As the result, report history will become
inconcistent with next successful report collection and cf-hub will go for
rebase query (fetching full state next time). This cleanup apply only to diff
reports which include class, variable, promise execution, software installed,
software patch, lastseen reports.

Redmine: #1150
(cherry picked from commit 65b96a5a28e478a2e68f4d4bbdd899a811563ca1)

Conflicts:
lib/3.7/cfe_internal.cf