### PR TITLE
Change: Replace hard coded time based classes

### DIFF
--- a/def.cf
+++ b/def.cf
@@ -258,7 +258,6 @@ bundle common def
         comment => "If reports are not collected for an extended period of time
                     the disk may fill up or cause additional collection
                     issues.";
-
 }
 
 bundle common inventory_control

--- a/lib/3.6/cfe_internal.cf
+++ b/lib/3.6/cfe_internal.cf
@@ -133,8 +133,12 @@ bundle agent cfe_internal_hub_maintain
                                                      }
                                                     ]');
 
+  classes:
+      "enable_cfe_internal_reporting_database_purge_old_history" -> { "postgres", "CFEngine Enterprise" }
+        expression => "enterprise_edition.Hr00.Min00_05";
+
   methods:
-    Hr00.Min00_05::
+    enable_cfe_internal_reporting_database_purge_old_history::
       "Remove old report history"
       usebundle => cfe_internal_database_cleanup_reports(@(report_settings)),
       action => if_elapsed(5);

--- a/lib/3.7/cfe_internal.cf
+++ b/lib/3.7/cfe_internal.cf
@@ -133,8 +133,12 @@ bundle agent cfe_internal_hub_maintain
                                                      }
                                                     ]');
 
+  classes:
+      "enable_cfe_internal_reporting_database_purge_old_history" -> { "postgres", "CFEngine Enterprise" }
+        expression => "enterprise_edition.Hr00.Min00_05";
+
   methods:
-    Hr00.Min00_05::
+    enable_cfe_internal_reporting_database_purge_old_history::
       "Remove old report history"
       usebundle => cfe_internal_database_cleanup_reports(@(report_settings)),
       action => if_elapsed(5);


### PR DESCRIPTION
Hard coding time based classes makes it difficult to allow policy execution
outside of that window without modifying the policy. This preserves the same
functionality while increasing flexibility which can be useful especially when
troubleshooting.

Ref: https://dev.cfengine.com/issues/7010