### PR TITLE
Add: Support for class augmentation from def.json in update policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Notable changes to the framework should be documented here
  - CHANGELOG.md
  - Support for user specified overring of framework defaults without modifying
    policy supplied by the framework itself (see example_def.json)
+ - Support for def.json class augmentation in update policy
 
 ### Changed
  - Relocate def.cf to controls/VER/

--- a/controls/3.7/update_def.cf
+++ b/controls/3.7/update_def.cf
@@ -5,6 +5,12 @@ bundle common update_def
       "$(override_classes)" expression => "any", meta => { "override" };
 
       "have_augments_file" expression => fileexists($(augments_file)), scope => "bundle";
+      "have_augments_classes" expression => isvariable("augments[classes]"), scope => "bundle";
+
+    have_augments_classes::
+      "$(augments_classes_data_keys)"
+        expression => classmatch("$(augments[classes][$(augments_classes_data_keys)])"),
+        meta => { "augments_class", "derived_from=$(augments_file)" };
 
   vars:
       "current_version" string => "3.7.0";
@@ -20,6 +26,10 @@ bundle common update_def
       "override_classes" slist => getvalues("augments[classes]");
       "override_data_$(override_vars)" data => mergedata("augments[vars][$(override_vars)]");
       "override_data_s_$(override_vars)" string => format("%S", "override_data_$(override_vars)");
+
+    have_augments_classes::
+      "augments_classes_data" data => mergedata("augments[classes]");
+      "augments_classes_data_keys" slist => getindices("augments_classes_data");
 
     any::
       # Begin change


### PR DESCRIPTION
Ref: https://dev.cfengine.com/issues/7315
(cherry picked from commit 9eac03ebf32570765d4ab7642631c7621c635553)

Conflicts:
controls/3.8/update_def.cf