### PR TITLE
Add: bundle agent sysctl

### DIFF
--- a/lib/3.6/bundles.cf
+++ b/lib/3.6/bundles.cf
@@ -416,3 +416,51 @@ bundle agent run_ifdefined(namespace, mybundle)
     verbose_mode::
       "$(this.bundle): found matching bundles $(bundlesfound) for namespace '$(namespace)' and bundle '$(mybundle)'";
 }
+bundle agent sysctl(settings_array)
+# @brief bundle to set and load sysctl settings
+# @param name of array containing sysctl settings
+#
+# This bundle is a wrapper around set_variable_values 
+# targetting /etc/sysctl.conf. It runs sysctl -p after
+# editing sysctl.conf, to load the new values.
+# Contributed by Aleksey Tsalolikhin, 2 July 2015
+#
+# **Example:**
+#
+# ```cf3
+# bundle agent example
+# {
+#   vars:
+#       "sysctl_settings[vm.swappiness]"         string => "4";
+#       "sysctl_settings[net.core.rmem_max]"     string => "4194304";
+#       "sysctl_settings[net.core.rmem_default]" string => "4194304";
+#
+#   methods:
+#       "Edit and reload /etc/sysctl.conf" usebundle => sysctl("$(this.bundle).sysctl_settings");
+# }
+#
+# ```
+{
+  vars:
+      "sysctl_conf" string => "/etc/sysctl.conf";
+
+    DEBUG|verbose_mode::
+      "keys" slist => getindices("$(settings_array)");
+
+  files:
+      "$(sysctl_conf)"
+        edit_line     => set_variable_values("$(settings_array)"),
+        edit_defaults => backup_timestamp,
+        classes       => if_repaired("reinit_sysctl");
+
+  commands:
+    reinit_sysctl::
+      "$(paths.path[sysctl]) -p $(sysctl_conf)";
+
+  reports:
+    DEBUG|verbose_mode::
+      "array name = $(settings_array)";
+      "$(this.bundle): $(settings_array): $(keys) = $($(settings_array)[$(keys)])";
+    (DEBUG|verbose_mode).reinit_sysctl::
+      "$(this.bundle): Edited and reloaded $(sysctl_conf)";
+}

--- a/lib/3.6/bundles.cf
+++ b/lib/3.6/bundles.cf
@@ -431,9 +431,12 @@ bundle agent sysctl(settings_array)
 # bundle agent example
 # {
 #   vars:
-#       "sysctl_settings[vm.swappiness]"         string => "4";
-#       "sysctl_settings[net.core.rmem_max]"     string => "4194304";
-#       "sysctl_settings[net.core.rmem_default]" string => "4194304";
+#       "sysctl_settings"
+#         data => parsejson('{
+#                              "net.core.rmem_max"     :  "4194304",
+#                              "net.core.rmem_default" : "4194304",
+#                              "vm.swappiness"         : "5",
+#                            }');
 #
 #   methods:
 #       "Edit and reload /etc/sysctl.conf" usebundle => sysctl("$(this.bundle).sysctl_settings");

--- a/lib/3.6/bundles.cf
+++ b/lib/3.6/bundles.cf
@@ -444,7 +444,7 @@ bundle agent sysctl(settings_array)
   vars:
       "sysctl_conf" string => "/etc/sysctl.conf";
 
-    DEBUG|verbose_mode::
+    DEBUG|DEBUG_sysctl|verbose_mode::
       "keys" slist => getindices("$(settings_array)");
 
   files:
@@ -458,9 +458,9 @@ bundle agent sysctl(settings_array)
       "$(paths.path[sysctl]) -p $(sysctl_conf)";
 
   reports:
-    DEBUG|verbose_mode::
-      "array name = $(settings_array)";
-      "$(this.bundle): $(settings_array): $(keys) = $($(settings_array)[$(keys)])";
-    (DEBUG|verbose_mode).reinit_sysctl::
-      "$(this.bundle): Edited and reloaded $(sysctl_conf)";
+    DEBUG|DEBUG_sysctl|verbose_mode::
+      "DEBUG $(this.bundle): array name = $(settings_array)";
+      "DEBUG $(this.bundle): $(settings_array): $(keys) = $($(settings_array)[$(keys)])";
+    (DEBUG|DEBUG_sysctl|verbose_mode).reinit_sysctl::
+      "DEBUG $(this.bundle): Edited and reloaded $(sysctl_conf)";
 }


### PR DESCRIPTION
This is a bundle to set and load sysctl settings (a common sysadmin task).

It's a wrapper around set_variable_values.  It edits /etc/sysctl.conf and then runs sysctl -p to load the values.