### PR TITLE
Change: Switch inform_mode reports to DEBUG|DEBUG_bundlename

### DIFF
--- a/cfe_internal/enterprise/CFE_hub_specific.cf
+++ b/cfe_internal/enterprise/CFE_hub_specific.cf
@@ -132,8 +132,7 @@ bundle agent cfe_internal_apache_sudoer
 
   reports:
     (DEBUG|DEBUG_cfe_internal_apache_sudoer).!cfengine_internal_sudoers_editing_enable::
-      "DEBUG $(this.bundle)";
-      "$(const.t)editing of the sudoers file is disabled; the Apache user may not be able to run passwordless sudo cf-runagent";
+      "DEBUG $(this.bundle): editing of the sudoers file is disabled; the Apache user may not be able to run passwordless sudo cf-runagent";
 }
 
 #

--- a/cfe_internal/enterprise/CFE_hub_specific.cf
+++ b/cfe_internal/enterprise/CFE_hub_specific.cf
@@ -131,8 +131,9 @@ bundle agent cfe_internal_apache_sudoer
       edit_line => apache_sudoer;
 
   reports:
-    inform_mode.!cfengine_internal_sudoers_editing_enable::
-      "$(this.bundle): editing of the sudoers file is disabled; the Apache user may not be able to run passwordless sudo cf-runagent";
+    (DEBUG|DEBUG_cfe_internal_apache_sudoer).!cfengine_internal_sudoers_editing_enable::
+      "DEBUG $(this.bundle)";
+      "$(const.t)editing of the sudoers file is disabled; the Apache user may not be able to run passwordless sudo cf-runagent";
 }
 
 #

--- a/cfe_internal/update/cfe_internal_local_git_remote.cf
+++ b/cfe_internal/update/cfe_internal_local_git_remote.cf
@@ -15,11 +15,10 @@ support sketch activation deployments from Mission Portal",
 
   reports:
     DEBUG|DEBUG_cfe_internal_local_git_remote::
-      "DEBUG $(this.bundle)";
-      "$(const.t)set the permissions of the Git clone $(update_def.local_masterfiles_git)"
+      "DEBUG $(this.bundle): set the permissions of the Git clone $(update_def.local_masterfiles_git)"
         ifvarclass => "did_perms_local_git_remote_clone";
 
-      "$(const.t)failed to set the permissions of the Git clone $(update_def.local_masterfiles_git)"
+      "DEBUG $(this.bundle): failed to set the permissions of the Git clone $(update_def.local_masterfiles_git)"
         ifvarclass => "failed_perms_local_git_remote_clone";
 }
 

--- a/cfe_internal/update/cfe_internal_local_git_remote.cf
+++ b/cfe_internal/update/cfe_internal_local_git_remote.cf
@@ -14,10 +14,13 @@ support sketch activation deployments from Mission Portal",
                            "failed_perms_local_git_remote_clone");
 
   reports:
-    inform_mode.did_perms_local_git_remote_clone::
-      "$(this.bundle): set the permissions of the Git clone $(update_def.local_masterfiles_git)";
-    inform_mode.failed_perms_local_git_remote_clone::
-      "$(this.bundle): failed to set the permissions of the Git clone $(update_def.local_masterfiles_git)";
+    DEBUG|DEBUG_cfe_internal_local_git_remote::
+      "DEBUG $(this.bundle)";
+      "$(const.t)set the permissions of the Git clone $(update_def.local_masterfiles_git)"
+        ifvarclass => "did_perms_local_git_remote_clone";
+
+      "$(const.t)failed to set the permissions of the Git clone $(update_def.local_masterfiles_git)"
+        ifvarclass => "failed_perms_local_git_remote_clone";
 }
 
 body depth_search u_cfe_internal_recurse(d)

--- a/controls/3.5/def.cf
+++ b/controls/3.5/def.cf
@@ -209,8 +209,7 @@ bundle common def
 
   reports:
     DEBUG|DEBUG_def::
-      "DEBUG: $(this.bundle)";
-      "$(const.t) Found augments file '$(augments_file)', but augments are not supported in this version"
+      "DEBUG $(this.bundle): Found augments file '$(augments_file)', but augments are not supported in this version"
         ifvarclass => "have_augments_file";
 
 }

--- a/controls/3.5/update_def.cf
+++ b/controls/3.5/update_def.cf
@@ -122,7 +122,6 @@ bundle common update_def
 
   reports:
     DEBUG|DEBUG_def::
-      "DEBUG: $(this.bundle)";
-      "$(const.t) Found augments file '$(augments_file)', but augments are not supported in this version"
+      "DEBUG $(this.bundle): Found augments file '$(augments_file)', but augments are not supported in this version"
         ifvarclass => "have_augments_file";
 }

--- a/controls/3.6/def.cf
+++ b/controls/3.6/def.cf
@@ -298,17 +298,15 @@ bundle common def
 
   reports:
     DEBUG|DEBUG_def::
-      "DEBUG: $(this.bundle)";
+      "DEBUG $(this.bundle): def.json was found at $(augments_file)";
 
-      "$(const.t) def.json was found at $(augments_file)";
-
-      "$(const.t) override request $(override_vars) to '$(override_data_s_$(override_vars))'; new value '$($(override_vars))'"
+      "DEBUG $(this.bundle): override request $(override_vars) to '$(override_data_s_$(override_vars))'; new value '$($(override_vars))'"
       ifvarclass => isvariable("override_data_$(override_vars)");
 
-      "$(const.t) defined class '$(augments_classes_data_keys)' because of classmatch('$(augments[classes][$(augments_classes_data_keys)])')"
+      "DEBUG $(this.bundle): defined class '$(augments_classes_data_keys)' because of classmatch('$(augments[classes][$(augments_classes_data_keys)])')"
       ifvarclass => "$(augments_classes_data_keys)";
 
-      "$(const.t) $(defvars) = $($(defvars))";
+      "DEBUG $(this.bundle): $(defvars) = $($(defvars))";
 }
 
 bundle common inventory_control

--- a/controls/3.6/update_def.cf
+++ b/controls/3.6/update_def.cf
@@ -141,16 +141,15 @@ bundle common update_def
 
   reports:
     DEBUG|DEBUG_update_def::
-      "DEBUG: $(this.bundle)";
-      "$(const.t) override request $(override_vars) to '$(override_data_s_$(override_vars))'; new value '$($(override_vars))'"
+      "DEBUG $(this.bundle): override request $(override_vars) to '$(override_data_s_$(override_vars))'; new value '$($(override_vars))'"
         ifvarclass => isvariable("override_data_$(override_vars)");
 
-      "$(const.t) defined class role/byname $(extra_roles[byname][$(roles_byname_keys)]) because of classmatch('$(roles_byname_keys)')"
+      "DEBUG $(this.bundle): defined class role/byname $(extra_roles[byname][$(roles_byname_keys)]) because of classmatch('$(roles_byname_keys)')"
         ifvarclass => "$(extra_roles[byname][$(roles_byname_keys)])";
 
-      "$(const.t) defined class role/byrole $(roles_byrole_keys) because of classmatch('$(extra_roles[byrole][$(roles_byrole_keys)])')"
+      "DEBUG $(this.bundle): defined class role/byrole $(roles_byrole_keys) because of classmatch('$(extra_roles[byrole][$(roles_byrole_keys)])')"
         ifvarclass => "$(roles_byrole_keys)";
 
-      "$(const.t) override class $(override_classes)";
-      "$(const.t) $(defvars) = $($(defvars))";
+      "DEBUG $(this.bundle): override class $(override_classes)";
+      "DEBUG $(this.bundle): $(defvars) = $($(defvars))";
 }

--- a/controls/3.7/def.cf
+++ b/controls/3.7/def.cf
@@ -297,7 +297,7 @@ bundle common def
                     issues.";
 
   reports:
-    DEBUG|DEBUG_def::
+    DEBUG|DEBUG_$(this.bundle)::
       "DEBUG $(this.bundle): def.json was found at $(augments_file)";
 
       "DEBUG $(this.bundle): override request $(override_vars) to '$(override_data_s_$(override_vars))'; new value '$($(override_vars))'"

--- a/controls/3.7/def.cf
+++ b/controls/3.7/def.cf
@@ -297,7 +297,7 @@ bundle common def
                     issues.";
 
   reports:
-    DEBUG|DEBUG_$(this.bundle)::
+    "DEBUG|DEBUG_$(this.bundle)"::
       "DEBUG $(this.bundle): def.json was found at $(augments_file)";
 
       "DEBUG $(this.bundle): override request $(override_vars) to '$(override_data_s_$(override_vars))'; new value '$($(override_vars))'"

--- a/controls/3.7/def.cf
+++ b/controls/3.7/def.cf
@@ -298,17 +298,15 @@ bundle common def
 
   reports:
     DEBUG|DEBUG_def::
-      "DEBUG: $(this.bundle)";
+      "DEBUG $(this.bundle): def.json was found at $(augments_file)";
 
-      "$(const.t) def.json was found at $(augments_file)";
-
-      "$(const.t) override request $(override_vars) to '$(override_data_s_$(override_vars))'; new value '$($(override_vars))'"
+      "DEBUG $(this.bundle): override request $(override_vars) to '$(override_data_s_$(override_vars))'; new value '$($(override_vars))'"
       ifvarclass => isvariable("override_data_$(override_vars)");
 
