### PR TITLE
Fix: Superflous reporting about chkconfig usage

### DIFF
--- a/lib/3.6/services.cf
+++ b/lib/3.6/services.cf
@@ -289,7 +289,7 @@ bundle agent standard_services(service,state)
       "$(this.bundle): Service $(service) unit file is not loaded; doing nothing";
     inform_mode.chkconfig::
       "$(this.bundle): using chkconfig layer to $(state) $(service) (chkconfig mode $(chkconfig_mode))"
-        ifvarclass => "!chkconfig_$(c_service)_unregistered";
+        ifvarclass => "!chkconfig_$(c_service)_unregistered.((start.!onboot)|(stop.onboot))";
     inform_mode.chkconfig::
       "$(this.bundle): skipping chkconfig layer to $(state) $(service) because $(service) is not registered with chkconfig (chkconfig --list $(service))"
         ifvarclass => "chkconfig_$(c_service)_unregistered";


### PR DESCRIPTION
Inform mode is supposed to be for changes, previously a report was printed
each time the agent was run in inform mode even if there were no changes. This
guards the chkconfig report so that it is only printed under the same
conditions that trigger the command to be run.

Ref: https://dev.cfengine.com/issues/7196
(cherry picked from commit 0a7464de936e101a45a0ea6fe373dfbaec9cca9d)

Conflicts:
lib/3.7/services.cf