### PR TITLE
Add: Policy to configure external watchdog for cf-execd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 Notable changes to the framework should be documented here
 
-## [Unreleased][unreleased]
+## 3.7
 ### Added
  - CHANGELOG.md
  - Support for user specified overring of framework defaults without modifying

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 Notable changes to the framework should be documented here
 
+## [Unreleased][unreleased]
+### Added
+ - External watchdog policy to ensure that cf-execd is running so that policy will be
+   run on schedule.
+   - This policy configures /etc/cron.d/cfengine_watchdog if /etc/cron.d is
+     present to check for cf-execd once a minute and launch it if it is not
+     running.
+   - The policy can be enabled by defining the class
+     cfe_internal_core_watchdog_enabled, or disabled by defining
+     cfe_internal_core_watchdog_disabled. In the event both classes are defined
+     at the same time enabled wins.
+
 ## 3.7
 ### Added
  - CHANGELOG.md
@@ -11,15 +23,6 @@ Notable changes to the framework should be documented here
  - Add measure_promise_time action body to lib (3.5, 3.6, 3.7, 3.8)
  - New negative class guard `cfengine_internal_disable_agent_email` so that
    agent email can be easily disabled by augmenting def.json
- - External watchdog policy to ensure that cf-execd is running so that policy will be
-   run on schedule.
-   - This policy configures /etc/cron.d/cfengine_watchdog if /etc/cron.d is
-     present to check for cf-execd once a minute and launch it if it is not
-     running.
-   - The policy can be enabled by defining the class
-     cfe_internal_core_watchdog_enabled, or disabled by defining
-     cfe_internal_core_watchdog_disabled. In the event both classes are defined
-     at the same time enabled wins.
 
 ### Changed
  - Relocate def.cf to controls/VER/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ Notable changes to the framework should be documented here
  - Add measure_promise_time action body to lib (3.5, 3.6, 3.7, 3.8)
  - New negative class guard `cfengine_internal_disable_agent_email` so that
    agent email can be easily disabled by augmenting def.json
+ - External watchdog policy to ensure that cf-execd is running so that policy will be
+   run on schedule.
+   - This policy configures /etc/cron.d/cfengine_watchdog if /etc/cron.d is
+     present to check for cf-execd once a minute and launch it if it is not
+     running.
+   - The policy can be enabled by defining the class
+     cfe_internal_core_watchdog_enabled, or disabled by defining
+     cfe_internal_core_watchdog_disabled. In the event both classes are defined
+     at the same time enabled wins.
 
 ### Changed
  - Relocate def.cf to controls/VER/

--- a/cfe_internal/core/main.cf
+++ b/cfe_internal/core/main.cf
@@ -15,4 +15,15 @@ bundle agent cfe_internal_core_main
         handle => "cfe_internal_management_log_rotation",
         comment => "Rotate CFEngine logs so we dont fill the disk";
 
+    cfe_internal_core_watchdog_disabled::
+
+      "Disable Core Watchdog"
+        usebundle => cfe_internal_core_watchdog("disabled");
+
+    cfe_internal_core_watchdog_enabled::
+
+      "Enable Core Watchdog"
+        usebundle => cfe_internal_core_watchdog("enabled");
+
+
 }

--- a/cfe_internal/core/watchdog/watchdog.cf
+++ b/cfe_internal/core/watchdog/watchdog.cf
@@ -61,7 +61,6 @@ bundle agent cfe_internal_core_watchdog_cron_d(state)
         create => "true";
 
       "$(cron_d_watchdog)"
-        edit_defaults => empty,
         edit_template => "$(template)",
         handle => "cfe_internal_core_watchdog_enable_cron_d_file_content",
         template_method => "mustache";