-      "$(const.t) defined class '$(augments_classes_data_keys)' because of classmatch('$(augments[classes][$(augments_classes_data_keys)])')"
+      "DEBUG $(this.bundle): defined class '$(augments_classes_data_keys)' because of classmatch('$(augments[classes][$(augments_classes_data_keys)])')"
       ifvarclass => "$(augments_classes_data_keys)";
 
-      "$(const.t) $(defvars) = $($(defvars))";
+      "DEBUG $(this.bundle): $(defvars) = $($(defvars))";
 }
 
 bundle common inventory_control

--- a/controls/3.7/update_def.cf
+++ b/controls/3.7/update_def.cf
@@ -141,16 +141,15 @@ bundle common update_def
 
   reports:
     DEBUG|DEBUG_update_def::
-      "DEBUG: $(this.bundle)";
-      "$(const.t) override request $(override_vars) to '$(override_data_s_$(override_vars))'; new value '$($(override_vars))'"
+      "DEBUG $(this.bundle): override request $(override_vars) to '$(override_data_s_$(override_vars))'; new value '$($(override_vars))'"
         ifvarclass => isvariable("override_data_$(override_vars)");
 
-      "$(const.t) defined class role/byname $(extra_roles[byname][$(roles_byname_keys)]) because of classmatch('$(roles_byname_keys)')"
+      "DEBUG $(this.bundle): defined class role/byname $(extra_roles[byname][$(roles_byname_keys)]) because of classmatch('$(roles_byname_keys)')"
         ifvarclass => "$(extra_roles[byname][$(roles_byname_keys)])";
 
-      "$(const.t) defined class role/byrole $(roles_byrole_keys) because of classmatch('$(extra_roles[byrole][$(roles_byrole_keys)])')"
+      "DEBUG $(this.bundle): defined class role/byrole $(roles_byrole_keys) because of classmatch('$(extra_roles[byrole][$(roles_byrole_keys)])')"
         ifvarclass => "$(roles_byrole_keys)";
 
-      "$(const.t) override class $(override_classes)";
-      "$(const.t) $(defvars) = $($(defvars))";
+      "DEBUG $(this.bundle): override class $(override_classes)";
+      "DEBUG $(this.bundle): $(defvars) = $($(defvars))";
 }

--- a/controls/3.7/update_def.cf
+++ b/controls/3.7/update_def.cf
@@ -140,7 +140,7 @@ bundle common update_def
       #"enable_cfengine_enterprise_hub_ha" expression => "enterprise_edition";
 
   reports:
-    DEBUG|DEBUG_update_def::
+    DEBUG|DEBUG_$(this.bundle)::
       "DEBUG $(this.bundle): override request $(override_vars) to '$(override_data_s_$(override_vars))'; new value '$($(override_vars))'"
         ifvarclass => isvariable("override_data_$(override_vars)");
 

--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -100,8 +100,7 @@ bundle agent cfe_autorun_inventory_ipv4_addresses
 
   reports:
     DEBUG|DEBUG_cfe_autorun_inventory_ipv4_addresses::
-      "DEBUG $(this.bundle)";
-      "$(const.t)Inventorying: '$(ipv4_addresses)'";
+      "DEBUG $(this.bundle): Inventorying '$(ipv4_addresses)'";
 }
 
 bundle agent cfe_autorun_inventory_disk
@@ -296,13 +295,12 @@ bundle agent cfe_autorun_inventory_proc_cpuinfo
 
   reports:
     DEBUG|DEBUG_cfe_autorun_inventory_proc::
-     "DEBUG $(this.bundle)";
-     "$(const.t)cpuinfo[$(default:cfe_autorun_inventory_proc.cpuinfo_array[$(default:cfe_autorun_inventory_proc.cpuinfo_idx)][0])] = $(default:cfe_autorun_inventory_proc.cpuinfo[$(default:cfe_autorun_inventory_proc.cpuinfo_array[$(default:cfe_autorun_inventory_proc.cpuinfo_idx)][0])])";
-     "$(const.t)CPU physical cores: '$(cpuinfo_physical_cores)'"
+     "DEBUG $(this.bundle): cpuinfo[$(default:cfe_autorun_inventory_proc.cpuinfo_array[$(default:cfe_autorun_inventory_proc.cpuinfo_idx)][0])] = $(default:cfe_autorun_inventory_proc.cpuinfo[$(default:cfe_autorun_inventory_proc.cpuinfo_array[$(default:cfe_autorun_inventory_proc.cpuinfo_idx)][0])])";
+     "DEBUG $(this.bundle): CPU physical cores: '$(cpuinfo_physical_cores)'"
         ifvarclass => "have_cpuinfo_cpu_cores";
-     "$(const.t)CPU model name: '$(cpuinfo_cpu_model_name)'"
+     "DEBUG $(this.bundle): CPU model name: '$(cpuinfo_cpu_model_name)'"
         ifvarclass => "have_cpuinfo_model_name";
-     "$(const.t)CPU Physical Sockets: '$(cpuinfo_physical_socket_inventory)'";
+     "DEBUG $(this.bundle): CPU Physical Sockets: '$(cpuinfo_physical_socket_inventory)'";
 }
 
 bundle agent cfe_autorun_inventory_cpuinfo
@@ -335,9 +333,8 @@ bundle agent cfe_autorun_inventory_cpuinfo
 
   reports:
     DEBUG|DEBUG_cfe_autorun_inventory_cpuinfo::
-      "DEBUG $(this.bundle)";
-      "$(const.t) CPU model: $(cpu_model)";
-      "$(const.t) CPU physical cores: $(cpuinfo_physical_cores)";
+      "DEBUG $(this.bundle): CPU model: '$(cpu_model)'";
+      "DEBUG $(this.bundle): CPU physical cores: '$(cpuinfo_physical_cores)'";
 }
 
 bundle agent cfe_autorun_inventory_mtab
@@ -515,8 +512,7 @@ bundle agent cfe_autorun_inventory_dmidecode
 
   reports:
     DEBUG|DEBUG_cfe_autorun_inventory_dmidecode::
-      "DEBUG $(this.bundle)";
-      "$(const.t)Obtained $(dmidefs[$(dmivars)]) = '$(dmi[$(dmivars)])'";
+      "DEBUG $(this.bundle): Obtained $(dmidefs[$(dmivars)]) = '$(dmi[$(dmivars)])'";
 }
 
 bundle agent cfe_autorun_inventory_LLDP
@@ -594,11 +590,10 @@ bundle agent cfe_autorun_inventory_packages
 
   reports:
     DEBUG|DEBUG_cfe_autorun_inventory_packages::
-      "DEBUG $(this.bundle)";
-      "$(const.t)refresh interval is $(refresh)";
-      "$(const.t)we have the inventory files."
+      "DEBUG $(this.bundle): refresh interval is $(refresh)";
+      "DEBUG $(this.bundle): we have the inventory files."
         ifvarclass => "have_inventory";
-      "$(const.t)we don't have the inventory files."
+      "DEBUG $(this.bundle): we don't have the inventory files."
         ifvarclass => "!have_inventory";
 }
 
@@ -789,14 +784,13 @@ bundle agent inventory_cmdb_load(file)
 
   reports:
     DEBUG|DEBUG_inventory_cmdb_load::
-      "DEBUG $(this.bundle)";
-      "$(const.t)Got CMDB data from $(file): $(cmdb_string)"
+      "DEBUG $(this.bundle): Got CMDB data from $(file): $(cmdb_string)"
         ifvarclass => "have_cmdb_data";
-      "$(const.t)Got CMDB key = $(vkeys_$(bkeys)), CMDB value = $((vkeys_$(bkeys)))"
+      "DEBUG $(this.bundle): Got CMDB key = $(vkeys_$(bkeys)), CMDB value = $((vkeys_$(bkeys)))"
         ifvarclass => "have_cmdb_data";
-      "$(const.t): Got CMDB class = $(ckeys)"
+      "DEBUG $(this.bundle): Got CMDB class = $(ckeys)"
         ifvarclass => "have_cmdb_data";
-      "$(const.t): Could not read the CMDB data from $(file)"
+      "DEBUG $(this.bundle): Could not read the CMDB data from $(file)"
         ifvarclass => "!have_cmdb_data";
 }
 

--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -514,8 +514,9 @@ bundle agent cfe_autorun_inventory_dmidecode
                                               "system_array");
 
   reports:
-    inform_mode::
-      "$(this.bundle): Obtained $(dmidefs[$(dmivars)]) = '$(dmi[$(dmivars)])'";
+    DEBUG|DEBUG_cfe_autorun_inventory_dmidecode::
+      "DEBUG $(this.bundle)";
+      "$(const.t)Obtained $(dmidefs[$(dmivars)]) = '$(dmi[$(dmivars)])'";
 }
 
 bundle agent cfe_autorun_inventory_LLDP
@@ -592,12 +593,13 @@ bundle agent cfe_autorun_inventory_packages
       action => if_elapsed_day;
 
   reports:
