### PR TITLE
Add FreeBSD ports package module and tests

### DIFF
--- a/lib/packages.cf
+++ b/lib/packages.cf
@@ -94,6 +94,29 @@ body package_module yum
     #default_options => {};
 }
 
+body package_module freebsd_ports
+# @brief Define details used when interfacing with the freebsd ports package
+# module.
+#
+# **Note:** Ports are expected to be setup prior to trying to use the packages
+# promise. You may need to ensure that `portsnap extract` has been run, e.g.
+# fileexists("/usr/ports/Mk/bsd.port.mk")
+#
+# **Example:**
+# ```cf3
+# bundle agent main
+# {
+#   packages:
+#     freebsd::
+#       "vim"
+#         policy => "present",
+#         package_module => freebsd_ports;
+# }
+# ```
+{
+    query_installed_ifelapsed => "60";
+    query_updates_ifelapsed => "1440";
+}
 
 bundle common packages_common
 # @ignore

--- a/modules/packages/Makefile.am
+++ b/modules/packages/Makefile.am
@@ -1,3 +1,3 @@
 package_modulesdir = $(prefix)/modules/packages
 
-dist_package_modules_SCRIPTS = apt_get yum pkgsrc
+dist_package_modules_SCRIPTS = apt_get yum pkgsrc freebsd_ports

--- a/modules/packages/freebsd_ports
+++ b/modules/packages/freebsd_ports
@@ -1,0 +1,108 @@
+#!/bin/sh -e
+
+command=$1
+
+while read -r line; do
+  export INPUT_$line
+done
+
+get_package_data() {
+  name="${INPUT_File?File must be given to get-package-data}"
+  echo PackageType=repo
+  echo Name=$name
+}
+
+list_installed() {
+  # Example pkg output:
+  # sudo-1.8.14p3
+  # Name           : sudo
+  # Version        : 1.8.14p3
+  # Installed on   : Sun Aug 16 05:36:05 UTC 2015
+  # Origin         : security/sudo
+  # Architecture   : freebsd:10:x86:64
+  #
+  # After rewrite:
+  # Name=sudo
+  # Version=1.8.14p3
+  # Architecture=none
+  pkg info -f -a | egrep '^(Name|Version|Architecture)' | sed -e 's/[ ]*:[ ]*/=/' -e 's/^Architecture=.*/Architecture=none/'
+}
+
+repo_install() {
+  name="${INPUT_Name?Name must be given to repo-install}"
+  version="${INPUT_Version}"
+
+  export BATCH=1
+  PORT_PATH=$(whereis -sq "$name")
+
+  if [ -z "$PORT_PATH" ]
+  then
+    echo "ErrorMessage=Could not install $name, port does not exist"
+    exit 0
+  fi
+
+  cd "$PORT_PATH"
+
+  if [ -n "$version" ]
+  then
+    available=$(make -V PKGVERSION)
+    if [ "$available" != "$version" ]
+    then
+      echo "ErrorMessage=Could not install $name $version, available version was $available"
+      exit 0
+    fi
+  fi
+
+  make deinstall reinstall >&2
+}
+
+update_ports_tree() {
+  portsnap --interactive fetch update >&2
+}
+
+list_updates_local() {
+  # Example pkg output:
+  # ca_root_nss-3.19.3                 <   needs updating (index has 3.20)
+  #
+  # After sed:
+  # Name=ca_root_nss
+  # Version=3.20
+  # Architecture=none
+  pkg version -v -l "<" | sed -e 's/\([^ ]*\)-[^-]* .* \(.*\))/Name=\1\
+Version=\2\
+Architecture=none/'
+}
+
+remove() {
+  name="${INPUT_Name?Name must be given to remove}"
+  BATCH=1
+  cd $(whereis -sq "$name")
+  make deinstall >&2
+}
+
+case $command in
+  supports-api-version)
+    echo 1
+  ;;
+  get-package-data)
+    get_package_data
+  ;;
+  list-installed)
+    list_installed
+  ;;
+  repo-install)
+    repo_install
+  ;;
+  list-updates)
+    update_ports_tree
+    list_updates_local
+  ;;
+  list-updates-local)
+    list_updates_local
+  ;;
+  remove)
+    remove
+  ;;
+  *)
+    echo "ErrorMessage=Invalid operation"
+esac

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -7,8 +7,9 @@ check_SCRIPTS += \
 	test_package_module_yum
 endif
 
