### PR TITLE
Change: Move executor control mail settings

### DIFF
--- a/controls/cf_execd.cf
+++ b/controls/cf_execd.cf
@@ -15,9 +15,13 @@ body executor control
       splaytime  => "4"; # activity will be spread over this many time slices
 
     cfengine_internal_agent_email.!cfengine_internal_disable_agent_email::
-      mailto     => "$(def.mailto)";
-      mailfrom   => "$(def.mailfrom)";
-      smtpserver => "$(def.smtpserver)";
+    # Unfortunately, body executor control is unable to dereference varibles
+    # from def.cf in time to use anything loaded from def.json or the default
+    # overrides so we need to set these directly for the time being. Ref:
+    # https://dev.cfengine.com/issues/7607
+      mailto     => "root@localhost";
+      mailfrom   => "root@$(sys.fqhost)";
+      smtpserver => "localhost";
 
     any::
 

--- a/example_def.json
+++ b/example_def.json
@@ -11,17 +11,12 @@
         "my_debian_role": [ "debian.*" ],
         "services_autorun": [ "any" ],
         "cfengine_internal_disable_agent_email": [ "enterprise_edition" ],
-        "cfe_internal_core_watchdog_enabled": [ "any" ],
+        "cfe_internal_core_watchdog_enabled": [ "any" ]
     },
 
     "inputs": [ "$(sys.libdir)/bundles.cf" ],
     "vars": {
         "acl": [ ".*$(def.domain)", "$(sys.policy_hub)/16" ],
-
-        "domain": "mydomain-com",
-        "mailto": "people@mydomain-com",
-        "mailfrom": "me@mydomain-com",
-        "smtpserver": "smtp.mydomain-com",
 
         "input_name_patterns": [ ".*\\.cf",".*\\.dat",".*\\.txt", ".*\\.conf", ".*\\.mustache",
                                  ".*\\.sh", ".*\\.pl", ".*\\.py", ".*\\.rb",


### PR DESCRIPTION
Def is not fully resolved when evaluated by execd which makes it
currently not possible to set mail settings from the augments_file or
from the override vars defined in def. For now, these settings need to
be set directly for the best reliability.

Ref: https://dev.cfengine.com/issues/7607

This should be picked to 3.7.x as well if a better solution is not found.