### PR TITLE
Change: Exclude oracle hosts from redhat_pure

### DIFF
--- a/inventory/redhat.cf
+++ b/inventory/redhat.cf
@@ -4,7 +4,7 @@ bundle common inventory_redhat
 # This common bundle is for Red Hat Linux inventory work.
 {
   classes:
-      "redhat_pure" expression => "redhat.!centos",
+      "redhat_pure" expression => "redhat.!centos.!oracle",
       comment => "pure Red Hat",
       meta => { "inventory", "attribute_name=none" };
 


### PR DESCRIPTION
Oracle Enterprise Linux hosts are not pure redhat and should be
excluded.

Ref: https://dev.cfengine.com/issues/7081