### PR TITLE
inventory: rework LLDP inventory to produce a data container and use -f keyvalue

### DIFF
--- a/controls/3.6/def.cf
+++ b/controls/3.6/def.cf
@@ -322,7 +322,7 @@ bundle common inventory_control
 # are disabled.
 {
   vars:
-      "lldpctl_exec" string => "/usr/bin/lldpctl";
+      "lldpctl_exec" string => "/usr/sbin/lldpctl";
       "lsb_exec" string => "/usr/bin/lsb_release";
       "mtab" string => "/etc/mtab";
       "proc" string => "/proc";

--- a/controls/3.7/def.cf
+++ b/controls/3.7/def.cf
@@ -319,7 +319,7 @@ bundle common inventory_control
 # are disabled.
 {
   vars:
-      "lldpctl_exec" string => "/usr/bin/lldpctl";
+      "lldpctl_exec" string => "/usr/sbin/lldpctl";
       "lsb_exec" string => "/usr/bin/lsb_release";
       "mtab" string => "/etc/mtab";
       "proc" string => "/proc";

--- a/controls/3.8/def.cf
+++ b/controls/3.8/def.cf
@@ -323,7 +323,7 @@ bundle common inventory_control
 # are disabled.
 {
   vars:
-      "lldpctl_exec" string => "/usr/bin/lldpctl";
+      "lldpctl_exec" string => "/usr/sbin/lldpctl";
       "lsb_exec" string => "/usr/bin/lsb_release";
       "mtab" string => "/etc/mtab";
       "proc" string => "/proc";

--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -533,9 +533,11 @@ bundle agent cfe_autorun_inventory_LLDP
 
   commands:
     !disable_inventory_LLDP::
-      "$(inventory_control.lldpctl_exec) | perl -n -e 'my ($k, $v) = m/([^=]+)=(.*)/; $k =~ s/\W/_/g; print \"=$k=$v\";"
-      classes => kept_successful_command,
-      module => "true";
+      # we'd use '-f json' but it's not available in the standard lldpctl package
+      "$(inventory_control.lldpctl_exec) -f keyvalue | $(sys.workdir)/modules/inventory/lldpctl.pl"
+        contain => in_shell,
+        classes => kept_successful_command,
+        module => "true";
 }
 
 bundle agent cfe_autorun_inventory_packages

--- a/modules/inventory/lldpctl.pl
+++ b/modules/inventory/lldpctl.pl
@@ -1,0 +1,64 @@
+#!/usr/bin/perl
+
+use warnings;
+use strict;
+use JSON;
+
+# turn this off if you want "x.enabled" not to be converted to a bool
+my $convert_enabled_to_boolean = 1;
+
+print "^meta=inventory\n";
+print "^context=cfe_autorun_inventory_LLDP\n";
+
+my %entries;
+while (<>)
+{
+ chomp;
+ if (m/^([^=]+)=(.+)$/)
+ {
+  add_entry(\%entries, $1, $2);
+ }
+}
+
+my $encoder = JSON->new();
+print "%lldp=", $encoder->encode(\%entries), "\n";
+
+sub add_entry
+{
+ my $d = shift @_;
+ my $k = shift @_;
+ my $v = shift @_;
+
+ if ($convert_enabled_to_boolean && $k =~ m/([^\.]+)\.enabled/)
+ {
+  my $kbool = $1;
+  $d->{$kbool} = jconvert($v);
+ }
+ elsif ($k =~ m/([^\.]+)\.(.+)/)
+ {
+  my $k0 = $1;
+  my $k1 = $2;
+
+  $d->{$k0} ||= {};
+  add_entry($d->{$k0}, $k1, $v);
+ }
+ else
+ {
+  $d->{$k} = jconvert($v);
+ }
+}
+
+sub jconvert
+{
+ my $v = shift;
+
+ return JSON::true if $v eq 'on';
+ return JSON::false if $v eq 'off';
+
+ return JSON::true if $v eq 'yes';
+ return JSON::false if $v eq 'no';
+
+ return 0+$v if $v =~ m/^[0-9]+$/;
+
+ return $v;
+}


### PR DESCRIPTION
The `lldpctl` location was incorrect and the module script was broken.

This revision adds a full LLDP inventory into a data container.