### PR TITLE
Package promise fixes

### DIFF
--- a/modules/packages/apt_get
+++ b/modules/packages/apt_get
@@ -193,7 +193,7 @@ def one_package_argument(name, arch, version, is_apt_install):
                     archs.append(arch)
 
     version_suffix = ""
-    if version != "" and is_apt_install:
+    if version != "":
         version_suffix = "=" + version
 
     if archs:
@@ -266,7 +266,7 @@ def repo_install():
     return 0
 
 def remove():
-    cmd_line = [dpkg_cmd, "--remove"]
+    cmd_line = [apt_get_cmd] + apt_get_options + ["remove"]
 
     args = package_arguments_builder(False)
 

--- a/modules/packages/apt_get
+++ b/modules/packages/apt_get
@@ -93,7 +93,7 @@ def get_package_data():
         sys.stdout.write("PackageType=file\n")
         sys.stdout.flush()
         return subprocess_call([dpkg_deb_cmd, "--showformat", dpkg_output_format, "-W", pkg_string])
-    elif (re.search("([:,]|-[0-9])", pkg_string)):
+    elif (re.search("([:,]|_[0-9])", pkg_string)):
         # Contains either a version number or an illegal symbol.
         sys.stdout.write(line + "ErrorMessage: Package string with illegal format\n")
         return 1

--- a/modules/packages/yum
+++ b/modules/packages/yum
@@ -334,7 +334,7 @@ def repo_install():
 
 
 def remove():
-    cmd_line = [rpm_cmd, "--allmatches"] + rpm_quiet_option + ["-e"]
+    cmd_line = [yum_cmd] + yum_options + ["remove"]
 
     # package_arguments_builder will always return empty second element in case
     # of removals, so just drop it.         |

--- a/tests/unit/test_package_module_apt_get
+++ b/tests/unit/test_package_module_apt_get
@@ -129,7 +129,7 @@ dpkg-query --showformat ${Architecture}=${Status}
 dpkg --print-architecture
 dpkg-query --showformat ${Architecture}=${Status}
  -W d:*
-dpkg --remove a:x b:y c d"""])
+apt-get """ + apt_get_options + " remove a:x=1 b:y c=3 d"])
 
 assert check("list-updates", [], 75,
              ["Name=dpkg\nVersion=1.16.1.2ubuntu7.6\nArchitecture=amd64",

--- a/tests/unit/test_package_module_yum
+++ b/tests/unit/test_package_module_yum
@@ -122,7 +122,7 @@ assert check("remove", ["Name=a\nVersion=1\nArchitecture=x",
                         "Name=b\nArchitecture=y",
                         "Name=c\nVersion=3",
                         "Name=d"],
-             0, [], 1, ["rpm --allmatches --quiet -e a-1.x b.y c-3 d"])
+             0, [], 1, ["yum --quiet -y remove a-1.x b.y c-3 d"])
 
 assert check("list-updates", [], 18,
              ["Name=yum\nVersion=3.2.29-43.el6_5\nArchitecture=noarch",


### PR DESCRIPTION
<pre>
commit 7092480966efee1872ef008beb36c2c3fcd681ba
Author: Kristian Amlie <kristian.amlie@cfengine.com>
Date:   Fri Aug 14 11:10:01 2015

    Redmine #7424: Fix package promise not removing dependant packages.
    
    Changelog: Title

commit 9a0ec964221e6969ddb64cadfe7b276cf565b924
Author: Kristian Amlie <kristian.amlie@cfengine.com>
Date:   Thu Aug 13 14:18:30 2015

    Redmine #7421: Fix incorrect version detection in promise string.
    
    Debian packages use "pkg_1.0.deb" format, not "pkg-1.0.deb", to encode
    version. This made it impossible to install packages that had version
    numbers in their name, such as virtualbox-5.0.
    
    Changelog: Package promise: Fix inability to install certain packages
    with numbers.
</pre>