### PR TITLE
Change: Guard update_bins package promises with trigger_upgrade

### DIFF
--- a/cfe_internal/update/update_bins.cf
+++ b/cfe_internal/update/update_bins.cf
@@ -149,7 +149,7 @@ bundle agent cfe_internal_update_bins
 
   packages:
 
-    !am_policy_hub.linux.enterprise::
+    !am_policy_hub.linux.enterprise.trigger_upgrade::
 
       "$(novapkg)"
       comment => "Update Nova package to a newer version (package is there)",
@@ -162,7 +162,7 @@ bundle agent cfe_internal_update_bins
       ifvarclass => "nova_edition.have_software_dir",
       classes => u_if_else("bin_update_success", "bin_update_fail");
 
-    !am_policy_hub.(solaris|solarisx86).enterprise::
+    !am_policy_hub.(solaris|solarisx86).enterprise.trigger_upgrade::
 
       "$(novapkg)"
       comment => "Update Nova package to a newer version (package is there)",
@@ -175,7 +175,7 @@ bundle agent cfe_internal_update_bins
       ifvarclass => "nova_edition.have_software_dir",
       classes => u_if_else("bin_update_success", "bin_update_fail");
 
-    !am_policy_hub.windows.enterprise::
+    !am_policy_hub.windows.enterprise.trigger_upgrade::
 
       "$(novapkg)"
       comment => "Update Nova package to a newer version (package is there)",
@@ -188,7 +188,7 @@ bundle agent cfe_internal_update_bins
       ifvarclass => "nova_edition.have_software_dir",
       classes => u_if_else("bin_update_success", "bin_update_fail");
 
-    !am_policy_hub.aix.enterprise::
+    !am_policy_hub.aix.enterprise.trigger_upgrade::
 
       "$(novapkg)"
       comment => "Update Nova package to a newer version (package is there)",


### PR DESCRIPTION
Ref: https://dev.cfengine.com/issues/7456

Changelog: Fix noise from internal policy to upgrade windows agents
(Redmine #7456)

(cherry picked from commit 00b5fb3431f65ff7b07b8779b8ab8dbe0c027d9f)