-    inform_mode::
-      "$(this.bundle): refresh interval is $(refresh)";
-    inform_mode.have_inventory::
-      "$(this.bundle): we have the inventory files.";
-    inform_mode.!have_inventory::
-      "$(this.bundle): we don't have the inventory files.";
+    DEBUG|DEBUG_cfe_autorun_inventory_packages::
+      "DEBUG $(this.bundle)";
+      "$(const.t)refresh interval is $(refresh)";
+      "$(const.t)we have the inventory files."
+        ifvarclass => "have_inventory";
+      "$(const.t)we don't have the inventory files."
+        ifvarclass => "!have_inventory";
 }
 
 body package_method inventory_apt_get(update_interval)
@@ -786,13 +788,16 @@ bundle agent inventory_cmdb_load(file)
       "ckeys" slist => getindices("cmdb[classes]");
 
   reports:
-    inform_mode.have_cmdb_data::
-      "$(this.bundle): Got CMDB data from $(file): $(cmdb_string)";
-    verbose_mode.have_cmdb_data::
-      "$(this.bundle): Got CMDB key = $(vkeys_$(bkeys)), CMDB value = $((vkeys_$(bkeys)))";
-      "$(this.bundle): Got CMDB class = $(ckeys)";
-    inform_mode.!have_cmdb_data::
-      "$(this.bundle): Could not read the CMDB data from $(file)";
+    DEBUG|DEBUG_inventory_cmdb_load::
+      "DEBUG $(this.bundle)";
+      "$(const.t)Got CMDB data from $(file): $(cmdb_string)"
+        ifvarclass => "have_cmdb_data";
+      "$(const.t)Got CMDB key = $(vkeys_$(bkeys)), CMDB value = $((vkeys_$(bkeys)))"
+        ifvarclass => "have_cmdb_data";
+      "$(const.t): Got CMDB class = $(ckeys)"
+        ifvarclass => "have_cmdb_data";
+      "$(const.t): Could not read the CMDB data from $(file)"
+        ifvarclass => "!have_cmdb_data";
 }
 
 body copy_from inventory_cmdb_copy_from

--- a/inventory/linux.cf
+++ b/inventory/linux.cf
@@ -59,6 +59,5 @@ bundle common inventory_linux
 
   reports:
     (DEBUG|DEBUG_inventory_linux).has_os_release::
-      "DEBUG $(this.bundle)";
-      "$(const.t)OS release ID = $(os_release_id), OS release version = $(os_release_version)";
+      "DEBUG $(this.bundle): OS release ID = $(os_release_id), OS release version = $(os_release_version)";
 }

--- a/inventory/lsb.cf
+++ b/inventory/lsb.cf
@@ -71,9 +71,12 @@ bundle agent inventory_lsb
       meta => { "inventory", "attribute_name=none" };
 
   reports:
-    inform_mode._inventory_lsb_found::
-      "$(this.bundle): OS = $(os), codename = $(codename), release = $(release), flavor = $(flavor), description = $(description)";
-    verbose_mode._inventory_lsb_found::
-      "$(this.bundle): got $(dim) LSB keys";
-      "$(this.bundle): prepared LSB key $(lsb_keys) = '$(lsb[$(lsb_keys)][1])'";
+    DEBUG|DEBUG_inventory_lsb::
+      "DEBUG $(this.bundle)";
+      "$(const.t)OS = $(os), codename = $(codename), release = $(release), flavor = $(flavor), description = $(description)"
+        ifvarclass => "_inventory_lsb_found";
+      "$(const.t): got $(dim) LSB keys"
+        ifvarclass => "_inventory_lsb_found";
+      "$(const.t): prepared LSB key $(lsb_keys) = '$(lsb[$(lsb_keys)][1])'"
+        ifvarclass => "_inventory_lsb_found";
 }

--- a/inventory/lsb.cf
+++ b/inventory/lsb.cf
@@ -72,11 +72,10 @@ bundle agent inventory_lsb
 
   reports:
     DEBUG|DEBUG_inventory_lsb::
-      "DEBUG $(this.bundle)";
-      "$(const.t)OS = $(os), codename = $(codename), release = $(release), flavor = $(flavor), description = $(description)"
+      "DEBUG $(this.bundle): OS = $(os), codename = $(codename), release = $(release), flavor = $(flavor), description = $(description)"
         ifvarclass => "_inventory_lsb_found";
-      "$(const.t): got $(dim) LSB keys"
+      "DEBUG $(this.bundle): got $(dim) LSB keys"
         ifvarclass => "_inventory_lsb_found";
-      "$(const.t): prepared LSB key $(lsb_keys) = '$(lsb[$(lsb_keys)][1])'"
+      "DEBUG $(this.bundle): prepared LSB key $(lsb_keys) = '$(lsb[$(lsb_keys)][1])'"
         ifvarclass => "_inventory_lsb_found";
 }

--- a/lib/3.5/commands.cf
+++ b/lib/3.5/commands.cf
@@ -67,8 +67,7 @@ bundle agent daemonize(command)
 
   reports:
     DEBUG|DEBUG_daemonize::
-      "DEBUG $(this.bundle)";
-      "$(const.t): This bundle does not support Windows"
+      "DEBUG $(this.bundle): This bundle does not support Windows"
         ifvarclass => "windows";
 }
 

--- a/lib/3.5/commands.cf
+++ b/lib/3.5/commands.cf
@@ -66,8 +66,10 @@ bundle agent daemonize(command)
         contain => in_shell;
 
   reports:
-    windows.(inform_mode|verbose_mode)::
-      "$(this.bundle): This bundle does not support Windows";
+    DEBUG|DEBUG_daemonize::
+      "DEBUG $(this.bundle)";
+      "$(const.t): This bundle does not support Windows"
+        ifvarclass => "windows";
 }
 
 ##-------------------------------------------------------

--- a/lib/3.5/feature.cf
+++ b/lib/3.5/feature.cf
@@ -33,18 +33,19 @@ bundle agent feature
       "_$(off)" string => "off", classes => feature_cancel("$(extract_$(off)[1])");
 
   reports:
-    inform_mode::
-      "$(this.bundle): $(on) => SET class '$(extract_$(on)[2]) for '$(extract_$(on)[1])'"
+    DEBUG|DEBUG_feature::
+      "DEBUG $(this.bundle)";
+      "$(const.t)$(on) => SET class '$(extract_$(on)[2]) for '$(extract_$(on)[1])'"
       ifvarclass => "parsed_$(on)";
 
-      "$(this.bundle): $(off) => UNSET class '$(extract_$(off)[1])'"
+      "$(const.t)$(off) => UNSET class '$(extract_$(off)[1])'"
       ifvarclass => "parsed_$(off)";
 
-      "$(this.bundle): have $(extract_$(on)[2])" ifvarclass => "$(extract_$(on)[2])";
-      "$(this.bundle): have no $(extract_$(on)[2])" ifvarclass => "!$(extract_$(on)[2])";
+      "$(const.t)have $(extract_$(on)[2])" ifvarclass => "$(extract_$(on)[2])";
+      "$(const.t)have no $(extract_$(on)[2])" ifvarclass => "!$(extract_$(on)[2])";
 
-      "$(this.bundle): have $(extract_$(off)[1])" ifvarclass => "$(extract_$(off)[1])";
-      "$(this.bundle): have no $(extract_$(off)[1])" ifvarclass => "!$(extract_$(off)[1])";
+      "$(const.t)have $(extract_$(off)[1])" ifvarclass => "$(extract_$(off)[1])";
+      "$(const.t)have no $(extract_$(off)[1])" ifvarclass => "!$(extract_$(off)[1])";
 }
 
 bundle agent feature_test
@@ -71,11 +72,13 @@ bundle agent feature_test
       "off" slist => classesmatching("feature_unset_.*");
 
   reports:
-      "$(this.bundle): have $(extract_$(on)[2])" ifvarclass => "$(extract_$(on)[2])";
-      "$(this.bundle): have no $(extract_$(on)[2])" ifvarclass => "!$(extract_$(on)[2])";
+    DEBUG|DEBUG_feature_test::
+      "DEBUG $(this.bundle)";
+      "$(const.t)have $(extract_$(on)[2])" ifvarclass => "$(extract_$(on)[2])";
+      "$(const.t)have no $(extract_$(on)[2])" ifvarclass => "!$(extract_$(on)[2])";
 
-      "$(this.bundle): have $(extract_$(off)[1])" ifvarclass => "$(extract_$(off)[1])";
-      "$(this.bundle): have no $(extract_$(off)[1])" ifvarclass => "!$(extract_$(off)[1])";
+      "$(const.t)have $(extract_$(off)[1])" ifvarclass => "$(extract_$(off)[1])";
+      "$(const.t)have no $(extract_$(off)[1])" ifvarclass => "!$(extract_$(off)[1])";
 }
 
 body classes feature_cancel(x)

--- a/lib/3.5/feature.cf
+++ b/lib/3.5/feature.cf
@@ -34,18 +34,17 @@ bundle agent feature
 
   reports:
     DEBUG|DEBUG_feature::