-if HAVE_PKG_INSTALL
 if HAVE_SHUNIT2
+check_SCRIPTS += test_package_module_freebsd_ports
+if HAVE_PKG_INSTALL
 check_SCRIPTS += test_package_module_pkgsrc
 endif
 endif
@@ -16,12 +17,14 @@ endif
 TESTS = $(check_SCRIPTS)
 
 EXTRA_DIST = \
+	harness_freebsd_ports \
 	mock_apt_get \
 	mock_dpkg \
 	mock_dpkg_deb \
 	mock_dpkg_query \
 	mock_pkgin \
 	mock_pkg_info \
+	mock_freebsd_pkg \
 	mock_rpm \
 	mock_yum
 

--- a/tests/unit/harness_freebsd_ports
+++ b/tests/unit/harness_freebsd_ports
@@ -1,0 +1,97 @@
+#!/bin/sh -e
+
+whereis() {
+  case "$*" in
+  "-sq nano")
+    echo "/usr/ports/editors/nano"
+  ;;
+  "-sq ca_root_nss")
+    echo "/usr/ports/security/ca_root_nss"
+  ;;
+  "-sq madeup")
+  ;;
+  *)
+    >&2 echo "ERROR: whereis incorrect args: $*"
+    exit 1
+  ;;
+  esac
+}
+
+cd() {
+  CD_ARGS="$*"
+}
+
+make() {
+  if [ "$BATCH" != "1" ]
+  then
+    >&2 echo "ERROR: Make: BATCH != 1"
+    exit 1
+  fi
+
+  if [ "$CD_ARGS" != "$ASSERT_CWD" ]
+  then
+    >&2 echo "ASSERT:make expected to be run in directory:<$ASSERT_CWD> but ran in:<$CD_ARGS>"
+    exit 1
+  fi
+
+  if [ "$*" = "-V PKGVERSION" ]
+  then
+    case $CD_ARGS in
+    /usr/ports/editors/nano)
+      echo "2.4.2"
+    ;;
+    /usr/ports/security/ca_root_nss)
+      echo "3.20_1"
+    ;;
+    esac
+    return 0
+  fi
+
+  echo "Make output"
+
+  MAKE_RAN="$*"
+}
+
+portsnap() {
+  PORTSNAP_RAN=1
+  echo "Portsnap output"
+  expected="--interactive fetch update"
+  if [ "$*" != "$expected" ]
+  then
+    >&2 echo "ASSERT:portsnap expected:<$expected> but was:<$*>"
+    exit 1
+  fi
+}
+
+finish_and_assert() {
+  if [ "$ASSERT_MAKE_RUNS" ]
+  then
+    if [ ! "$MAKE_RAN" ]
+    then
+      >&2 echo "ASSERT:make was expected to run:<$ASSERT_MAKE_RUNS> but did not run"
+      exit 1
+    elif [ "$MAKE_RAN" != "$ASSERT_MAKE_RUNS" ]
+    then
+      >&2 echo "ASSERT:make task expected:<$ASSERT_MAKE_RUNS> but was:<$MAKE_RAN>"
+      exit 1
+    fi
+  elif [ "$MAKE_RAN" ]
+  then
+    >&2 echo "ASSERT:make was not expected to run but ran:<$MAKE_RAN>"
+    exit 1
+  fi
+
+  if [ "$ASSERT_PORTS_UPDATED" -a ! "$PORTSNAP_RAN" ]
+  then
+    >&2 echo "ASSERT:portsnap was expected to be run but it was not"
+    exit 1
+  fi
+}
+
+pkg() {
+  ./mock_freebsd_pkg "$@"
+}
+
+trap finish_and_assert EXIT
+
+. ../../modules/packages/freebsd_ports

