### PR TITLE
Fix: Multiple execd processes after upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Notable changes to the framework should be documented here
 ### Fixed
  - standard_services now restarts the service if it was not already running
    when using service_policy => restart with chkconfig (Redmine #7258)
+ - Multiple cf-execds running after cf-upgrade initiated upgrade. (Redmine #7185)
 
 ### Security
 

--- a/cfe_internal/update/update_bins.cf
+++ b/cfe_internal/update/update_bins.cf
@@ -145,6 +145,14 @@ bundle agent cfe_internal_update_bins
 
       "have_software_dir" expression => fileexists($(local_software_dir));
 
+
+      "found_cf_upgrade_process_running"
+        expression => regline(".*cf-upgrade.*", "$(sys.workdir)/state/cf_procs");
+
+  reports:
+    found_cf_upgrade_process_running::
+      "WARNING $(this.bundle): Found existing cf-upgrade processes in $(sys.workdir)/state/cf_procs. Will not attempt to upgrade";
+
       #
 
   packages:
@@ -159,7 +167,7 @@ bundle agent cfe_internal_update_bins
       package_architectures => { "$(pkgarch)" },
       package_version => "$(update_def.current_version)-1",
       package_method => u_generic( "$(local_software_dir)" ),
-      ifvarclass => "nova_edition.have_software_dir",
+      ifvarclass => "nova_edition.have_software_dir.!found_cf_upgrade_processes_running",
       classes => u_if_else("bin_update_success", "bin_update_fail");
 
     !am_policy_hub.(solaris|solarisx86).enterprise::
@@ -172,7 +180,7 @@ bundle agent cfe_internal_update_bins
       package_architectures => { "$(pkgarch)" },
       package_version => "$(update_def.current_version)",
       package_method => u_generic( "$(local_software_dir)" ),
-      ifvarclass => "nova_edition.have_software_dir",
+      ifvarclass => "nova_edition.have_software_dir.!found_cf_upgrade_processes_running",
       classes => u_if_else("bin_update_success", "bin_update_fail");
 
     !am_policy_hub.windows.enterprise::
@@ -376,14 +384,41 @@ bundle edit_line u_install_script
 
       "#!/bin/sh
 
-/bin/rpm -U $(const.dollar)1";
+/bin/rpm -U $(const.dollar)1
+counter=0
+while /usr/bin/pgrep cf-agent || /usr/bin/pgrep cf-execd; do
+counter=$(($counter+1))
+echo Maniacally trying to kill all cf-execd, and cf-agent processes for the $counter time after package upgrade to ensure only one copy of the new binaries is running.
+/usr/bin/pkill cf-agent
+/usr/bin/pkill cf-execd
+/sbin/service cfengine3 stop
+if [ $counter -gt 30 ]; then
+    break
+fi
+sleep 1
+done
+/sbin/service cfengine3 start
+";
 
     debian::
 
       "#!/bin/sh
 
-/usr/bin/dpkg --force-confdef --force-confnew --install $(const.dollar)1 > /dev/null";
-
+/usr/bin/dpkg --force-confdef --force-confnew --install $(const.dollar)1 > /dev/null
+counter=0
+while /usr/bin/pgrep cf-agent || /usr/bin/pgrep cf-execd; do
+counter=$(($counter+1))
+echo Maniacally trying to kill all cf-execd, and cf-agent processes for the $counter time after package upgrade to ensure only one copy of the new binaries is running.
+/usr/bin/pkill cf-agent
+/usr/bin/pkill cf-execd
+/usr/sbin/service cfengine3 stop
+if [ $counter -gt 30 ]; then
+    break
+fi
+sleep 1
+done
+/usr/sbin/service cfengine3 start
+";
     solarisx86|solaris::
 
       "#!/bin/sh
@@ -391,9 +426,20 @@ bundle edit_line u_install_script
 pkgname=`pkginfo -d $(const.dollar)1 | awk '{print $(const.dollar)2}'`
 /usr/sbin/pkgrm -n -a $(cfe_internal_update_bins.admin_file) $pkgname
 /usr/sbin/pkgadd -n -a $(cfe_internal_update_bins.admin_file) -d $(const.dollar)1 all
-$(sys.workdir)/bin/cf-execd || true
-exit 0";
-
+counter=0
+while /usr/bin/pgrep cf-agent || /usr/bin/pgrep cf-execd; do
+counter=$(($counter+1))
+echo Maniacally trying to kill all cf-execd, and cf-agent processes for the $counter time after package upgrade to ensure only one copy of the new binaries is running.
+/usr/bin/pkill cf-agent
+/usr/bin/pkill cf-execd
+/etc/init.d/cfengine3 stop
+if [ $counter -gt 30 ]; then
+    break
+fi
+sleep 1
+done
+/etc/init.d/cfengine3 start
+";
 }
 
 ################################################################################


### PR DESCRIPTION
cf-execd does not like being killed. Up through cfengine 3.6.5 it launches
itself again if it is killed. This addresses the situation for cf-upgrade
initiated upgrades by spinning a tight loop killing cf-agent and cf-execd
processes before finally restarting the service.

Ref: https://dev.cfengine.com/issues/7185