### PR TITLE
Add FreeBSD inventory module

### DIFF
--- a/def.cf
+++ b/def.cf
@@ -266,12 +266,19 @@ bundle common inventory_control
 # This common bundle is for controlling whether some inventory bundles
 # are disabled.
 {
-  vars:
+  defaults:
+
       "dmidecoder" string => "/usr/sbin/dmidecode";
       "lldpctl_exec" string => "/usr/bin/lldpctl";
       "lsb_exec" string => "/usr/bin/lsb_release";
       "mtab" string => "/etc/mtab";
       "proc" string => "/proc";
+
+  vars:
+
+    freebsd::
+
+      "dmidecoder" string => "/usr/local/sbin/dmidecode";
 
   classes:
       # setting this disables all the inventory modules except package_refresh
@@ -317,7 +324,7 @@ bundle common inventory_control
       # by default disable the proc inventory if the general
       # inventory is disabled or /proc is missing.  Note that
       # this is typically fast.
-      "disable_inventory_proc" expression => "disable_inventory";
+      "disable_inventory_proc" expression => "disable_inventory|freebsd";
       "disable_inventory_proc" not => isdir($(proc));
 
       # by default don't run the CMDB integration every time, even if

--- a/inventory/freebsd.cf
+++ b/inventory/freebsd.cf
@@ -1,0 +1,6 @@
+bundle common inventory_freebsd
+# @brief FreeBSD inventory bundle
+#
+# This common bundle is for FreeBSD inventory work.
+{
+}

--- a/promises.cf
+++ b/promises.cf
@@ -93,7 +93,7 @@ bundle common inventory
 # Tested to work properly against 3.5.x
 {
   classes:
-      "other_unix_os" expression => "!windows.!macos.!linux";
+      "other_unix_os" expression => "!windows.!macos.!linux.!freebsd";
       "specific_linux_os" expression => "redhat|debian|suse";
 
   vars:
@@ -113,6 +113,9 @@ bundle common inventory
     !cfengine_3_5.macos::
       "inputs" slist => { "inventory/any.cf", "inventory/macos.cf", "inventory/os.cf" };
       "bundles" slist => { "inventory_control", "inventory_any", "inventory_autorun", "inventory_macos", "inventory_os" };
+    !cfengine_3_5.freebsd::
+      "inputs" slist => { "inventory/any.cf", "inventory/freebsd.cf", "inventory/os.cf" };
+      "bundles" slist => { "inventory_control", "inventory_any", "inventory_autorun", "inventory_freebsd", "inventory_os" };
     !cfengine_3_5.linux.!specific_linux_os::
       "inputs" slist => { "inventory/any.cf", "inventory/linux.cf", "inventory/lsb.cf", "inventory/os.cf"};
       "bundles" slist => { "inventory_control", "inventory_any", "inventory_autorun", "inventory_linux", "inventory_lsb", "inventory_os" };


### PR DESCRIPTION
In the inventory_control agent, define default values for dmidecoder,
lldpctl_exec, lsb_exec, mtab and proc and redefine the dmidecoder variable on
freebsd with the correct path to the dmidecode binary

Explicitly define the disable_inventory_proc class on FreeBSD since procfs will
create a /proc directory but none of the files defined in the basefiles slist
exist on FreeBSD