-      "DEBUG $(this.bundle)";
-      "$(const.t)$(on) => SET class '$(extract_$(on)[2]) for '$(extract_$(on)[1])'"
+      "DEBUG $(this.bundle): $(on) => SET class '$(extract_$(on)[2]) for '$(extract_$(on)[1])'"
       ifvarclass => "parsed_$(on)";
 
-      "$(const.t)$(off) => UNSET class '$(extract_$(off)[1])'"
+      "DEBUG $(this.bundle): $(off) => UNSET class '$(extract_$(off)[1])'"
       ifvarclass => "parsed_$(off)";
 
-      "$(const.t)have $(extract_$(on)[2])" ifvarclass => "$(extract_$(on)[2])";
-      "$(const.t)have no $(extract_$(on)[2])" ifvarclass => "!$(extract_$(on)[2])";
+      "DEBUG $(this.bundle): have $(extract_$(on)[2])" ifvarclass => "$(extract_$(on)[2])";
+      "DEBUG $(this.bundle): have no $(extract_$(on)[2])" ifvarclass => "!$(extract_$(on)[2])";
 
-      "$(const.t)have $(extract_$(off)[1])" ifvarclass => "$(extract_$(off)[1])";
-      "$(const.t)have no $(extract_$(off)[1])" ifvarclass => "!$(extract_$(off)[1])";
+      "DEBUG $(this.bundle): have $(extract_$(off)[1])" ifvarclass => "$(extract_$(off)[1])";
+      "DEBUG $(this.bundle): have no $(extract_$(off)[1])" ifvarclass => "!$(extract_$(off)[1])";
 }
 
 bundle agent feature_test
@@ -73,12 +72,11 @@ bundle agent feature_test
 
   reports:
     DEBUG|DEBUG_feature_test::
-      "DEBUG $(this.bundle)";
-      "$(const.t)have $(extract_$(on)[2])" ifvarclass => "$(extract_$(on)[2])";
-      "$(const.t)have no $(extract_$(on)[2])" ifvarclass => "!$(extract_$(on)[2])";
+      "DEBUG $(this.bundle): have $(extract_$(on)[2])" ifvarclass => "$(extract_$(on)[2])";
+      "DEBUG $(this.bundle): have no $(extract_$(on)[2])" ifvarclass => "!$(extract_$(on)[2])";
 
-      "$(const.t)have $(extract_$(off)[1])" ifvarclass => "$(extract_$(off)[1])";
-      "$(const.t)have no $(extract_$(off)[1])" ifvarclass => "!$(extract_$(off)[1])";
+      "DEBUG $(this.bundle): have $(extract_$(off)[1])" ifvarclass => "$(extract_$(off)[1])";
+      "DEBUG $(this.bundle): have no $(extract_$(off)[1])" ifvarclass => "!$(extract_$(off)[1])";
 }
 
 body classes feature_cancel(x)

--- a/lib/3.6/commands.cf
+++ b/lib/3.6/commands.cf
@@ -66,8 +66,9 @@ bundle agent daemonize(command)
         contain => in_shell;
 
   reports:
-    windows.(inform_mode|verbose_mode)::
-      "$(this.bundle): This bundle does not support Windows";
+    DEBUG|DEBUG_daemonize::
+      "DEBUG $(this.bundle): This bundle does not support Windows"
+        ifvarclass => "windows";
 }
 
 ##-------------------------------------------------------

--- a/lib/3.6/feature.cf
+++ b/lib/3.6/feature.cf
@@ -33,18 +33,19 @@ bundle agent feature
       "_$(off)" string => "off", classes => feature_cancel("$(extract_$(off)[1])");
 
   reports:
-    inform_mode::
-      "$(this.bundle): $(on) => SET class '$(extract_$(on)[2]) for '$(extract_$(on)[1])'"
+    DEBUG|DEBUG_feature::
+      "DEBUG $(this.bundle)";
+      "$(const.t)$(on) => SET class '$(extract_$(on)[2]) for '$(extract_$(on)[1])'"
       ifvarclass => "parsed_$(on)";
 
-      "$(this.bundle): $(off) => UNSET class '$(extract_$(off)[1])'"
+      "$(const.t)$(off) => UNSET class '$(extract_$(off)[1])'"
       ifvarclass => "parsed_$(off)";
 
-      "$(this.bundle): have $(extract_$(on)[2])" ifvarclass => "$(extract_$(on)[2])";
-      "$(this.bundle): have no $(extract_$(on)[2])" ifvarclass => "!$(extract_$(on)[2])";
+      "$(const.t)have $(extract_$(on)[2])" ifvarclass => "$(extract_$(on)[2])";
+      "$(const.t)have no $(extract_$(on)[2])" ifvarclass => "!$(extract_$(on)[2])";
 
-      "$(this.bundle): have $(extract_$(off)[1])" ifvarclass => "$(extract_$(off)[1])";
-      "$(this.bundle): have no $(extract_$(off)[1])" ifvarclass => "!$(extract_$(off)[1])";
+      "$(const.t)have $(extract_$(off)[1])" ifvarclass => "$(extract_$(off)[1])";
+      "$(const.t)have no $(extract_$(off)[1])" ifvarclass => "!$(extract_$(off)[1])";
 }
 
 bundle agent feature_test
@@ -71,11 +72,13 @@ bundle agent feature_test
       "off" slist => classesmatching("feature_unset_.*");
 
   reports:
-      "$(this.bundle): have $(extract_$(on)[2])" ifvarclass => "$(extract_$(on)[2])";
-      "$(this.bundle): have no $(extract_$(on)[2])" ifvarclass => "!$(extract_$(on)[2])";
+    DEBUG|DEBUG_feature_test::
+      "DEBUG $(this.bundle)";
+      "$(const.t)have $(extract_$(on)[2])" ifvarclass => "$(extract_$(on)[2])";
+      "$(const.t)have no $(extract_$(on)[2])" ifvarclass => "!$(extract_$(on)[2])";
 
-      "$(this.bundle): have $(extract_$(off)[1])" ifvarclass => "$(extract_$(off)[1])";
-      "$(this.bundle): have no $(extract_$(off)[1])" ifvarclass => "!$(extract_$(off)[1])";
+      "$(const.t)have $(extract_$(off)[1])" ifvarclass => "$(extract_$(off)[1])";
+      "$(const.t)have no $(extract_$(off)[1])" ifvarclass => "!$(extract_$(off)[1])";
 }
 
 body classes feature_cancel(x)

--- a/lib/3.6/feature.cf
+++ b/lib/3.6/feature.cf
@@ -34,18 +34,17 @@ bundle agent feature
 
   reports:
     DEBUG|DEBUG_feature::
-      "DEBUG $(this.bundle)";
-      "$(const.t)$(on) => SET class '$(extract_$(on)[2]) for '$(extract_$(on)[1])'"
+      "DEBUG $(this.bundle): $(on) => SET class '$(extract_$(on)[2]) for '$(extract_$(on)[1])'"
       ifvarclass => "parsed_$(on)";
 
-      "$(const.t)$(off) => UNSET class '$(extract_$(off)[1])'"
+      "DEBUG $(this.bundle): $(off) => UNSET class '$(extract_$(off)[1])'"
       ifvarclass => "parsed_$(off)";
 
-      "$(const.t)have $(extract_$(on)[2])" ifvarclass => "$(extract_$(on)[2])";
-      "$(const.t)have no $(extract_$(on)[2])" ifvarclass => "!$(extract_$(on)[2])";
+      "DEBUG $(this.bundle): have $(extract_$(on)[2])" ifvarclass => "$(extract_$(on)[2])";
+      "DEBUG $(this.bundle): have no $(extract_$(on)[2])" ifvarclass => "!$(extract_$(on)[2])";
 
-      "$(const.t)have $(extract_$(off)[1])" ifvarclass => "$(extract_$(off)[1])";
-      "$(const.t)have no $(extract_$(off)[1])" ifvarclass => "!$(extract_$(off)[1])";
+      "DEBUG $(this.bundle): have $(extract_$(off)[1])" ifvarclass => "$(extract_$(off)[1])";
+      "DEBUG $(this.bundle): have no $(extract_$(off)[1])" ifvarclass => "!$(extract_$(off)[1])";
 }
 
 bundle agent feature_test
@@ -73,12 +72,11 @@ bundle agent feature_test
 
   reports:
     DEBUG|DEBUG_feature_test::
-      "DEBUG $(this.bundle)";
-      "$(const.t)have $(extract_$(on)[2])" ifvarclass => "$(extract_$(on)[2])";
-      "$(const.t)have no $(extract_$(on)[2])" ifvarclass => "!$(extract_$(on)[2])";
+      "DEBUG $(this.bundle): have $(extract_$(on)[2])" ifvarclass => "$(extract_$(on)[2])";
+      "DEBUG $(this.bundle): have no $(extract_$(on)[2])" ifvarclass => "!$(extract_$(on)[2])";
 
-      "$(const.t)have $(extract_$(off)[1])" ifvarclass => "$(extract_$(off)[1])";
-      "$(const.t)have no $(extract_$(off)[1])" ifvarclass => "!$(extract_$(off)[1])";
+      "DEBUG $(this.bundle): have $(extract_$(off)[1])" ifvarclass => "$(extract_$(off)[1])";
+      "DEBUG $(this.bundle): have no $(extract_$(off)[1])" ifvarclass => "!$(extract_$(off)[1])";
 }
 
 body classes feature_cancel(x)

