### PR TITLE
Fix POSIX shell detection on Solaris.

### DIFF
--- a/tests/acceptance/testall
+++ b/tests/acceptance/testall
@@ -27,18 +27,21 @@
 # Detect and replace non-POSIX shell
 #
 try_exec() {
-  type "$1" > /dev/null 2>&1 && exec "$@"
+    type "$1" > /dev/null 2>&1 && exec "$@"
 }
 
-unset foo
-(: ${foo%%bar}) 2> /dev/null
-T1="$?"
+broken_posix_shell()
+{
+    unset foo
+    local foo=1
+    test "$foo" != "1"
+}
 
-if test "$T1" != 0; then
-  try_exec /usr/xpg4/bin/sh "$0" "$@"
-  echo "No compatible shell script interpreter found."
-  echo "Please find a POSIX shell for your system."
-  exit 42
+if broken_posix_shell >/dev/null 2>&1; then
+    try_exec /usr/xpg4/bin/sh "$0" "$@"
+    echo "No compatible shell script interpreter found."
+    echo "Please find a POSIX shell for your system."
+    exit 42
 fi
 
 #


### PR DESCRIPTION
The old approach has been found not to work under some circumstances,
however this approach has been tested and found to work.