### PR TITLE
def.cf: separate inputs into a secondary def_inputs.cf file

### DIFF
--- a/controls/3.7/def.cf
+++ b/controls/3.7/def.cf
@@ -4,11 +4,6 @@
 #  - common/global variables and classes here
 #
 ###############################################################################
-body file control
-{
-      inputs => { @(def.augments_inputs) };
-}
-
 bundle common def
 {
   classes:

--- a/controls/3.7/def_inputs.cf
+++ b/controls/3.7/def_inputs.cf
@@ -1,0 +1,4 @@
+body file control
+{
+      inputs => { @(def.augments_inputs) };
+}

--- a/controls/3.8/def.cf
+++ b/controls/3.8/def.cf
@@ -4,11 +4,6 @@
 #  - common/global variables and classes here
 #
 ###############################################################################
-body file control
-{
-      inputs => { @(def.augments_inputs) };
-}
-
 bundle common def
 {
   classes:

--- a/controls/3.8/def_inputs.cf
+++ b/controls/3.8/def_inputs.cf
@@ -1,0 +1,4 @@
+body file control
+{
+      inputs => { @(def.augments_inputs) };
+}

--- a/promises.cf
+++ b/promises.cf
@@ -32,6 +32,7 @@ body common control
       inputs => {
                  # File definition for global variables and classes
                   "controls/$(sys.cf_version_major).$(sys.cf_version_minor)/def.cf",
+                  "controls/$(sys.cf_version_major).$(sys.cf_version_minor)/def_inputs.cf",
 
                 # Inventory policy
                   @(inventory.inputs),


### PR DESCRIPTION
Because of our friend the 3-pass convergent fairy, the `def.cf` inputs are not evaluated in time.  This commit separates the loading of the inputs from JSON in `def.cf` from using them in `def_inputs.cf`.

This should probably have an acceptance test.

Ref: https://dev.cfengine.com/issues/7420