### PR TITLE
Add: Policy to configure external watchdog for cf-execd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Notable changes to the framework should be documented here
  - Support for user specified overring of framework defaults without modifying
    policy supplied by the framework itself (see example_def.json)
  - Support for def.json class augmentation in update policy
+ - External watchdog policy to ensure that cf-execd is running so that policy will be
+   run on schedule.
+   - This policy configures /etc/cron.d/cfengine_watchdog if /etc/cron.d is
+     present to check for cf-execd once a minute and launch it if it is not
+     running.
+   - The policy can be enabled by defining the class
+     cfe_internal_core_watchdog_enabled, or disabled by defining
+     cfe_internal_core_watchdog_disabled. In the event both classes are defined
+     at the same time enabled wins.
 
 ### Changed
  - Relocate def.cf to controls/VER/

--- a/cfe_internal/core/main.cf
+++ b/cfe_internal/core/main.cf
@@ -15,4 +15,15 @@ bundle agent cfe_internal_core_main
         handle => "cfe_internal_management_log_rotation",
         comment => "Rotate CFEngine logs so we dont fill the disk";
 
+    cfe_internal_core_watchdog_disabled::
+
+      "Disable Core Watchdog"
+        usebundle => cfe_internal_core_watchdog("disabled");
+
+    cfe_internal_core_watchdog_enabled::
+
+      "Enable Core Watchdog"
+        usebundle => cfe_internal_core_watchdog("enabled");
+
+
 }

--- a/cfe_internal/core/watchdog/watchdog.cf
+++ b/cfe_internal/core/watchdog/watchdog.cf
@@ -1,0 +1,66 @@
+bundle agent cfe_internal_core_watchdog(state)
+# @breif Configure external watchdog processes to keep cf-execd running
+# @param state (enabled|disabled) The state to keep the watchdog configuration in
+{
+  meta:
+    "description"
+      string => "Configure external watchdog processes (like cron, or monit) to
+                 make sure that cf-execd is always running";
+
+  classes:
+    any::
+
+      "have_cron_d"
+        expression => isdir("/etc/cron.d");
+
+      "invalid_state"
+        not => regcmp("(enabled|disabled)", "$(state)");
+
+    !invalid_state::
+
+      # Define a class for whatever the desired state is so long as the state is
+      # valid
+
+      "$(state)"
+        expression => "any";
+
+  vars:
+    any::
+
+      "cf_execd"
+        string => ifelse("windows", translatepath('"$(sys.bindir)/cf-execd.exe)"'),
+                         "$(sys.bindir)/cf-execd");
+
+      "template"
+        string => "$(this.promise_dirname)/../../../templates/cfengine_watchdog.mustache";
+
+    have_cron_d::
+
+      "cron_d_watchdog" string => "/etc/cron.d/cfengine_watchdog";
+
+  files:
+
+    enabled.have_cron_d::
+
+      "$(cron_d_watchdog)"
+        create => "true";
+
+      "$(cron_d_watchdog)"
+        edit_defaults => empty,
+        edit_template => "$(template)",
+        handle => "cfe_internal_core_watchdog_enable_cron_d_file_content",
+        template_method => "mustache";
+
+    disabled.have_cron_d::
+
+      "$(cron_d_watchdog)"
+        delete => tidy;
+
+  reports:
+    DEBUG|DEBUG_cfe_internal_core_watchdog::
+      "DEBUG $(this.bundle): Watchdog '$(state)'";
+      "DEBUG $(this.bundle): Have /etc/cron.d/."
+        ifvarclass => "have_cron_d";
+      "DEBUG $(this.bundle): Invalid state '$(state)' only enabled|disabled allowed"
+        ifvarclass => "invalid_state";
+}

--- a/controls/3.7/def.cf
+++ b/controls/3.7/def.cf
@@ -216,7 +216,7 @@ bundle common def
         "$(sys.workdir)/reports",
       };
 
-    # enable_cfengine_enterprise_hub_ha is defined below 
+    # enable_cfengine_enterprise_hub_ha is defined below
     # Disabled by default
 
     enable_cfengine_enterprise_hub_ha::
@@ -238,6 +238,10 @@ bundle common def
 
       # Enable agent email output (also see mailto, mailfrom and smtpserver)
       "cfengine_internal_agent_email" expression => "any";
+
+      # Enable or disable external watchdog to ensure cf-execd is running
+      "cfe_internal_core_watchdog_enabled" expression => "!any";
+      "cfe_internal_core_watchdog_disabled" expression => "!any";
 
       # Transfer policies and binaries with encryption
       # you can also request it from the command line with

--- a/example_def.json
+++ b/example_def.json
@@ -10,6 +10,7 @@
         "my_apt_role": [ "debian.*" ],
         "my_debian_role": [ "debian.*" ],
         "services_autorun": [ "any" ],
+        "cfe_internal_core_watchdog_enabled": [ "any" ],
     },
 
     "inputs": [ "$(sys.libdir)/bundles.cf" ],

--- a/promises.cf
+++ b/promises.cf
@@ -156,6 +156,11 @@ bundle common cfe_internal_inputs
         comment => "This policy produces a text based host info report
                     and serves as a functional example of using mustache templates";
 
+      "input[cfengine_internal_core_watchdog]"
+        string => "cfe_internal/core/watchdog/watchdog.cf",
+        comment => "This policy configures external watchdogs to ensure that
+                    cf-execd is always running.";
+
     enterprise_edition::
 
       "input[enterprise_hub_specific]"

--- a/templates/cfengine_watchdog.mustache
+++ b/templates/cfengine_watchdog.mustache
@@ -1,0 +1,5 @@
+# This file is managed by CFEngine
+{{#classes.have_cron_d}}
+# If cf-execd is executable and if no process matching cf-execd can be found then restart cf-execd
+* * * * * root [ -x {{{vars.cfe_internal_core_watchdog.cf_execd}}} ] && if ! pgrep cf-execd > /dev/null; then {{{vars.cfe_internal_core_watchdog.cf_execd}}} {{{vars.cfe_internal_core_watchdog.cf_execd_options}}}; fi
+{{/classes.have_cron_d}}


### PR DESCRIPTION
Ref: https://dev.cfengine.com/issues/7324
(cherry picked from commit c73e806a1b033c3f2c4b918d3f22e72f611d26b1)

Conflicts:
controls/3.8/def.cf