### PR TITLE
Change: Inform guards to DEBUG

### DIFF
--- a/cfe_internal/enterprise/CFE_hub_specific.cf
+++ b/cfe_internal/enterprise/CFE_hub_specific.cf
@@ -133,7 +133,9 @@ bundle agent cfe_internal_apache_sudoer
 
   reports:
     inform_mode.!cfengine_internal_sudoers_editing_enable::
-      "$(this.bundle): editing of the sudoers file is disabled; the Apache user may not be able to run passwordless sudo cf-runagent";
+    (DEBUG|DEBUG_cfengine_internal_apache_sudoer).!cfengine_internal_sudoers_editing_enable::
+      "DEBUG $(this.bundle): Editing of the sudoers file is disabled. The Apache user
+       may not be able to run passwordless sudo cf-runagent";
 }
 
 #

--- a/cfe_internal/enterprise/CFE_hub_specific.cf
+++ b/cfe_internal/enterprise/CFE_hub_specific.cf
@@ -132,7 +132,6 @@ bundle agent cfe_internal_apache_sudoer
       edit_line => apache_sudoer;
 
   reports:
-    inform_mode.!cfengine_internal_sudoers_editing_enable::
     (DEBUG|DEBUG_cfengine_internal_apache_sudoer).!cfengine_internal_sudoers_editing_enable::
       "DEBUG $(this.bundle): Editing of the sudoers file is disabled. The Apache user
        may not be able to run passwordless sudo cf-runagent";

--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -601,12 +601,12 @@ bundle agent cfe_autorun_inventory_packages
       action => if_elapsed_day;
 
   reports:
-    inform_mode::
-      "$(this.bundle): refresh interval is $(refresh)";
-    inform_mode.have_inventory::
-      "$(this.bundle): we have the inventory files.";
-    inform_mode.!have_inventory::
-      "$(this.bundle): we don't have the inventory files.";
+    DEBUG|DEBUG_cfe_autorun_inventory_packages::
+      "DEBUG $(this.bundle): refresh interval is $(refresh)";
+    (DEBUG|DEBUG_cfe_autorun_inventory_packages).have_inventory::
+      "DEBUG $(this.bundle): we have the inventory files.";
+    (DEBUG|DEBUG_cfe_autorun_inventory_packages).!have_inventory::
+      "DEBUG $(this.bundle): we don't have the inventory files.";
 }
 
 body package_method inventory_apt_get(update_interval)


### PR DESCRIPTION
Inform mode is supposed to inform you of changes to the system, debug is more
appropriate for these informational messages. Also not using the same class as
defined by the log level options to the agent allows us to not be overwhelemed
with output when doing policy debugging.

Ref: https://dev.cfengine.com/issues/7318
(cherry picked from commit e4d4b9daf3ea26c32e9dafca1bf49527a2a2738f)