### PR TITLE
Add: IPv4 address inventory

### DIFF
--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -54,6 +54,10 @@ bundle agent inventory_autorun
 
       "loadaverage" usebundle => cfe_autorun_inventory_loadaverage(),
       handle => "cfe_internal_autorun_loadaverage";
+
+      "ipv4 addresses"
+        usebundle => cfe_autorun_inventory_ipv4_addresses,
+        handle => "cfe_internal_autorun_ipv4_addresses";
 }
 
 bundle agent cfe_autorun_inventory_listening_ports
@@ -65,6 +69,32 @@ bundle agent cfe_autorun_inventory_listening_ports
   vars:
       "ports" slist => sort( "mon.listening_ports", "int"),
       meta => { "inventory", "attribute_name=Ports listening" };
+}
+
+bundle agent cfe_autorun_inventory_ipv4_addresses
+# @brief Inventory ipv4 addresses
+# This will filter the loopback address (127.0.0.1, as it is likely not very interesting)
+{
+  vars:
+    "filter_reg"
+      string => "127\.0\.0\.1",
+      comment => "Addresses that match this regular expression will be filtered
+                  from the inventory for ipv4 addresses";
+
+    # Strings are displayed more beautifully in Mission Portal than lists, so
+    # we first generate the list of addresses to be inventoried and then do
+    # inventory using an array.
+    "ipv4_addresses"
+      slist => filter( $(filter_reg), "sys.ip_addresses", "true", "true", 999999999);
+
+    "ipv4[$(ipv4_addresses)]"
+      string => "$(ipv4_addresses)",
+      meta => { "inventory", "attribute_name=IPv4 addresses" };
+
+  reports:
+    DEBUG|DEBUG_cfe_autorun_inventory_ipv4_addresses::
+      "DEBUG $(this.bundle)";
+      "$(const.t)Inventorying: '$(ipv4_addresses)'";
 }
 
 bundle agent cfe_autorun_inventory_disk


### PR DESCRIPTION
Previously this inventory came directly from the agent. However in order to
provide easier user selectable filtering it has moved to policy.

Ref: https://dev.cfengine.com/issues/7097

Should be merged with change to core:
https://github.com/cfengine/core/pull/2163