### PR TITLE
Fix: Errors loading policy from core

### DIFF
--- a/cfe_internal/CFE_cfengine.cf
+++ b/cfe_internal/CFE_cfengine.cf
@@ -17,19 +17,26 @@
 
 bundle agent cfe_internal_management
 {
+  vars:
+    any::
+      "policy[cfe_internal_core_main]"
+        string => "cfe_internal_core_main",
+        comment => "Activate policies related to basic CFEngine operations";
+
+    enterprise_edition::
+      "policy[cfe_internal_enterprise_main]"
+        string => "cfe_internal_enterprise_main",
+        comment => "Activate policies related to CFEngne Enterprise operations";
+
+    any::
+      "bundles" slist => getindices(policy);
+
   methods:
 
       #
       # CFEngine internals
       #
 
-    any::
-      "any"
-        usebundle => "cfe_internal_core_main",
-        comment => "Activate policies related to basic CFEngine operations";
-
-    enterprise_edition::
-      "any"
-        usebundle => "cfe_internal_enterprise_main",
-        comment => "Activate policies related to CFEngne Enterprise operations";
+      "CFEngine_Internals"
+        usebundle => "$(bundles)";
 }

--- a/promises.cf
+++ b/promises.cf
@@ -14,7 +14,6 @@ body common control
                           @(inventory.bundles),
                           def,
                           @(cfengine_enterprise_hub_ha.classification_bundles),
-                          cfe_internal_hub_vars,
 
                           # Design Center
                           cfsketch_run,


### PR DESCRIPTION
This fixes errors that reference bundles that are not loaded by core after
some refactoring to reduce unnecessary policy loading for 3.7.

Ref: https://dev.cfengine.com/issues/7189