--- a/tests/unit/mock_freebsd_pkg
+++ b/tests/unit/mock_freebsd_pkg
@@ -1,0 +1,177 @@
+#!/bin/sh -e
+
+case "$*" in
+"info -f -a")
+  cat <<EOF
+autoconf-2.69
+Name           : autoconf
+Version        : 2.69
+Installed on   : Tue Aug 18 01:11:54 UTC 2015
+Origin         : devel/autoconf
+Architecture   : freebsd:10:x86:64
+Prefix         : /usr/local
+Categories     : devel
+Licenses       :
+Maintainer     : tijl@FreeBSD.org
+WWW            : http://www.gnu.org/software/autoconf/
+Comment        : Automatically configure source code on many Un*x platforms
+Annotations    :
+Flat size      : 2.90MiB
+Description    :
+Autoconf is an extensible package of m4 macros that produce shell
+scripts to automatically configure software source code packages.
+These scripts can adapt the packages to many kinds of UNIX-like
+systems without manual user intervention.  Autoconf creates a
+configuration script for a package from a template file that lists the
+operating system features that the package can use, in the form of m4
+macro calls.
+
+WWW: http://www.gnu.org/software/autoconf/
+
+autoconf-wrapper-20131203
+Name           : autoconf-wrapper
+Version        : 20131203
+Installed on   : Tue Aug 18 01:11:53 UTC 2015
+Origin         : devel/autoconf-wrapper
+Architecture   : freebsd:10:x86:64
+Prefix         : /usr/local
+Categories     : devel
+Licenses       :
+Maintainer     : tijl@FreeBSD.org
+WWW            : UNKNOWN
+Comment        : Wrapper script for GNU autoconf
+Annotations    :
+Flat size      : 2.93KiB
+Description    :
+This port installs a wrapper script for autoconf, with symlinks to the
+unversioned name of each tool included with autoconf.  This allows the
+correct version to be selected depending on the user's requirements.
+
+cfengine-3.7.0_1
+Name           : cfengine
+Version        : 3.7.0_1
+Installed on   : Tue Sep 29 23:21:28 UTC 2015
+Origin         : sysutils/cfengine
+Architecture   : freebsd:10:x86:64
+Prefix         : /usr/local
+Categories     : sysutils
+Licenses       : GPLv3
+Maintainer     : cy@FreeBSD.org
+WWW            : http://www.cfengine.org/
+Comment        : Systems administration tool for networks
+Options        :
+	LIBVIRT        : off
+	MYSQL          : off
+	PGSQL          : off
+Shared Libs required:
+	libpcre.so.1
+	libssl.so.8
+	liblmdb.so
+	libcrypto.so.8
+Shared Libs provided:
+	libpromises.so.3
+Annotations    :
+	cpe            : cpe:2.3:a:gnu:cfengine:3.7.0:::::freebsd10:x64:1
+Flat size      : 2.38MiB
+Description    :
+Cfengine is an automated suite of programs for configuring and
+maintaining Unix-like computers. It has been used on computing arrays
+of between 1 and 20,000 computers since 1993 by a wide range of
+organizations. Cfengine is supported by active research and was the
+first autonomic, hands-free management system for Unix-like operating
+systems. Cfengine is an autonomic maintenance system not merely a
+change management roll-out tool. Cfengine has a history of security
+and adaptability.
+
+WWW: http://www.cfengine.org/
+
+gettext-tools-0.19.5.1
+Name           : gettext-tools
+Version        : 0.19.5.1
+Installed on   : Sun Aug 16 05:35:50 UTC 2015
+Origin         : devel/gettext-tools
+Architecture   : freebsd:10:x86:64
+Prefix         : /usr/local
+Categories     : devel
+Licenses       : GPLv3
+Maintainer     : tijl@FreeBSD.org
+WWW            : http://www.gnu.org/software/gettext/
+Comment        : GNU gettext development and translation tools
+Options        :
+	DOCS           : on
+	THREADS        : on
+Shared Libs required:
+	libintl.so.8
+	libexpat.so.1
+Shared Libs provided:
+	libgettextpo.so.0
+	libgettextlib-0.19.5.1.so
+	libgettextsrc-0.19.5.1.so
+Annotations    :
+	cpe            : cpe:2.3:a:gnu:gettext:0.19.5.1:::::freebsd10:x64
+Flat size      : 9.78MiB
+Description    :
+GNU gettext is a framework of libraries and tools for internationalisation
+and localisation of software.
+
+This package contains development and translation tools.
+
+WWW: http://www.gnu.org/software/gettext/
+sudo-1.8.14p3
+Name           : sudo
+Version        : 1.8.14p3
+Installed on   : Sun Aug 16 05:36:05 UTC 2015
+Origin         : security/sudo
+Architecture   : freebsd:10:x86:64
+Prefix         : /usr/local
+Categories     : security
+Licenses       : sudo
+Maintainer     : garga@FreeBSD.org
+WWW            : http://www.sudo.ws/
+Comment        : Allow others to run commands as root
+Options        :
+	AUDIT          : on
+	DISABLE_AUTH   : off
+	DISABLE_ROOT_SUDO: off
+	DOCS           : on
+	INSULTS        : on
+	LDAP           : off
+	NLS            : on
+	NOARGS_SHELL   : on
+	OPIE           : off
+	SSSD           : off
+Shared Libs required:
+	libintl.so.8
+Shared Libs provided:
+	libsudo_util.so.0
+Annotations    :
+	cpe            : cpe:2.3:a:todd_miller:sudo:1.8.14p3:::::freebsd10:x64
+Flat size      : 3.33MiB
+Description    :
+This is the CU version of sudo.
+
+Sudo is a program designed to allow a sysadmin to give limited root
+privileges to users and log root activity.  The basic philosophy is to
+give as few privileges as possible but still allow people to get their
+work done.
+
+WWW: http://www.sudo.ws/
+EOF
+;;
+
+"version -v -l <")
+  cat <<EOF
+ca_root_nss-3.19.3                 <   needs updating (index has 3.20_1)
+portmaster-3.17.7                  <   needs updating (index has 3.17.8)
+EOF
+;;
+
+"info -e ca_root_nss")
+  exit 0
+;;
+
+"info -e nano")
+  exit 1
+;;
+
+esac

