### PR TITLE
Correctly detect if systemd is used in Debian

### DIFF
--- a/inventory/debian.cf
+++ b/inventory/debian.cf
@@ -23,6 +23,11 @@ bundle common inventory_debian
       "mint_release" string  => "$(mint_info[RELEASE][1])" ;
       "mint_codename" string => "$(mint_info[CODENAME][1])" ;
 
+    init_is_link::
+      "init_link_destination"
+          string => filestat("/sbin/init","linktarget") ;
+
+
   classes:
     any::
       "debian_derived_evaluated"
@@ -82,6 +87,12 @@ bundle common inventory_debian
       comment => "derived from Debian",
       meta => { "inventory", "attribute_name=none" };
 
+    init_is_link::
+      "systemd"
+          expression => regcmp("/lib/systemd/systemd",
+                               "$(init_link_destination)"),
+          comment => "Check if /sbin/init links to systemd" ;
+
     any::
       "has_lsb_release" expression => fileexists("/etc/lsb-release"),
       comment => "Check if we can get more info from /etc/lsb-release";
@@ -89,4 +100,7 @@ bundle common inventory_debian
       "has_etc_linuxmint_info" expression => fileexists("/etc/linuxmint/info"),
       comment => "If this is a Linux Mint system, this *could* be available";
 
+      "init_is_link"
+          expression => islink("/sbin/init"),
+          comment => "Detect if init is a link" ;
 }


### PR DESCRIPTION
CFEngine 3.6 tries to understand if a Linux is using systemd as init system
by looking at the contents of /proc/1/cmdline, that happens in
bundle common inventory_linux. That's indeed a smart thing to do but unfortunately
fails on Debian Jessie, where you have:

root@cf-test-v10:~# ls -l /sbin/init
lrwxrwxrwx 1 root root 20 May 26 06:07 /sbin/init -> /lib/systemd/systemd

the pseudo-file in /proc will still report /sbin/init and as a result the systemd
class won't be set. This affects services promises negatively

This patch checks if /sbin/init is a link; if it is, and it points to systemd,
the systemd class is set