### PR TITLE
Change: Manually backport enablement of limit_robot_agents

### DIFF
--- a/cfe_internal/CFE_cfengine.cf
+++ b/cfe_internal/CFE_cfengine.cf
@@ -87,10 +87,10 @@ bundle agent cfe_internal_management
 
 #   NB! On a container host this may kill CFEngine processes inside containers.
 #       See https://dev.cfengine.com/issues/6906
-#
-#      "any" usebundle => cfe_internal_limit_robot_agents,
-#      handle => "cfe_internal_management_limit_cfe_agents",
-#      comment => "Manage CFE processes";
+
+      "any" usebundle => cfe_internal_limit_robot_agents,
+      handle => "cfe_internal_management_limit_cfe_agents",
+      comment => "Manage CFE processes";
 
       "any" usebundle => cfe_internal_log_rotation,
       handle => "cfe_internal_management_log_rotation",


### PR DESCRIPTION
This policy was originally disabled because it killed execds running inside of 
containers. However it was keeping multiple cf-execds in check especially 
after agent upgrades.

Ref: https://dev.cfengine.com/issues/7185