### PR TITLE
Change: Stop replace_or_add bundle from adding extra lines

### DIFF
--- a/lib/3.5/files.cf
+++ b/lib/3.5/files.cf
@@ -776,11 +776,11 @@ bundle edit_line replace_or_add(pattern,line)
       "^(?!$(eline)$)$(pattern)$"
       comment => "Replace a pattern here",
       replace_with => value("$(line)"),
-      classes => always("replace_done_$(cline)");
+      classes => scoped_classes_generic("bundle", "replace_$(cline)");
 
   insert_lines:
       "$(line)"
-      ifvarclass => "replace_done_$(cline)";
+      ifvarclass => "replace_$(cline)_reached";
 }
 
 bundle edit_line fstab_option_editor(method, mount, option)

--- a/lib/3.6/files.cf
+++ b/lib/3.6/files.cf
@@ -1038,11 +1038,11 @@ bundle edit_line replace_or_add(pattern,line)
       "^(?!$(eline)$)$(pattern)$"
       comment => "Replace a pattern here",
       replace_with => value("$(line)"),
-      classes => always("replace_done_$(cline)");
+      classes => scoped_classes_generic("bundle", "replace_$(cline)");
 
   insert_lines:
       "$(line)"
-      ifvarclass => "replace_done_$(cline)";
+      ifvarclass => "replace_$(cline)_reached";
 }
 
 bundle edit_line converge(marker, lines)

--- a/lib/3.7/files.cf
+++ b/lib/3.7/files.cf
@@ -1038,11 +1038,11 @@ bundle edit_line replace_or_add(pattern,line)
       "^(?!$(eline)$)$(pattern)$"
       comment => "Replace a pattern here",
       replace_with => value("$(line)"),
-      classes => always("replace_done_$(cline)");
+      classes => scoped_classes_generic("bundle", "replace_$(cline)");
 
   insert_lines:
       "$(line)"
-      ifvarclass => "replace_done_$(cline)";
+      ifvarclass => "replace_$(cline)_reached";
 }
 
 bundle edit_line converge(marker, lines)


### PR DESCRIPTION
Classes defined as the result of a promise outcome are by default namespace
scoped. This causes the classes to live on beyond the individual bundle
activation, resulting in bad behaviour for classes being defined unexpectedly.

Ref: https://dev.cfengine.com/issues/7035

This should be picked to 3.6.x.

Let me know if you think this should be updated to include all classes defined in edit_line bundles or all classes defined using the always classes body in edit_line bundles.