### PR TITLE
Add: Negative class guard protecting agent email settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Notable changes to the framework should be documented here
  - Support for def.json class augmentation in update policy
  - Run vacuum operation on postgresql every night as a part of maintenance.
  - Add measure_promise_time action body to lib (3.5, 3.6, 3.7, 3.8)
+ - New negative class guard `cfengine_internal_disable_agent_email` so that
+   agent email can be easily disabled by augmenting def.json
 
 ### Changed
  - Relocate def.cf to controls/VER/

--- a/controls/3.7/cf_execd.cf
+++ b/controls/3.7/cf_execd.cf
@@ -14,7 +14,7 @@ body executor control
 
       splaytime  => "4"; # activity will be spread over this many time slices
 
-    cfengine_internal_agent_email::
+    cfengine_internal_agent_email.!cfengine_internal_disable_agent_email::
       mailto     => "$(def.mailto)";
       mailfrom   => "$(def.mailfrom)";
       smtpserver => "$(def.smtpserver)";

--- a/controls/3.7/def.cf
+++ b/controls/3.7/def.cf
@@ -236,8 +236,9 @@ bundle common def
       # Internal CFEngine log files rotation
       "cfengine_internal_rotate_logs" expression => "any";
 
-      # Enable agent email output (also see mailto, mailfrom and smtpserver)
+      # Enable or disable agent email output (also see mailto, mailfrom and smtpserver)
       "cfengine_internal_agent_email" expression => "any";
+      "cfengine_internal_disable_agent_email" expression => "!any";
 
       # Transfer policies and binaries with encryption
       # you can also request it from the command line with

--- a/example_def.json
+++ b/example_def.json
@@ -10,6 +10,7 @@
         "my_apt_role": [ "debian.*" ],
         "my_debian_role": [ "debian.*" ],
         "services_autorun": [ "any" ],
+        "cfengine_internal_disable_agent_email": [ "enterprise_edition" ]
     },
 
     "inputs": [ "$(sys.libdir)/bundles.cf" ],


### PR DESCRIPTION
This allows agent email to be easily disabled by augmenting def.json.

Ref: https://dev.cfengine.com/issues/7312