### PR TITLE
Add path to FreeBSD's service command.

### DIFF
--- a/lib/paths.cf
+++ b/lib/paths.cf
@@ -218,6 +218,7 @@ bundle common paths
 
       "path[getfacl]"  string => "/bin/getfacl";
       "path[dtrace]"   string => "/usr/sbin/dtrace";
+      "path[service]"  string => "/usr/sbin/service";
       "path[zpool]"    string => "/sbin/zpool";
       "path[zfs]"      string => "/sbin/zfs";
 


### PR DESCRIPTION
This makes it possible for service promises to use the standard_services bundle on stock FreeBSD too.