### PR TITLE
Fix package version parsing for pkgin-0.8.0.

### DIFF
--- a/lib/3.5/packages.cf
+++ b/lib/3.5/packages.cf
@@ -1033,8 +1033,8 @@ body package_method smartos
 {
       package_changes => "bulk";
       package_list_command => "/opt/local/bin/pkgin list";
-      package_list_name_regex    => "([^\s]+)\-[0-9]+.*\s";
-      package_list_version_regex => "[^\s]+\-([0-9][^\s]+)\s";
+      package_list_name_regex    => "([^\s]+)\-[0-9][^\s;]+.*[\s;]";
+      package_list_version_regex => "[^\s]+\-([0-9][^\s;]+).*[\s;]";
 
       package_installed_regex => ".*"; # all reported are installed
 

--- a/lib/3.6/packages.cf
+++ b/lib/3.6/packages.cf
@@ -1229,8 +1229,8 @@ body package_method smartos
 {
       package_changes => "bulk";
       package_list_command => "/opt/local/bin/pkgin list";
-      package_list_name_regex    => "([^\s]+)\-[0-9]+.*\s";
-      package_list_version_regex => "[^\s]+\-([0-9][^\s]+)\s";
+      package_list_name_regex    => "([^\s]+)\-[0-9][^\s;]+.*[\s;]";
+      package_list_version_regex => "[^\s]+\-([0-9][^\s;]+).*[\s;]";
 
       package_installed_regex => ".*"; # all reported are installed
 

--- a/lib/3.7/packages.cf
+++ b/lib/3.7/packages.cf
@@ -1229,8 +1229,8 @@ body package_method smartos
 {
       package_changes => "bulk";
       package_list_command => "/opt/local/bin/pkgin list";
-      package_list_name_regex    => "([^\s]+)\-[0-9]+.*\s";
-      package_list_version_regex => "[^\s]+\-([0-9][^\s]+)\s";
+      package_list_name_regex    => "([^\s]+)\-[0-9][^\s;]+.*[\s;]";
+      package_list_version_regex => "[^\s]+\-([0-9][^\s;]+).*[\s;]";
 
       package_installed_regex => ".*"; # all reported are installed
 


### PR DESCRIPTION
Please make this available in 3.6.6. All package operations in the 2014Q4 LTS SmartOS base, standard, minimal and multiarch images are affected.

Pkgin version 0.8.0 and later, when STDOUT is not a terminal separates
the package name/version from the description with a semi-colon. Prior
to 0.8.0 the description was separated by whitespace.

E.g.:

New behavior:

    zsh-5.0.7nb1;The Z shell

Old behavior:

    zsh-5.0.5nb1         The Z shell

This would cause cfengine to interpret the version as `5.0.7nb1;The`.

This backward compatible fix adjusts the package_version_regex for the
`smartos` package method to correctly match the version number.

This fix is demonstrated with the following pcretest session.

* The old regex form is demonstrated first.
  * The new output from pkgin is matched incorrectly.
  * The old output from pkgin is matched correctly.
* The new regex form is demonstrated second.
    * The new output from pkgin is matched correctly.
    * The old output from pkgin is matched correctly.

````
$ pcretest               
PCRE version 8.36 2014-09-26

  re> /([^\s]+)\-([0-9][^\s]+)\s/
data> zsh-5.0.7nb1;The Z shell
 0: zsh-5.0.7nb1;The 
 1: zsh
 2: 5.0.7nb1;The
data> zsh-5.0.5nb1         The Z shell
 0: zsh-5.0.5nb1 
 1: zsh
 2: 5.0.5nb1
data> 
  re> /([^\s]+)\-([0-9a-z.]+)[; ]/
data> zsh-5.0.7nb1;The Z shell
 0: zsh-5.0.7nb1;
 1: zsh
 2: 5.0.7nb1
data> zsh-5.0.5nb1         The Z shell
 0: zsh-5.0.5nb1 
 1: zsh
 2: 5.0.5nb1
data> ^D
````