--- a/lib/3.6/files.cf
+++ b/lib/3.6/files.cf
@@ -2028,8 +2028,8 @@ bundle agent file_tidy(file)
       "$(file)" delete => tidy;
 
   reports:
-    inform_mode|EXTRA::
-      "$(this.bundle): deleting $(file) with delete => tidy";
+    DEBUG|DEBUG_file_tidy::
+      "DEBUG $(this.bundle): deleting $(file) with delete => tidy";
 }
 
 bundle agent dir_sync(from, to)
@@ -2051,8 +2051,8 @@ bundle agent dir_sync(from, to)
       copy_from => copyfrom_sync($(from));
 
   reports:
-    inform_mode|EXTRA::
-      "$(this.bundle): copying directory $(from) to $(to)";
+    DEBUG|DEBUG_dir_sync::
+      "DEBUG $(this.bundle): copying directory $(from) to $(to)";
 }
 
 bundle agent file_copy(from, to)
@@ -2072,8 +2072,8 @@ bundle agent file_copy(from, to)
       copy_from => copyfrom_sync($(from));
 
   reports:
-    inform_mode|EXTRA::
-      "$(this.bundle): copying file $(from) to $(to)";
+    DEBUG|DEBUG_file_copy::
+      "DEBUG $(this.bundle): copying file $(from) to $(to)";
 }
 
 body copy_from copyfrom_sync(f)
@@ -2107,8 +2107,8 @@ bundle agent file_make(file, str)
       edit_defaults => empty;
 
   reports:
-    inform_mode|EXTRA::
-      "$(this.bundle): creating $(file) with contents '$(str)'";
+    DEBUG|DEBUG_file_make::
+      "DEBUG $(this.bundle): creating $(file) with contents '$(str)'";
 }
 
 bundle agent file_empty(file)
@@ -2128,8 +2128,8 @@ bundle agent file_empty(file)
       edit_defaults => empty;
 
   reports:
-    inform_mode|EXTRA::
-      "$(this.bundle): creating empty $(file) with 0 size";
+    DEBUG|DEBUG_file_empty::
+      "DEBUG $(this.bundle): creating empty $(file) with 0 size";
 }
 
 bundle agent file_hardlink(target, link)
@@ -2150,8 +2150,8 @@ bundle agent file_hardlink(target, link)
       link_from => linkfrom($(target), "hardlink");
 
   reports:
-    inform_mode|EXTRA::
-      "$(this.bundle): $(link) will be a hard link to $(target)";
+    DEBUG|DEBUG_file_hardlink::
+      "DEBUG $(this.bundle): $(link) will be a hard link to $(target)";
 }
 
 bundle agent file_link(target, link)
@@ -2172,6 +2172,6 @@ bundle agent file_link(target, link)
       link_from => linkfrom($(target), "symlink");
 
   reports:
-    inform_mode|EXTRA::
-      "$(this.bundle): $(link) will be a symlink to $(target)";
+    DEBUG|DEBUG_file_link::
+      "DEBUG $(this.bundle): $(link) will be a symlink to $(target)";
 }

--- a/lib/3.6/packages.cf
+++ b/lib/3.6/packages.cf
@@ -2115,6 +2115,7 @@ bundle agent package_specific(package_name, desired, package_version, package_ar
       package_method => generic;
 
   reports:
-    (inform_mode||verbose_mode).filebased.!suse.!debian.!redhat.!aix.!solaris_pkgadd::
-      "$(this.bundle): sorry, can't do file-based installs on $(sys.os)";
+    DEBUG|DEBUG_package_specific::
+      "DEBUG $(this.bundle): sorry, can't do file-based installs on $(sys.os)"
+        ifvarclass => "filebased.!suse.!debian.!redhat.!aix.!solaris_pkgadd";
 }

--- a/lib/3.6/services.cf
+++ b/lib/3.6/services.cf
@@ -283,22 +283,27 @@ bundle agent standard_services(service,state)
       "classic" usebundle => classic_services($(service), $(state));
 
   reports:
-    inform_mode.systemd::
-      "$(this.bundle): using systemd layer to $(state) $(service)";
-    inform_mode.systemd.!service_loaded::
-      "$(this.bundle): Service $(service) unit file is not loaded; doing nothing";
-    inform_mode.chkconfig::
-      "$(this.bundle): using chkconfig layer to $(state) $(service) (chkconfig mode $(chkconfig_mode))"
-        ifvarclass => "!chkconfig_$(c_service)_unregistered";
-    inform_mode.chkconfig::
-      "$(this.bundle): skipping chkconfig layer to $(state) $(service) because $(service) is not registered with chkconfig (chkconfig --list $(service))"
-        ifvarclass => "chkconfig_$(c_service)_unregistered";
-    inform_mode.sysvservice::
-      "$(this.bundle): using System V service / Upstart layer to $(state) $(service)";
-    inform_mode.smf::
-      "$(this.bundle): using Solaris SMF to $(state) $(service) (svcadm mode $(svcadm_mode))";
-    inform_mode.fallback::
-      "$(this.bundle): falling back to classic_services to $(state) $(service)";
+    DEBUG|DEBUG_standard_services::
+      "DEBUG $(this.bundle): using systemd layer to $(state) $(service)"
+        ifvarclass => "systemd";
+
+      "DEBUG $(this.bundle): Service $(service) unit file is not loaded; doing nothing"
+        ifvarclass => "systemd.!service_loaded";
+
+      "DEBUG $(this.bundle): using chkconfig layer to $(state) $(service) (chkconfig mode $(chkconfig_mode))"
+        ifvarclass => "chkconfig.!chkconfig_$(c_service)_unregistered";
+
+      "DEBUG $(this.bundle): skipping chkconfig layer to $(state) $(service) because $(service) is not registered with chkconfig (chkconfig --list $(service))"
+        ifvarclass => "chkconfig.chkconfig_$(c_service)_unregistered";
+
+      "DEBUG $(this.bundle): using System V service / Upstart layer to $(state) $(service)"
+        ifvarclass => "sysvservice";
+
+      "DEBUG $(this.bundle): using Solaris SMF to $(state) $(service) (svcadm mode $(svcadm_mode))"
+        ifvarclass => "smf";
+
+      "DEBUG $(this.bundle): falling back to classic_services to $(state) $(service)"
+        ifvarclass => "fallback";
 }
 
 bundle agent classic_services(service,state)
@@ -905,49 +910,49 @@ bundle agent classic_services(service,state)
                         canonify("$(inits)_set"));
 
   reports:
-    inform_mode::
-      "$(this.bundle): Using init system $(inits)"
+    DEBUG|DEBUG_classic_services::
+      "DEBUG $(this.bundle): Using init system $(inits)"
       ifvarclass => and(canonify("$(inits)_set"));
 
-      "$(this.bundle): No init system is set, using $(default[init])"
+      "DEBUG $(this.bundle): No init system is set, using $(default[init])"
       ifvarclass => "no_inits_set";
 
-      "$(this.bundle): The service $(service) needs to be started"
+      "DEBUG $(this.bundle): The service $(service) needs to be started"
       ifvarclass => and(canonify("start_$(service)"));
 
-      "$(this.bundle): The service pattern is provided: $(pattern[$(service)])"
+      "DEBUG $(this.bundle): The service pattern is provided: $(pattern[$(service)])"
       ifvarclass => and(isvariable("pattern[$(service)]"));
 
-      "$(this.bundle): The default service pattern was used: $(default[pattern])"
+      "DEBUG $(this.bundle): The default service pattern was used: $(default[pattern])"
       ifvarclass => not(isvariable("pattern[$(service)]"));
 
-      "$(this.bundle): The stopcommand is provided: $(stopcommand[$(service)])"
+      "DEBUG $(this.bundle): The stopcommand is provided: $(stopcommand[$(service)])"
       ifvarclass => and(isvariable("stopcommand[$(service)]"));
 
-      "$(this.bundle): The stopcommand is NOT provided, using default"
+      "DEBUG $(this.bundle): The stopcommand is NOT provided, using default"
       ifvarclass => not(isvariable("stopcommand[$(service)]"));
 
-      "$(this.bundle): The startcommand is provided: $(startcommand[$(service)])"
+      "DEBUG $(this.bundle): The startcommand is provided: $(startcommand[$(service)])"
       ifvarclass => and(isvariable("startcommand[$(service)]"));
 
-      "$(this.bundle): The startcommand is NOT provided, using default"
+      "DEBUG $(this.bundle): The startcommand is NOT provided, using default"
       ifvarclass => not(isvariable("startcommand[$(service)]"));
 
-      "$(this.bundle): The restartcommand is provided: $(restartcommand[$(service)])"
+      "DEBUG $(this.bundle): The restartcommand is provided: $(restartcommand[$(service)])"
       ifvarclass => and(isvariable("restartcommand[$(service)]"));
 
-      "$(this.bundle): The restartcommand is NOT provided, using default"
+      "DEBUG $(this.bundle): The restartcommand is NOT provided, using default"
       ifvarclass => not(isvariable("restartcommand[$(service)]"));
 
