### PR TITLE
Change: autorun related verbose_mode class guards to DEBUG

### DIFF
--- a/lib/3.7/autorun.cf
+++ b/lib/3.7/autorun.cf
@@ -18,6 +18,6 @@ bundle agent autorun
       "autorun" usebundle => $(sorted_bundles);
 
   reports:
-    services_autorun.verbose_mode::
-      "$(this.bundle): found bundle $(sorted_bundles) with tag 'autorun'";
+    DEBUG|DEBUG_autorun|DEBUG_services_autorun::
+      "DEBUG $(this.bundle): found bundle $(sorted_bundles) with tag 'autorun'";
 }

--- a/promises.cf
+++ b/promises.cf
@@ -271,8 +271,12 @@ bundle common services_autorun
       "bundles" slist => { "autorun" }; # run loaded bundles
 
   reports:
-    verbose_mode::
-      "$(this.bundle): defining inputs='$(inputs)'";
+    DEBUG|DEBUG_services_autorun::
+      "DEBUG $(this.bundle): adding input='$(inputs)'"
+        ifvarclass => isvariable("inputs");
+
+      "DEBUG $(this.bundle): adding input='$(found_inputs)'"
+        ifvarclass => isvariable("found_inputs");
 }
 
 


### PR DESCRIPTION
Ref: https://dev.cfengine.com/issues/7317
(cherry picked from commit eadd416d240db867d5c12691e24901f64fb29450)

Conflicts:
lib/3.8/autorun.cf