### PR TITLE
turn off cleanup of several cf-execd and cf-monitord by default

### DIFF
--- a/cfe_internal/CFE_cfengine.cf
+++ b/cfe_internal/CFE_cfengine.cf
@@ -70,9 +70,12 @@ bundle agent cfe_internal_management
 
     any::
 
-      "any" usebundle => cfe_internal_limit_robot_agents,
-      handle => "cfe_internal_management_limit_cfe_agents",
-      comment => "Manage CFE processes";
+#   NB! On a container host this may kill CFEngine processes inside containers.
+#       See https://dev.cfengine.com/issues/6906
+#
+#      "any" usebundle => cfe_internal_limit_robot_agents,
+#      handle => "cfe_internal_management_limit_cfe_agents",
+#      comment => "Manage CFE processes";
 
       "any" usebundle => cfe_internal_log_rotation,
       handle => "cfe_internal_management_log_rotation",


### PR DESCRIPTION
May kill CFEngine processes inside containers.
Redmine: https://dev.cfengine.com/issues/6906.

This is a workaround, ideal solution is to have a way to filter process in the current namespace (zone/cgroup/etc.).

Consider backport to 3.6.x.