### PR TITLE
Add: Comment about RHEL4 dmidecode based inventory

### DIFF
--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -463,6 +463,9 @@ bundle agent cfe_autorun_inventory_dmidecode
     have_dmidecode::
       "decoder" string => "$(inventory_control.dmidecoder)";
 
+
+    # Redhat 4 can support the -s option to dmidecode if
+    # kernel-utils-2.4-15.el4 or greater is installed.
     have_dmidecode.!(redhat_4|redhat_3)::
       "dmi[$(dmivars)]" string => execresult("$(decoder) -s $(dmivars)",
                                              "useshell"),


### PR DESCRIPTION
We learned that there are package updates available that allow RHEL4 to be
used with the dmidecode inventory for redhat 4. Automatically detecting the
package condition is considered too complex compared to the value provided so
it is left for the user to adjust as necessary.

(cherry picked from commit bf02336dc830eb219dacd726a7f9a288d0c64b4f)