-      "$(this.bundle): The reloadcommand is provided: $(reloadcommand[$(service)])"
+      "DEBUG $(this.bundle): The reloadcommand is provided: $(reloadcommand[$(service)])"
       ifvarclass => and(isvariable("reloadcommand[$(service)]"));
 
-      "$(this.bundle): The reloadcommand is NOT provided, using default"
+      "DEBUG $(this.bundle): The reloadcommand is NOT provided, using default"
       ifvarclass => not(isvariable("reloadcommand[$(service)]"));
 
-      "$(this.bundle): The baseinit is provided: $(baseinit[$(service)])"
+      "DEBUG $(this.bundle): The baseinit is provided: $(baseinit[$(service)])"
       ifvarclass => and(isvariable("baseinit[$(service)]"));
 
-      "$(this.bundle): The baseinit is NOT provided, using default"
+      "DEBUG $(this.bundle): The baseinit is NOT provided, using default"
       ifvarclass => not(isvariable("baseinit[$(service)]"));
 }

--- a/lib/3.6/vcs.cf
+++ b/lib/3.6/vcs.cf
@@ -289,8 +289,8 @@ bundle agent git(repo_path, subcmd, args)
 # @param args a single string of arguments to pass
 #
 # This bundle will drop privileges if running as root (uid 0) and the
-# repository is owned by a different user. Use `inform_mode` (from the
-# command line, `-I`) to see every Git command it runs.
+# repository is owned by a different user. Use `DEBUG` or `DEBUG_git` classes (from the
+# command line, `--define DEBUG` or `--define DEBUG_git`) to see every Git command it runs.
 #
 # **Example:**
 #
@@ -338,9 +338,10 @@ bundle agent git(repo_path, subcmd, args)
       contain => in_dir( $(repo_path) );
 
   reports:
-    inform_mode.am_root.need_to_drop::
-      "$(this.bundle): with dropped privileges to uid '$(repo_uid)' and gid '$(repo_gid)', in directory '$(repo_path)', running Git command '$(oneliner) $(subcmd) $(args)'";
+    DEBUG|DEBUG_git::
+      "DEBUG $(this.bundle): with dropped privileges to uid '$(repo_uid)' and gid '$(repo_gid)', in directory '$(repo_path)', running Git command '$(oneliner) $(subcmd) $(args)'"
+        ifvarclass => "am_root.need_to_drop";
 
-    inform_mode.(!am_root|!need_to_drop)::
-      "$(this.bundle): with current privileges, in directory '$(repo_path)', running Git command '$(oneliner) $(subcmd) $(args)'";
+      "DEBUG $(this.bundle): with current privileges, in directory '$(repo_path)', running Git command '$(oneliner) $(subcmd) $(args)'"
+        ifvarclass => "!am_root|!need_to_drop";
 }

--- a/lib/3.7/commands.cf
+++ b/lib/3.7/commands.cf
@@ -39,7 +39,7 @@
 # the online docs
 #
 
-# For CFEngine Core: 3.7.0 to 3.7.x
+# For CFEngine Core: 3.6.0 to 3.6.x
 # Commands bodies
 
 ###################################################
@@ -66,8 +66,9 @@ bundle agent daemonize(command)
         contain => in_shell;
 
   reports:
-    windows.(inform_mode|verbose_mode)::
-      "$(this.bundle): This bundle does not support Windows";
+    DEBUG|DEBUG_daemonize::
+      "DEBUG $(this.bundle): This bundle does not support Windows"
+        ifvarclass => "windows";
 }
 
 ##-------------------------------------------------------

--- a/lib/3.7/commands.cf
+++ b/lib/3.7/commands.cf
@@ -39,7 +39,7 @@
 # the online docs
 #
 
-# For CFEngine Core: 3.6.0 to 3.6.x
+# For CFEngine Core: 3.7.0 to 3.7.x
 # Commands bodies
 
 ###################################################
@@ -66,7 +66,7 @@ bundle agent daemonize(command)
         contain => in_shell;
 
   reports:
-    DEBUG|DEBUG_daemonize::
+    DEBUG|DEBUG_$(this.bundle)::
       "DEBUG $(this.bundle): This bundle does not support Windows"
         ifvarclass => "windows";
 }

--- a/lib/3.7/feature.cf
+++ b/lib/3.7/feature.cf
@@ -33,18 +33,19 @@ bundle agent feature
       "_$(off)" string => "off", classes => feature_cancel("$(extract_$(off)[1])");
 
   reports:
-    inform_mode::
-      "$(this.bundle): $(on) => SET class '$(extract_$(on)[2]) for '$(extract_$(on)[1])'"
+    DEBUG|DEBUG_feature::
+      "DEBUG $(this.bundle)";
+      "$(const.t)$(on) => SET class '$(extract_$(on)[2]) for '$(extract_$(on)[1])'"
       ifvarclass => "parsed_$(on)";
 
-      "$(this.bundle): $(off) => UNSET class '$(extract_$(off)[1])'"
+      "$(const.t)$(off) => UNSET class '$(extract_$(off)[1])'"
       ifvarclass => "parsed_$(off)";
 
-      "$(this.bundle): have $(extract_$(on)[2])" ifvarclass => "$(extract_$(on)[2])";
-      "$(this.bundle): have no $(extract_$(on)[2])" ifvarclass => "!$(extract_$(on)[2])";
+      "$(const.t)have $(extract_$(on)[2])" ifvarclass => "$(extract_$(on)[2])";
+      "$(const.t)have no $(extract_$(on)[2])" ifvarclass => "!$(extract_$(on)[2])";
 
-      "$(this.bundle): have $(extract_$(off)[1])" ifvarclass => "$(extract_$(off)[1])";
-      "$(this.bundle): have no $(extract_$(off)[1])" ifvarclass => "!$(extract_$(off)[1])";
+      "$(const.t)have $(extract_$(off)[1])" ifvarclass => "$(extract_$(off)[1])";
+      "$(const.t)have no $(extract_$(off)[1])" ifvarclass => "!$(extract_$(off)[1])";
 }
 
 bundle agent feature_test
@@ -71,11 +72,13 @@ bundle agent feature_test
       "off" slist => classesmatching("feature_unset_.*");
 
   reports:
-      "$(this.bundle): have $(extract_$(on)[2])" ifvarclass => "$(extract_$(on)[2])";
-      "$(this.bundle): have no $(extract_$(on)[2])" ifvarclass => "!$(extract_$(on)[2])";
+    DEBUG|DEBUG_feature_test::
+      "DEBUG $(this.bundle)";
+      "$(const.t)have $(extract_$(on)[2])" ifvarclass => "$(extract_$(on)[2])";
+      "$(const.t)have no $(extract_$(on)[2])" ifvarclass => "!$(extract_$(on)[2])";
 
-      "$(this.bundle): have $(extract_$(off)[1])" ifvarclass => "$(extract_$(off)[1])";
-      "$(this.bundle): have no $(extract_$(off)[1])" ifvarclass => "!$(extract_$(off)[1])";
+      "$(const.t)have $(extract_$(off)[1])" ifvarclass => "$(extract_$(off)[1])";
+      "$(const.t)have no $(extract_$(off)[1])" ifvarclass => "!$(extract_$(off)[1])";
 }
 
 body classes feature_cancel(x)

--- a/lib/3.7/feature.cf
+++ b/lib/3.7/feature.cf
@@ -34,18 +34,17 @@ bundle agent feature
 
   reports:
     DEBUG|DEBUG_feature::
-      "DEBUG $(this.bundle)";
-      "$(const.t)$(on) => SET class '$(extract_$(on)[2]) for '$(extract_$(on)[1])'"
+      "DEBUG $(this.bundle): $(on) => SET class '$(extract_$(on)[2]) for '$(extract_$(on)[1])'"
       ifvarclass => "parsed_$(on)";
 
-      "$(const.t)$(off) => UNSET class '$(extract_$(off)[1])'"
+      "DEBUG $(this.bundle): $(off) => UNSET class '$(extract_$(off)[1])'"
       ifvarclass => "parsed_$(off)";
 
-      "$(const.t)have $(extract_$(on)[2])" ifvarclass => "$(extract_$(on)[2])";
-      "$(const.t)have no $(extract_$(on)[2])" ifvarclass => "!$(extract_$(on)[2])";
+      "DEBUG $(this.bundle): have $(extract_$(on)[2])" ifvarclass => "$(extract_$(on)[2])";
+      "DEBUG $(this.bundle): have no $(extract_$(on)[2])" ifvarclass => "!$(extract_$(on)[2])";
 
-      "$(const.t)have $(extract_$(off)[1])" ifvarclass => "$(extract_$(off)[1])";
-      "$(const.t)have no $(extract_$(off)[1])" ifvarclass => "!$(extract_$(off)[1])";
+      "DEBUG $(this.bundle): have $(extract_$(off)[1])" ifvarclass => "$(extract_$(off)[1])";
+      "DEBUG $(this.bundle): have no $(extract_$(off)[1])" ifvarclass => "!$(extract_$(off)[1])";
 }
 
 bundle agent feature_test
