### PR TITLE
lib/3.7/files.cf: summarize file_make and file_make_mog with long strings

### DIFF
--- a/lib/3.7/files.cf
+++ b/lib/3.7/files.cf
@@ -2100,6 +2100,15 @@ bundle agent file_make(file, str)
 # and some more text here");
 # ```
 {
+  vars:
+      "len" int => string_length($(str));
+    summarize::
+      "summary" string => format("%s...%s",
+                                string_head($(str), 4),
+                                string_tail($(str), 4));
+  classes:
+      "summarize" expression => isgreaterthan($(len), 12);
+
   files:
       "$(file)"
       create => "true",
@@ -2108,7 +2117,11 @@ bundle agent file_make(file, str)
 
   reports:
     inform_mode|EXTRA::
-      "$(this.bundle): creating $(file) with contents '$(str)'";
+      "$(this.bundle): creating $(file) with contents '$(str)'"
+      ifvarclass => "!summarize";
+
+      "$(this.bundle): creating $(file) with contents '$(summary)'"
+      ifvarclass => "summarize";
 }
 
 bundle agent file_make_mog(file, str, mode, owner, group)
@@ -2127,6 +2140,15 @@ bundle agent file_make_mog(file, str, mode, owner, group)
 # and some more text here", "0644", "root", "root");
 # ```
 {
+  vars:
+      "len" int => string_length($(str));
+    summarize::
+      "summary" string => format("%s...%s",
+                                string_head($(str), 4),
+                                string_tail($(str), 4));
+  classes:
+      "summarize" expression => isgreaterthan($(len), 12);
+
   files:
       "$(file)"
       create => "true",
@@ -2136,7 +2158,11 @@ bundle agent file_make_mog(file, str, mode, owner, group)
 
   reports:
     inform_mode|EXTRA::
-      "$(this.bundle): creating $(file) with contents '$(str)', mode '$(mode)', owner '$(owner)' and group '$(group)'";
+      "$(this.bundle): creating $(file) with contents '$(str)', mode '$(mode)', owner '$(owner)' and group '$(group)'"
+      ifvarclass => "!summarize";
+
+      "$(this.bundle): creating $(file) with contents '$(summary)', mode '$(mode)', owner '$(owner)' and group '$(group)'"
+      ifvarclass => "summarize";
 }
 
 bundle agent file_empty(file)


### PR DESCRIPTION
@nickanderson for your review

I can backport this to 3.6, of course.  It's a pretty trivial change but makes the reports a lot more readable for large strings.