### PR TITLE
Backport fix process_result logic to match the purpose of days_older_than().

### DIFF
--- a/lib/3.5/processes.cf
+++ b/lib/3.5/processes.cf
@@ -62,7 +62,7 @@ body process_select exclude_procs(x)
 body process_select days_older_than(d)
 {
       stime_range    => irange(ago(0,0,"$(d)",0,0,0),now);
-      process_result => "stime";
+      process_result => "!stime";
 }
 
 ##

--- a/lib/3.6/processes.cf
+++ b/lib/3.6/processes.cf
@@ -67,7 +67,7 @@ body process_select days_older_than(d)
 # @param d Days that processes need to be old to be selected
 {
       stime_range    => irange(ago(0,0,"$(d)",0,0,0),now);
-      process_result => "stime";
+      process_result => "!stime";
 }
 
 ##


### PR DESCRIPTION
see: https://dev.cfengine.com/issues/3009

(cherry picked from commit 5038696c37fcfbc5c4ec85915d44d13f5bdfb1bf)

Conflicts:
lib/3.7/processes.cf
lib/3.8/processes.cf