@@ -73,12 +72,11 @@ bundle agent feature_test
 
   reports:
     DEBUG|DEBUG_feature_test::
-      "DEBUG $(this.bundle)";
-      "$(const.t)have $(extract_$(on)[2])" ifvarclass => "$(extract_$(on)[2])";
-      "$(const.t)have no $(extract_$(on)[2])" ifvarclass => "!$(extract_$(on)[2])";
+      "DEBUG $(this.bundle): have $(extract_$(on)[2])" ifvarclass => "$(extract_$(on)[2])";
+      "DEBUG $(this.bundle): have no $(extract_$(on)[2])" ifvarclass => "!$(extract_$(on)[2])";
 
-      "$(const.t)have $(extract_$(off)[1])" ifvarclass => "$(extract_$(off)[1])";
-      "$(const.t)have no $(extract_$(off)[1])" ifvarclass => "!$(extract_$(off)[1])";
+      "DEBUG $(this.bundle): have $(extract_$(off)[1])" ifvarclass => "$(extract_$(off)[1])";
+      "DEBUG $(this.bundle): have no $(extract_$(off)[1])" ifvarclass => "!$(extract_$(off)[1])";
 }
 
 body classes feature_cancel(x)

--- a/lib/3.7/feature.cf
+++ b/lib/3.7/feature.cf
@@ -33,7 +33,7 @@ bundle agent feature
       "_$(off)" string => "off", classes => feature_cancel("$(extract_$(off)[1])");
 
   reports:
-    DEBUG|DEBUG_feature::
+    DEBUG|DEBUG_$(this.bundle)::
       "DEBUG $(this.bundle): $(on) => SET class '$(extract_$(on)[2]) for '$(extract_$(on)[1])'"
       ifvarclass => "parsed_$(on)";
 
@@ -71,7 +71,7 @@ bundle agent feature_test
       "off" slist => classesmatching("feature_unset_.*");
 
   reports:
-    DEBUG|DEBUG_feature_test::
+    DEBUG|DEBUG_$(this.bundle)::
       "DEBUG $(this.bundle): have $(extract_$(on)[2])" ifvarclass => "$(extract_$(on)[2])";
       "DEBUG $(this.bundle): have no $(extract_$(on)[2])" ifvarclass => "!$(extract_$(on)[2])";
 

--- a/lib/3.7/files.cf
+++ b/lib/3.7/files.cf
@@ -2028,7 +2028,7 @@ bundle agent file_tidy(file)
       "$(file)" delete => tidy;
 
   reports:
-    DEBUG|DEBUG_file_tidy::
+    DEBUG|DEBUG_$(this.bundle)::
       "DEBUG $(this.bundle): deleting $(file) with delete => tidy";
 }
 
@@ -2051,7 +2051,7 @@ bundle agent dir_sync(from, to)
       copy_from => copyfrom_sync($(from));
 
   reports:
-    DEBUG|DEBUG_dir_sync::
+    DEBUG|DEBUG_$(this.bundle)::
       "DEBUG $(this.bundle): copying directory $(from) to $(to)";
 }
 
@@ -2072,7 +2072,7 @@ bundle agent file_copy(from, to)
       copy_from => copyfrom_sync($(from));
 
   reports:
-    DEBUG|DEBUG_file_copy::
+    DEBUG|DEBUG_$(this.bundle)::
       "DEBUG $(this.bundle): copying file $(from) to $(to)";
 }
 
@@ -2116,7 +2116,7 @@ bundle agent file_make(file, str)
       edit_defaults => empty;
 
   reports:
-    DEBUG|DEBUG_file_make::
+    DEBUG|DEBUG_$(this.bundle)::
       "DEBUG $(this.bundle): creating $(file) with contents '$(str)'"
       ifvarclass => "!summarize";
 
@@ -2157,7 +2157,7 @@ bundle agent file_make_mog(file, str, mode, owner, group)
       edit_defaults => empty;
 
   reports:
-    DEBUG|DEBUG_file_make_mog::
+    DEBUG|DEBUG_$(this.bundle)::
       "DEBUG $(this.bundle): creating $(file) with contents '$(str)', mode '$(mode)', owner '$(owner)' and group '$(group)'"
       ifvarclass => "!summarize";
 
@@ -2182,7 +2182,7 @@ bundle agent file_empty(file)
       edit_defaults => empty;
 
   reports:
-    DEBUG|DEBUG_file_empty::
+    DEBUG|DEBUG_$(this.bundle)::
       "DEBUG $(this.bundle): creating empty $(file) with 0 size";
 }
 
@@ -2204,7 +2204,7 @@ bundle agent file_hardlink(target, link)
       link_from => linkfrom($(target), "hardlink");
 
   reports:
-    DEBUG|DEBUG_file_hardlink::
+    DEBUG|DEBUG_$(this.bundle)::
       "DEBUG $(this.bundle): $(link) will be a hard link to $(target)";
 }
 
@@ -2226,6 +2226,6 @@ bundle agent file_link(target, link)
       link_from => linkfrom($(target), "symlink");
 
   reports:
-    DEBUG|DEBUG_file_link::
+    DEBUG|DEBUG_$(this.bundle)::
       "DEBUG $(this.bundle): $(link) will be a symlink to $(target)";
 }

--- a/lib/3.7/files.cf
+++ b/lib/3.7/files.cf
@@ -2028,8 +2028,8 @@ bundle agent file_tidy(file)
       "$(file)" delete => tidy;
 
   reports:
-    inform_mode|EXTRA::
-      "$(this.bundle): deleting $(file) with delete => tidy";
+    DEBUG|DEBUG_file_tidy::
+      "DEBUG $(this.bundle): deleting $(file) with delete => tidy";
 }
 
 bundle agent dir_sync(from, to)
@@ -2051,8 +2051,8 @@ bundle agent dir_sync(from, to)
       copy_from => copyfrom_sync($(from));
 
   reports:
-    inform_mode|EXTRA::
-      "$(this.bundle): copying directory $(from) to $(to)";
+    DEBUG|DEBUG_dir_sync::
+      "DEBUG $(this.bundle): copying directory $(from) to $(to)";
 }
 
 bundle agent file_copy(from, to)
@@ -2072,8 +2072,8 @@ bundle agent file_copy(from, to)
       copy_from => copyfrom_sync($(from));
 
   reports:
-    inform_mode|EXTRA::
-      "$(this.bundle): copying file $(from) to $(to)";
+    DEBUG|DEBUG_file_copy::
+      "DEBUG $(this.bundle): copying file $(from) to $(to)";
 }
 
 body copy_from copyfrom_sync(f)
@@ -2116,11 +2116,11 @@ bundle agent file_make(file, str)
       edit_defaults => empty;
 
   reports:
-    inform_mode|EXTRA::
-      "$(this.bundle): creating $(file) with contents '$(str)'"
+    DEBUG|DEBUG_file_make::
+      "DEBUG $(this.bundle): creating $(file) with contents '$(str)'"
       ifvarclass => "!summarize";
 
-      "$(this.bundle): creating $(file) with contents '$(summary)'"
+      "DEBUG $(this.bundle): creating $(file) with contents '$(summary)'"
       ifvarclass => "summarize";
 }
 
@@ -2157,11 +2157,11 @@ bundle agent file_make_mog(file, str, mode, owner, group)
       edit_defaults => empty;
 
   reports:
-    inform_mode|EXTRA::
-      "$(this.bundle): creating $(file) with contents '$(str)', mode '$(mode)', owner '$(owner)' and group '$(group)'"
+    DEBUG|DEBUG_file_make_mog::
+      "DEBUG $(this.bundle): creating $(file) with contents '$(str)', mode '$(mode)', owner '$(owner)' and group '$(group)'"
       ifvarclass => "!summarize";
 
-      "$(this.bundle): creating $(file) with contents '$(summary)', mode '$(mode)', owner '$(owner)' and group '$(group)'"
+      "DEBUG $(this.bundle): creating $(file) with contents '$(summary)', mode '$(mode)', owner '$(owner)' and group '$(group)'"
       ifvarclass => "summarize";
 }
 
@@ -2182,8 +2182,8 @@ bundle agent file_empty(file)
       edit_defaults => empty;
 
   reports:
-    inform_mode|EXTRA::
-      "$(this.bundle): creating empty $(file) with 0 size";
+    DEBUG|DEBUG_file_empty::
+      "DEBUG $(this.bundle): creating empty $(file) with 0 size";
 }
 
 bundle agent file_hardlink(target, link)
@@ -2204,8 +2204,8 @@ bundle agent file_hardlink(target, link)
       link_from => linkfrom($(target), "hardlink");
 
   reports:
-    inform_mode|EXTRA::
-      "$(this.bundle): $(link) will be a hard link to $(target)";
+    DEBUG|DEBUG_file_hardlink::
+      "DEBUG $(this.bundle): $(link) will be a hard link to $(target)";
 }
 
 bundle agent file_link(target, link)
@@ -2226,6 +2226,6 @@ bundle agent file_link(target, link)
       link_from => linkfrom($(target), "symlink");
 
   reports:
