### PR TITLE
Fix: rm_rf_depth should also remove the named directory

### DIFF
--- a/lib/3.5/bundles.cf
+++ b/lib/3.5/bundles.cf
@@ -131,6 +131,9 @@ bundle agent rm_rf_depth(name,depth)
       depth_search => recurse_with_base($(depth)),
       delete => tidy;
 
+      "$(name)/."
+        delete => tidy;
+
     !isdir::
       "$(name)" delete => tidy;
 }

--- a/lib/3.6/bundles.cf
+++ b/lib/3.6/bundles.cf
@@ -156,6 +156,9 @@ bundle agent rm_rf_depth(name,depth)
       depth_search => recurse_with_base($(depth)),
       delete => tidy;
 
+      "$(name)/."
+        delete => tidy;
+
     !isdir::
       "$(name)" delete => tidy;
 }

--- a/lib/3.7/bundles.cf
+++ b/lib/3.7/bundles.cf
@@ -156,6 +156,9 @@ bundle agent rm_rf_depth(name,depth)
       depth_search => recurse_with_base($(depth)),
       delete => tidy;
 
+      "$(name)/."
+        delete => tidy;
+
     !isdir::
       "$(name)" delete => tidy;
 }


### PR DESCRIPTION
Previously it was only removing the contents of the directory.

Ref: https://dev.cfengine.com/issues/7009