### PR TITLE
Change: Switch stdlib inputs to classic arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Notable changes to the framework should be documented here
  - Set postgresql_monitoring_maintenance only for versions 3.6.0 and 3.6.1
  - Move hub specific bundles from lib/VER/cfe_internal.cf into lib/VER/cfe_internal_hub.cf
    and load them only if policy_server policy if set.
+ - Re-organize lib/VER/stdlib.cf from lists into classic array for use with getvalues
 
 ### Deprecated
 

--- a/lib/3.7/stdlib.cf
+++ b/lib/3.7/stdlib.cf
@@ -51,25 +51,27 @@ bundle common stdlib_common
 # @ignore
 {
   vars:
-      "inputs" slist => {
-                          "$(this.promise_dirname)/paths.cf",
-                          "$(this.promise_dirname)/common.cf",
-                          "$(this.promise_dirname)/commands.cf",
-                          "$(this.promise_dirname)/packages.cf",
-                          "$(this.promise_dirname)/files.cf",
-                          "$(this.promise_dirname)/edit_xml.cf",
-                          "$(this.promise_dirname)/services.cf",
-                          "$(this.promise_dirname)/processes.cf",
-                          "$(this.promise_dirname)/storage.cf",
-                          "$(this.promise_dirname)/databases.cf",
-                          "$(this.promise_dirname)/users.cf",
-                          "$(this.promise_dirname)/monitor.cf",
-                          "$(this.promise_dirname)/guest_environments.cf",
-                          "$(this.promise_dirname)/bundles.cf",
-                          "$(this.promise_dirname)/cfe_internal.cf",
-                          "$(this.promise_dirname)/cfengine_enterprise_hub_ha.cf",
-                          "$(this.promise_dirname)/cfe_internal_hub.cf",
-      };
+
+      "input[paths]"                      string => "$(this.promise_dirname)/paths.cf";
+      "input[common]"                     string => "$(this.promise_dirname)/common.cf";
+      "input[commands]"                   string => "$(this.promise_dirname)/commands.cf";
+      "input[packages]"                   string => "$(this.promise_dirname)/packages.cf";
+      "input[files]"                      string => "$(this.promise_dirname)/files.cf";
+      "input[edit_xml]"                   string => "$(this.promise_dirname)/edit_xml.cf";
+      "input[services]"                   string => "$(this.promise_dirname)/services.cf";
+      "input[processes]"                  string => "$(this.promise_dirname)/processes.cf";
+      "input[storage]"                    string => "$(this.promise_dirname)/storage.cf";
+      "input[databases]"                  string => "$(this.promise_dirname)/databases.cf";
+      "input[users]"                      string => "$(this.promise_dirname)/users.cf";
+      "input[monitor]"                    string => "$(this.promise_dirname)/monitor.cf";
+      "input[guest_environments]"         string => "$(this.promise_dirname)/guest_environments.cf";
+      "input[bundles]"                    string => "$(this.promise_dirname)/bundles.cf";
+      "input[cfe_internal]"               string => "$(this.promise_dirname)/cfe_internal.cf";
+      "input[cfe_internal_hub]"           string => "$(this.promise_dirname)/cfe_internal_hub.cf";
+      "input[cfengine_enterprise_hub_ha]" string => "$(this.promise_dirname)/cfengine_enterprise_hub_ha.cf";
+
+    any::
+      "inputs" slist => getvalues(input);
 
   reports:
     verbose_mode::


### PR DESCRIPTION
This work is to facilitate more modular loading of inputs in the future.

(cherry picked from commit fa03aace91bd9925fe831f861fd24f7c43a6a7a1)

Conflicts:
lib/3.8/stdlib.cf