### PR TITLE
Remove log rotation for cf_notkept.log and cf_repaierd.log from 3.7 l…

### DIFF
--- a/controls/3.7/def.cf
+++ b/controls/3.7/def.cf
@@ -180,8 +180,6 @@ bundle common def
 
       "enterprise_log_files" slist =>
       {
-        "$(sys.workdir)/cf_notkept.log",
-        "$(sys.workdir)/cf_repair.log",
         "$(sys.workdir)/state/cf_value.log",
         "$(sys.workdir)/outputs/dc-scripts.log",
       };


### PR DESCRIPTION
…ib as their generation is removed.