-    inform_mode|EXTRA::
-      "$(this.bundle): $(link) will be a symlink to $(target)";
+    DEBUG|DEBUG_file_link::
+      "DEBUG $(this.bundle): $(link) will be a symlink to $(target)";
 }

--- a/lib/3.7/packages.cf
+++ b/lib/3.7/packages.cf
@@ -2115,6 +2115,7 @@ bundle agent package_specific(package_name, desired, package_version, package_ar
       package_method => generic;
 
   reports:
-    (inform_mode||verbose_mode).filebased.!suse.!debian.!redhat.!aix.!solaris_pkgadd::
-      "$(this.bundle): sorry, can't do file-based installs on $(sys.os)";
+    DEBUG|DEBUG_package_specific::
+      "DEBUG $(this.bundle): sorry, can't do file-based installs on $(sys.os)"
+        ifvarclass => "filebased.!suse.!debian.!redhat.!aix.!solaris_pkgadd";
 }

--- a/lib/3.7/packages.cf
+++ b/lib/3.7/packages.cf
@@ -2115,7 +2115,7 @@ bundle agent package_specific(package_name, desired, package_version, package_ar
       package_method => generic;
 
   reports:
-    DEBUG|DEBUG_package_specific::
+    DEBUG|DEBUG_$(this.bundle)::
       "DEBUG $(this.bundle): sorry, can't do file-based installs on $(sys.os)"
         ifvarclass => "filebased.!suse.!debian.!redhat.!aix.!solaris_pkgadd";
 }

--- a/lib/3.7/services.cf
+++ b/lib/3.7/services.cf
@@ -905,49 +905,49 @@ bundle agent classic_services(service,state)
                         canonify("$(inits)_set"));
 
   reports:
-    inform_mode::
-      "$(this.bundle): Using init system $(inits)"
+    DEBUG|DEBUG_classic_services::
+      "DEBUG $(this.bundle): Using init system $(inits)"
       ifvarclass => and(canonify("$(inits)_set"));
 
-      "$(this.bundle): No init system is set, using $(default[init])"
+      "DEBUG $(this.bundle): No init system is set, using $(default[init])"
       ifvarclass => "no_inits_set";
 
-      "$(this.bundle): The service $(service) needs to be started"
+      "DEBUG $(this.bundle): The service $(service) needs to be started"
       ifvarclass => and(canonify("start_$(service)"));
 
-      "$(this.bundle): The service pattern is provided: $(pattern[$(service)])"
+      "DEBUG $(this.bundle): The service pattern is provided: $(pattern[$(service)])"
       ifvarclass => and(isvariable("pattern[$(service)]"));
 
-      "$(this.bundle): The default service pattern was used: $(default[pattern])"
+      "DEBUG $(this.bundle): The default service pattern was used: $(default[pattern])"
       ifvarclass => not(isvariable("pattern[$(service)]"));
 
-      "$(this.bundle): The stopcommand is provided: $(stopcommand[$(service)])"
+      "DEBUG $(this.bundle): The stopcommand is provided: $(stopcommand[$(service)])"
       ifvarclass => and(isvariable("stopcommand[$(service)]"));
 
-      "$(this.bundle): The stopcommand is NOT provided, using default"
+      "DEBUG $(this.bundle): The stopcommand is NOT provided, using default"
       ifvarclass => not(isvariable("stopcommand[$(service)]"));
 
-      "$(this.bundle): The startcommand is provided: $(startcommand[$(service)])"
+      "DEBUG $(this.bundle): The startcommand is provided: $(startcommand[$(service)])"
       ifvarclass => and(isvariable("startcommand[$(service)]"));
 
-      "$(this.bundle): The startcommand is NOT provided, using default"
+      "DEBUG $(this.bundle): The startcommand is NOT provided, using default"
       ifvarclass => not(isvariable("startcommand[$(service)]"));
 
-      "$(this.bundle): The restartcommand is provided: $(restartcommand[$(service)])"
+      "DEBUG $(this.bundle): The restartcommand is provided: $(restartcommand[$(service)])"
       ifvarclass => and(isvariable("restartcommand[$(service)]"));
 
-      "$(this.bundle): The restartcommand is NOT provided, using default"
+      "DEBUG $(this.bundle): The restartcommand is NOT provided, using default"
       ifvarclass => not(isvariable("restartcommand[$(service)]"));
 
-      "$(this.bundle): The reloadcommand is provided: $(reloadcommand[$(service)])"
+      "DEBUG $(this.bundle): The reloadcommand is provided: $(reloadcommand[$(service)])"
       ifvarclass => and(isvariable("reloadcommand[$(service)]"));
 
-      "$(this.bundle): The reloadcommand is NOT provided, using default"
+      "DEBUG $(this.bundle): The reloadcommand is NOT provided, using default"
       ifvarclass => not(isvariable("reloadcommand[$(service)]"));
 
-      "$(this.bundle): The baseinit is provided: $(baseinit[$(service)])"
+      "DEBUG $(this.bundle): The baseinit is provided: $(baseinit[$(service)])"
       ifvarclass => and(isvariable("baseinit[$(service)]"));
 
-      "$(this.bundle): The baseinit is NOT provided, using default"
+      "DEBUG $(this.bundle): The baseinit is NOT provided, using default"
       ifvarclass => not(isvariable("baseinit[$(service)]"));
 }

--- a/lib/3.7/services.cf
+++ b/lib/3.7/services.cf
@@ -905,7 +905,7 @@ bundle agent classic_services(service,state)
                         canonify("$(inits)_set"));
 
   reports:
-    DEBUG|DEBUG_classic_services::
+    DEBUG|DEBUG_$(this.bundle)::
       "DEBUG $(this.bundle): Using init system $(inits)"
       ifvarclass => and(canonify("$(inits)_set"));
 

--- a/lib/3.7/vcs.cf
+++ b/lib/3.7/vcs.cf
@@ -289,8 +289,8 @@ bundle agent git(repo_path, subcmd, args)
 # @param args a single string of arguments to pass
 #
 # This bundle will drop privileges if running as root (uid 0) and the
-# repository is owned by a different user. Use `inform_mode` (from the
-# command line, `-I`) to see every Git command it runs.
+# repository is owned by a different user. Use `DEBUG` or `DEBUG_git` classes (from the
+# command line, `--define DEBUG` or `--define DEBUG_git`) to see every Git command it runs.
 #
 # **Example:**
 #
@@ -338,9 +338,10 @@ bundle agent git(repo_path, subcmd, args)
       contain => in_dir( $(repo_path) );
 
   reports:
-    inform_mode.am_root.need_to_drop::
-      "$(this.bundle): with dropped privileges to uid '$(repo_uid)' and gid '$(repo_gid)', in directory '$(repo_path)', running Git command '$(oneliner) $(subcmd) $(args)'";
+    DEBUG|DEBUG_git::
+      "DEBUG $(this.bundle): with dropped privileges to uid '$(repo_uid)' and gid '$(repo_gid)', in directory '$(repo_path)', running Git command '$(oneliner) $(subcmd) $(args)'"
+        ifvarclass => "am_root.need_to_drop";
 
-    inform_mode.(!am_root|!need_to_drop)::
-      "$(this.bundle): with current privileges, in directory '$(repo_path)', running Git command '$(oneliner) $(subcmd) $(args)'";
+      "DEBUG $(this.bundle): with current privileges, in directory '$(repo_path)', running Git command '$(oneliner) $(subcmd) $(args)'"
+        ifvarclass => "!am_root|!need_to_drop";
 }

--- a/lib/3.7/vcs.cf
+++ b/lib/3.7/vcs.cf
@@ -338,7 +338,7 @@ bundle agent git(repo_path, subcmd, args)
       contain => in_dir( $(repo_path) );
 
   reports:
-    DEBUG|DEBUG_git::
+    DEBUG|DEBUG_$(this.bundle)::
       "DEBUG $(this.bundle): with dropped privileges to uid '$(repo_uid)' and gid '$(repo_gid)', in directory '$(repo_path)', running Git command '$(oneliner) $(subcmd) $(args)'"
         ifvarclass => "am_root.need_to_drop";
 

--- a/promises.cf
+++ b/promises.cf
@@ -245,8 +245,7 @@ bundle common cfengine_controls
 
   reports:
     DEBUG|DEBUG_cfengine_controls::
-      "DEBUG $(this.bundle)";
-        "$(const.t)defining inputs='$(inputs)'";
+        "DEBUG $(this.bundle): defining inputs='$(inputs)'";
 }
 
 bundle common services_autorun
@@ -263,8 +262,8 @@ bundle common services_autorun
       "bundles" slist => { "autorun" }; # run loaded bundles
 
   reports:
-    verbose_mode::
-      "$(this.bundle): defining inputs='$(inputs)'";
+    DEBUG|DEBUG_services_autorun::
+      "DEBUG $(this.bundle): defining inputs='$(inputs)'";
 }
 
 


### PR DESCRIPTION
Inform mode is intended to show changes to the system. The current use of
inform_mode throughout the framework can lead to much more information than
needed.

Using a DEBUG|DEBUG_bundlename class guard allows this policy level debug
information to be reported for the entire policy run or for individual bundles
in a consistent way.

Ref: https://dev.cfengine.com/issues/7197