### PR TITLE
Add support for failover to 3rd HA node located outside cluster.

### DIFF
--- a/cfe_internal/enterprise/ha/ha.cf
+++ b/cfe_internal/enterprise/ha/ha.cf
@@ -2,7 +2,7 @@ bundle agent ha_main
 {
  classes:
    enable_cfengine_enterprise_hub_ha::
-    "ha_master_valid" expression => isvariable("sys.hub_active_ip");
+    "have_ha_hub_active_ip" expression => isvariable("sys.hub_active_ip");
 
  methods:
   policy_server.enterprise::
@@ -11,7 +11,7 @@ bundle agent ha_main
   policy_server.enable_cfengine_enterprise_hub_ha.hub_active::
     "manage_mp_enable_cfengine_enterprise_hub_ha_file" usebundle => ha_manage_notification_scripts_dir;
 
-  policy_server.enable_cfengine_enterprise_hub_ha.!hub_active.ha_master_valid::
+  policy_server.!hub_active.have_ha_hub_active_ip::
     "sync_config_data" usebundle => ha_hub_sync_config_data;
 }
 

--- a/cfe_internal/enterprise/ha/ha_def.cf
+++ b/cfe_internal/enterprise/ha/ha_def.cf
@@ -22,6 +22,18 @@ bundle common ha_def
      slist => getvalues("hub_sha"),
      comment => "We use the list of hub key files for restricting clients access only to those";
 
+
+   "replication_only_node[$(ips)]"
+      string => "dummy", ifvarclass => strcmp("$(config[$(ips)][is_in_cluster])", "false");
+
+   "replication_only_nodes"
+      slist => getindices("replication_only_node");
+
+
+  classes:
+      "ha_replication_only_node" expression => some($(sys.policy_hub), replication_only_nodes);
+
+
   reports:
     verbose_mode::
       "HA hub $(ips) $(config[$(ips)][sha])";

--- a/cfe_internal/enterprise/ha/ha_update.cf
+++ b/cfe_internal/enterprise/ha/ha_update.cf
@@ -10,6 +10,9 @@ bundle agent ha_update
 
   enable_cfengine_enterprise_hub_ha.hub_data_synced::
       "manage_keys" usebundle => manage_hub_synced_data;
+
+  enable_cfengine_enterprise_hub_ha.ha_replication_only_node::
+      "syncronize_master_hub_dat" usebundle => sync_master_hub_dat;
 }
 
 bundle agent ha_agent_sync
@@ -76,6 +79,17 @@ bundle agent manage_hub_synced_data
                   keys are copied to ppkeys will be able to authenticate and connect
                   to hub.";
 }
+
+bundle agent sync_master_hub_dat
+{
+ files:
+    "$(ha_def.master_hub_location)"
+      copy_from => ha_no_backup_scp("$(ha_def.master_hub_location)", @(update_def.standby_servers)),
+      comment => "Update master hub IP on CFEngine node",
+      handle => "ha_cfengine_node_update_master";
+
+}
+
 
 body file_select hub_all_keys
 {

--- a/cfe_internal/update/update_processes.cf
+++ b/cfe_internal/update/update_processes.cf
@@ -122,6 +122,14 @@ bundle agent maintain_cfe_hub_process
       comment => "Check for $(sys.workdir)/inputs/promises.cf",
       handle => "cfe_internal_maintain_cfe_hub_process_classes_files_ok";
 
+    am_policy_hub.enable_cfengine_enterprise_hub_ha::
+      "ha_run_hub_process" or =>
+        { "!ha_replication_only_node", "ha_replication_only_node.failover_to_replication_node_enabled" };
+
+     "ha_kill_hub_process" or =>
+        { "ha_replication_only_node.!failover_to_replication_node_enabled" };
+
+
       #
 
   processes:
@@ -154,11 +162,16 @@ bundle agent maintain_cfe_hub_process
       handle => "cfe_internal_maintain_cfe_hub_process_processes_postgres",
       ifvarclass => "nova|enterprise";
 
-    am_policy_hub.files_ok.!windows::
+    am_policy_hub.!enable_cfengine_enterprise_hub_ha.files_ok.!windows|ha_run_hub_process::
       "cf-hub"      restart_class => "start_hub",
       comment => "Monitor cf-hub process",
       handle => "cfe_internal_maintain_cfe_hub_process_processes_cf_hub",
       ifvarclass => "(nova|enterprise).no_vacuumdb";
+
+    am_policy_hub.ha_kill_hub_process::
+      "cf-hub"      signals => { "term" },
+      comment => "Terminate cf-hub on backup HA node outside cluster",
+      handle => "cfe_internal_kill_hub_process_on_inactive_ha_node";
 
       #
 
@@ -196,7 +209,6 @@ bundle agent maintain_cfe_hub_process
       handle => "cfe_internal_maintain_cfe_hub_process_commands_start_cf-consumer";
 
     !windows.am_policy_hub.start_hub::
-
       "$(sys.cf_hub)"
       comment => "Start cf-hub process",
       classes => u_kept_successful_command,

--- a/controls/3.7/def.cf
+++ b/controls/3.7/def.cf
@@ -288,6 +288,9 @@ bundle common def
       "enable_cfengine_enterprise_hub_ha" expression => "!any";
       #"enable_cfengine_enterprise_hub_ha" expression => "enterprise_edition";
 
+      # Enable failover to node which is outside cluster
+      #"failover_to_replication_node_enabled" expression => "enterprise_edition";
+
       # Enable cleanup of agent report diffs when they exceed
       # `def.max_client_history_size`
       "enable_cfe_internal_cleanup_agent_reports" -> { "cf-hub", "CFEngine Enterprise" }

--- a/controls/3.7/update_def.cf
+++ b/controls/3.7/update_def.cf
@@ -150,6 +150,9 @@ bundle common update_def
       "enable_cfengine_enterprise_hub_ha" expression => "!any";
       #"enable_cfengine_enterprise_hub_ha" expression => "enterprise_edition";
 
+      # Enable failover to node which is outside cluster
+      #"failover_to_replication_node_enabled" expression => "enterprise_edition";
+
   reports:
     DEBUG|DEBUG_update_def::
       "DEBUG: $(this.bundle)";


### PR DESCRIPTION
In order to support environments with 3 HA nodes we need to
provide functionality allowing manual failover to 3rd HA node.
Idea is that 3rd node is used only as disaster-recovery node
and failover to that node will be manual.
CFEngine policy will limit manual steps to absolute minimum.

(cherry picked from commit a6d653c2caed4b3e43ba980d6e1463a20629641c)

Conflicts:

	controls/3.8/def.cf
	controls/3.8/update_def.cf