--- a/cfe_internal/core/watchdog/watchdog.cf
+++ b/cfe_internal/core/watchdog/watchdog.cf
@@ -1,0 +1,66 @@
+bundle agent cfe_internal_core_watchdog(state)
+# @breif Configure external watchdog processes to keep cf-execd running
+# @param state (enabled|disabled) The state to keep the watchdog configuration in
+{
+  meta:
+    "description"
+      string => "Configure external watchdog processes (like cron, or monit) to
+                 make sure that cf-execd is always running";
+
+  classes:
+    any::
+
+      "have_cron_d"
+        expression => isdir("/etc/cron.d");
+
+      "invalid_state"
+        not => regcmp("(enabled|disabled)", "$(state)");
+
+    !invalid_state::
+
+      # Define a class for whatever the desired state is so long as the state is
+      # valid
+
+      "$(state)"
+        expression => "any";
+
+  vars:
+    any::
+
+      "cf_execd"
+        string => ifelse("windows", translatepath('"$(sys.bindir)/cf-execd.exe)"'),
+                         "$(sys.bindir)/cf-execd");
+
+      "template"
+        string => "$(this.promise_dirname)/../../../templates/cfengine_watchdog.mustache";
+
+    have_cron_d::
+
+      "cron_d_watchdog" string => "/etc/cron.d/cfengine_watchdog";
+
+  files:
+
+    enabled.have_cron_d::
+
+      "$(cron_d_watchdog)"
+        create => "true";
+
+      "$(cron_d_watchdog)"
+        edit_defaults => empty,
+        edit_template => "$(template)",
+        handle => "cfe_internal_core_watchdog_enable_cron_d_file_content",
+        template_method => "mustache";
+
+    disabled.have_cron_d::
+
+      "$(cron_d_watchdog)"
+        delete => tidy;
+
+  reports:
+    DEBUG|DEBUG_cfe_internal_core_watchdog::
+      "DEBUG $(this.bundle): Watchdog '$(state)'";
+      "DEBUG $(this.bundle): Have /etc/cron.d/."
+        ifvarclass => "have_cron_d";
+      "DEBUG $(this.bundle): Invalid state '$(state)' only enabled|disabled allowed"
+        ifvarclass => "invalid_state";
+}

--- a/cfe_internal/core/watchdog/watchdog.cf
+++ b/cfe_internal/core/watchdog/watchdog.cf
@@ -8,18 +8,39 @@ bundle agent cfe_internal_core_watchdog(state)
                  make sure that cf-execd is always running";
 
   classes:
-    any::
+      "invalid_state"
+        not => regcmp("(enabled|disabled)", "$(state)");
 
       "have_cron_d"
         expression => isdir("/etc/cron.d");
 
-      "invalid_state"
-        not => regcmp("(enabled|disabled)", "$(state)");
+      "use_cfe_internal_core_watchdog_cron_d"
+        expression => "have_cron_d._stdlib_has_path_pgrep";
 
-    !invalid_state::
+  methods:
+    use_cfe_internal_core_watchdog_cron_d::
+      "any" usebundle => cfe_internal_core_watchdog_cron_d( $(state) );
 
-      # Define a class for whatever the desired state is so long as the state is
-      # valid
+  reports:
+    DEBUG|DEBUG_cfe_internal_core_watchdog::
+      "DEBUG $(this.bundle): Watchdog '$(state)'";
+      "DEBUG $(this.bundle): Invalid state '$(state)' only enabled|disabled allowed"
+        ifvarclass => "invalid_state";
+
+    !use_cfe_internal_core_watchdog_cron_d::
+      "WARNING $(this.bundle): Currently only supports /etc/cron.d on systems that have pgrep in the the stdlib paths bundle.";
+}
+
+bundle agent cfe_internal_core_watchdog_cron_d(state)
+# @brief Use a cron job installed in /etc/cron.d to watch and make sure that
+# cf-execd is always running.
+# @param state (enabled|disabled) The state to keep the watchdog configuration
+# in. Enabled manages the cron job, disabled removes it.
+{
+  classes:
+    any::
+
+      # Define a class for whatever the desired state is
 
       "$(state)"
         expression => "any";
@@ -27,20 +48,14 @@ bundle agent cfe_internal_core_watchdog(state)
   vars:
     any::
 
-      "cf_execd"
-        string => ifelse("windows", translatepath('"$(sys.bindir)/cf-execd.exe)"'),
-                         "$(sys.bindir)/cf-execd");
-
       "template"
         string => "$(this.promise_dirname)/../../../templates/cfengine_watchdog.mustache";
-
-    have_cron_d::
 
       "cron_d_watchdog" string => "/etc/cron.d/cfengine_watchdog";
 
   files:
 
-    enabled.have_cron_d::
+    enabled::
 
       "$(cron_d_watchdog)"
         create => "true";
@@ -51,16 +66,8 @@ bundle agent cfe_internal_core_watchdog(state)
         handle => "cfe_internal_core_watchdog_enable_cron_d_file_content",
         template_method => "mustache";
 
-    disabled.have_cron_d::
+    disabled::
 
       "$(cron_d_watchdog)"
         delete => tidy;
-
-  reports:
-    DEBUG|DEBUG_cfe_internal_core_watchdog::
-      "DEBUG $(this.bundle): Watchdog '$(state)'";
-      "DEBUG $(this.bundle): Have /etc/cron.d/."
-        ifvarclass => "have_cron_d";
-      "DEBUG $(this.bundle): Invalid state '$(state)' only enabled|disabled allowed"
-        ifvarclass => "invalid_state";
 }

