### PR TITLE
Fix: standard_services restart when service not running with chkconfig

### DIFF
--- a/lib/3.6/services.cf
+++ b/lib/3.6/services.cf
@@ -262,7 +262,7 @@ bundle agent standard_services(service,state)
       classes => kept_successful_command,
       contain => silent;
 
-    chkconfig.have_init.((start.!running)|((stop|restart|reload).running)).non_disabling::
+    chkconfig.have_init.(((start|restart).!running)|((stop|restart|reload).running)).non_disabling::
       "$(init) $(state)"
       contain => silent;
 


### PR DESCRIPTION
Previously if a service was not running and policy restart was specified the
service would not be restarted (and an inform level report would indicate that
it was). Now the service is restarted even if its not running.

Ref: https://dev.cfengine.com/issues/7258
(cherry picked from commit 1f48a2ca6763fccdd898b9708c6990e61ab3641d)

Conflicts:
CHANGELOG.md
lib/3.7/services.cf
lib/3.8/services.cf