### PR TITLE
def.cf: separate inputs into a secondary def_inputs.cf file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Notable changes to the framework should be documented here
      cfe_internal_core_watchdog_enabled, or disabled by defining
      cfe_internal_core_watchdog_disabled. In the event both classes are defined
      at the same time enabled wins.
+### Fixed
+   - Augmenting inputs from the augments_file (Redmine #7420)
 
 ## 3.7.0
 ### Added

--- a/controls/3.7/def.cf
+++ b/controls/3.7/def.cf
@@ -4,11 +4,6 @@
 #  - common/global variables and classes here
 #
 ###############################################################################
-body file control
-{
-      inputs => { @(def.augments_inputs) };
-}
-
 bundle common def
 {
   classes:

--- a/controls/3.7/def_inputs.cf
+++ b/controls/3.7/def_inputs.cf
@@ -1,0 +1,4 @@
+body file control
+{
+      inputs => { @(def.augments_inputs) };
+}

--- a/controls/3.8/def.cf
+++ b/controls/3.8/def.cf
@@ -4,11 +4,6 @@
 #  - common/global variables and classes here
 #
 ###############################################################################
-body file control
-{
-      inputs => { @(def.augments_inputs) };
-}
-
 bundle common def
 {
   classes:

--- a/controls/3.8/def_inputs.cf
+++ b/controls/3.8/def_inputs.cf
@@ -1,0 +1,4 @@
+body file control
+{
+      inputs => { @(def.augments_inputs) };
+}

--- a/promises.cf
+++ b/promises.cf
@@ -32,6 +32,7 @@ body common control
       inputs => {
                  # File definition for global variables and classes
                   "controls/$(sys.cf_version_major).$(sys.cf_version_minor)/def.cf",
+                  "controls/$(sys.cf_version_major).$(sys.cf_version_minor)/def_inputs.cf",
 
                 # Inventory policy
                   @(inventory.inputs),


### PR DESCRIPTION
Ref: https://dev.cfengine.com/issues/7420
Supercedes: https://github.com/cfengine/masterfiles/pull/530