--- a/controls/3.8/def.cf
+++ b/controls/3.8/def.cf
@@ -216,7 +216,7 @@ bundle common def
         "$(sys.workdir)/reports",
       };
 
-    # enable_cfengine_enterprise_hub_ha is defined below 
+    # enable_cfengine_enterprise_hub_ha is defined below
     # Disabled by default
 
     enable_cfengine_enterprise_hub_ha::
@@ -238,6 +238,11 @@ bundle common def
 
       # Enable agent email output (also see mailto, mailfrom and smtpserver)
       "cfengine_internal_agent_email" expression => "any";
+
+
+      # Enable or disable external watchdog to ensure cf-execd is running
+      "cfe_internal_core_watchdog_enabled" expression => "!any";
+      "cfe_internal_core_watchdog_disabled" expression => "!any";
 
       # Transfer policies and binaries with encryption
       # you can also request it from the command line with

--- a/example_def.json
+++ b/example_def.json
@@ -11,6 +11,7 @@
         "my_debian_role": [ "debian.*" ],
         "services_autorun": [ "any" ],
         "cfengine_internal_disable_agent_email": [ "enterprise_edition" ]
+        "cfe_internal_core_watchdog_enabled": [ "any" ],
     },
 
     "inputs": [ "$(sys.libdir)/bundles.cf" ],

--- a/lib/3.8/paths.cf
+++ b/lib/3.8/paths.cf
@@ -106,6 +106,7 @@ bundle common paths
     linux::
       "path[lsattr]"        string => "/usr/bin/lsattr";
       "path[tar]"           string => "/bin/tar";
+      "path[pgrep]"         string => "/usr/bin/pgrep";
 
     aix::
 

--- a/promises.cf
+++ b/promises.cf
@@ -156,6 +156,11 @@ bundle common cfe_internal_inputs
         comment => "This policy produces a text based host info report
                     and serves as a functional example of using mustache templates";
 
+      "input[cfengine_internal_core_watchdog]"
+        string => "cfe_internal/core/watchdog/watchdog.cf",
+        comment => "This policy configures external watchdogs to ensure that
+                    cf-execd is always running.";
+
     enterprise_edition::
 
       "input[enterprise_hub_specific]"

--- a/templates/cfengine_watchdog.mustache
+++ b/templates/cfengine_watchdog.mustache
@@ -1,5 +1,3 @@
 # This file is managed by CFEngine
-{{#classes.have_cron_d}}
 # If cf-execd is executable and if no process matching cf-execd can be found then restart cf-execd
-* * * * * root [ -x {{{vars.cfe_internal_core_watchdog.cf_execd}}} ] && if ! pgrep cf-execd > /dev/null; then {{{vars.cfe_internal_core_watchdog.cf_execd}}} {{{vars.cfe_internal_core_watchdog.cf_execd_options}}}; fi
-{{/classes.have_cron_d}}
+* * * * * root [ -x {{{vars.sys.cf_execd}}} ] && if ! {{{vars.paths.pgrep}}} cf-execd > /dev/null; then {{{vars.sys.cf_execd}}}; fi

--- a/templates/cfengine_watchdog.mustache
+++ b/templates/cfengine_watchdog.mustache
@@ -1,0 +1,5 @@
+# This file is managed by CFEngine
+{{#classes.have_cron_d}}
+# If cf-execd is executable and if no process matching cf-execd can be found then restart cf-execd
+* * * * * root [ -x {{{vars.cfe_internal_core_watchdog.cf_execd}}} ] && if ! pgrep cf-execd > /dev/null; then {{{vars.cfe_internal_core_watchdog.cf_execd}}} {{{vars.cfe_internal_core_watchdog.cf_execd_options}}}; fi
+{{/classes.have_cron_d}}


### PR DESCRIPTION
Ref: https://dev.cfengine.com/issues/7324