### PR TITLE
Fix: Policy errors for 3.5 and 3.6

### DIFF
--- a/controls/3.5/def_inputs.cf
+++ b/controls/3.5/def_inputs.cf
@@ -1,0 +1,1 @@
+# Unsupported on 3.5, here so that inputs do not complain.

--- a/controls/3.5/update_def_inputs.cf
+++ b/controls/3.5/update_def_inputs.cf
@@ -1,0 +1,6 @@
+# Unsupported on 3.5, here so that inputs do not complain.
+bundle common u_cfengine_enterprise
+{
+  vars:
+    "def" slist => { cf_null };
+}

--- a/controls/3.6/def_inputs.cf
+++ b/controls/3.6/def_inputs.cf
@@ -1,0 +1,4 @@
+body file control
+{
+      inputs => { @(def.augments_inputs) };
+}


### PR DESCRIPTION
- Missing inputs cause policy errors

Ref: https://dev.cfengine.com/issues/7549