### PR TITLE
Change: Enable limit_robot_agents maintenance policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Notable changes to the framework should be documented here
      at the same time enabled wins.
    - Fix process_result logic to match the purpose of body process_select days_older_than (Redmine #3009)
 
-## 3.7
+## 3.7.0
 ### Added
  - CHANGELOG.md
  - Support for user specified overring of framework defaults without modifying
@@ -54,6 +54,8 @@ Notable changes to the framework should be documented here
    and load them only if policy_server policy if set.
  - Re-organize lib/VER/stdlib.cf from lists into classic array for use with getvalues
  - inform_mode classes changed to DEBUG|DEBUG_$(this.bundle):: (Redmine: #7191)
+ - Enabled limit_robot_agents in order to work around multiple cf-execd
+   processes after upgrade. (Redmine #7185)
 
 ### Deprecated
 

--- a/cfe_internal/core/main.cf
+++ b/cfe_internal/core/main.cf
@@ -5,10 +5,10 @@ bundle agent cfe_internal_core_main
 
 #   NB! On a container host this may kill CFEngine processes inside containers.
 #       See https://dev.cfengine.com/issues/6906
-#
-#      "any" usebundle => cfe_internal_limit_robot_agents,
-#      handle => "cfe_internal_management_limit_cfe_agents",
-#      comment => "Manage CFE processes";
+
+      "any" usebundle => cfe_internal_limit_robot_agents,
+        handle => "cfe_internal_management_limit_cfe_agents",
+        comment => "Manage CFE processes";
 
       "any"
         usebundle => cfe_internal_log_rotation,


### PR DESCRIPTION
This policy was originally disabled because it killed execds running inside of
containers. However it was keeping multiple cf-execds in check especially
after agent upgrades.

Ref: https://dev.cfengine.com/issues/7185

This needs picked to 3.7 and 3.6