### PR TITLE
Correct inventory_lslpp() package name regexp

### DIFF
--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -542,7 +542,7 @@ body package_method inventory_lslpp(update_interval)
       package_list_update_ifelapsed => $(update_interval);
 
       package_list_command       => "/usr/bin/lslpp -Lqc"; # list RPMs too
-      package_list_name_regex    => "([^:]+):.*";
+      package_list_name_regex    => ".:+([^:]+):.*";
       package_list_version_regex => "[^:]+:[^:]+:([^:]+):.*";
       package_installed_regex    => "[^:]+:[^:]+:[^:]+:[^:]+:[^:]+:([CA]):.*";
 


### PR DESCRIPTION
The existing regexp is incorrect on AIX resulting in invalid package inventory.

Here is the format for lslpp -Lqc (using bos.64bit as the example.)
`bos.64bit:bos.64bit:6.1.8.0: : :C:F:Base Operating System 64 bit Runtime: : : : : : :0:0:/:1241`
`^^^^^^^^^` - this is hit
Problem: field 1 is not the package name. Field 1 is the package family. Thus, another example...
`sysmgt.websm:sysmgt.websm.apps:6.1.8.0: : :C:F:Web-based System Manager Applications: : : : : : :0:0:/:1241`
`sysmgt.websm:sysmgt.websm.diag:6.1.0.0: : :C: :Web-based System Manager Diagnostic Applications : : : : : : :1:0:/:0748`
The packages are `sysmgt.websm.apps` and `sysmgt.websm.diag` - however the existing regexp inventories both as `sysmgt.websm` with contradicting versions. This also occurs in bos.* and sys.* families. 

Note; this may misbehave on 5.3 but I do not have any 5.3 to check. If it does, 5.3 should be handled as a more specific class.