--- a/tests/unit/test_package_module_freebsd_ports
+++ b/tests/unit/test_package_module_freebsd_ports
@@ -1,0 +1,183 @@
+#! /bin/sh
+
+FREEBSD_PORTS=./harness_freebsd_ports
+
+setUp()
+{
+  unset ASSERT_MAKE_RUNS
+  unset ASSERT_CWD
+  unset ASSERT_PORTS_UPDATED
+}
+
+testApiVersion()
+{
+  actual=`echo | $FREEBSD_PORTS supports-api-version`
+
+  assertEquals "exit code" 0 $?
+  assertEquals 1 "$actual"
+}
+
+testInvalidComand()
+{
+  actual=`echo | $FREEBSD_PORTS oogly-boogly-moogly`
+
+  assertEquals "exit code" 0 $?
+  assertEquals "ErrorMessage=Invalid operation" "$actual"
+}
+
+testGetData()
+{
+  input="File=zip
+Version=3.0-4
+Architecture=none"
+  expected="PackageType=repo
+Name=zip"
+
+  actual=`echo "$input" | $FREEBSD_PORTS get-package-data`
+
+  assertEquals "exit code" 0 $?
+  assertEquals "$expected" "$actual"
+}
+
+testListPackages()
+{
+  expected="Name=autoconf
+Version=2.69
+Architecture=none
+Name=autoconf-wrapper
+Version=20131203
+Architecture=none
+Name=cfengine
+Version=3.7.0_1
+Architecture=none
+Name=gettext-tools
+Version=0.19.5.1
+Architecture=none
+Name=sudo
+Version=1.8.14p3
+Architecture=none"
+
+  actual=`echo | $FREEBSD_PORTS list-installed`
+
+  assertEquals "exit code" 0 $?
+  assertEquals "$expected" "$actual"
+}
+
+testInstallPackage()
+{
+  input="Name=nano
+Version=2.4.2
+Architecture=none"
+  ASSERT_MAKE_RUNS="deinstall reinstall"
+  export ASSERT_MAKE_RUNS
+  ASSERT_CWD=/usr/ports/editors/nano
+  export ASSERT_CWD
+
+  actual=`echo "$input" | $FREEBSD_PORTS repo-install`
+
+  assertEquals "exit code" 0 $?
+  assertEquals "" "$actual"
+}
+
+testListUpdates()
+{
+  expected="Name=ca_root_nss
+Version=3.20_1
+Architecture=none
+Name=portmaster
+Version=3.17.8
+Architecture=none"
+  ASSERT_PORTS_UPDATED=1
+  export ASSERT_PORTS_UPDATED
+
+  actual=`echo | $FREEBSD_PORTS list-updates`
+
+  assertEquals "exit code" 0 $?
+  assertEquals "$expected" "$actual"
+}
+
+
+testListUpdatesLocal()
+{
+  expected="Name=ca_root_nss
+Version=3.20_1
+Architecture=none
+Name=portmaster
+Version=3.17.8
+Architecture=none"
+
+  actual=`echo | $FREEBSD_PORTS list-updates-local`
+
+  assertEquals "exit code" 0 $?
+  assertEquals "$expected" "$actual"
+}
+
+testUpdatePackage()
+{
+  input="Name=ca_root_nss
+Version=3.20_1"
+  ASSERT_MAKE_RUNS="deinstall reinstall"
+  export ASSERT_MAKE_RUNS
+  ASSERT_CWD=/usr/ports/security/ca_root_nss
+  export ASSERT_CWD
+
+  actual=`echo "$input" | $FREEBSD_PORTS repo-install`
+
+  assertEquals "exit code" 0 $?
+  assertEquals "" "$actual"
+}
+
+testInstallWrongVersion()
+{
+  input="Name=nano
+Version=2.4.3
+Architecture=none"
+  ASSERT_CWD=/usr/ports/editors/nano
+  export ASSERT_CWD
+
+  actual=`echo "$input" | $FREEBSD_PORTS repo-install`
+
+  assertEquals "exit code" 0 $?
+  assertEquals "ErrorMessage=Could not install nano 2.4.3, available version was 2.4.2" "$actual"
+}
+
+testInstallAnyVersion()
+{
+  input="Name=nano
+Architecture=none"
+  ASSERT_MAKE_RUNS="deinstall reinstall"
+  export ASSERT_MAKE_RUNS
+  ASSERT_CWD=/usr/ports/editors/nano
+  export ASSERT_CWD
+
+  actual=`echo "$input" | $FREEBSD_PORTS repo-install`
+
+  assertEquals "exit code" 0 $?
+  assertEquals "" "$actual"
+}
+
+testRemove()
+{
+  input="Name=nano"
+  ASSERT_MAKE_RUNS=deinstall
+  export ASSERT_MAKE_RUNS
+  ASSERT_CWD=/usr/ports/editors/nano
+  export ASSERT_CWD
+
+  actual=`echo "$input" | $FREEBSD_PORTS remove`
+
+  assertEquals "exit code" 0 $?
+  assertEquals "" "$actual"
+}
+
+testTryInstallNonexistentPackage()
+{
+  input="Name=madeup"
+
+  actual=`echo "$input" | $FREEBSD_PORTS repo-install`
+
+  assertEquals "exit code" 0 $?
+  assertEquals "ErrorMessage=Could not install madeup, port does not exist" "$actual"
+}
+
+. `which shunit2`


### PR DESCRIPTION
This is my initial stab at adding support for the FreeBSD ports system via a package module.

Nice things:
* It exists and it works – yay FreeBSD support!
* It has no dependencies outside of the FreeBSD base system (other than assuming a bootstrapped pkg, which I think is reasonable)
* It's tested

Areas that (might) need work that I know of:
* The Architecture is faked at the moment
* It can't install more than one package at a time – it wasn't clear to me from the docs if this is necessary
* My m4 knowledge is non-existent so the way I've crammed my tests in is probably not ideal
