### PR TITLE
Change: Backport documentation fix in stdlib services

### DIFF
--- a/lib/3.6/services.cf
+++ b/lib/3.6/services.cf
@@ -403,8 +403,6 @@ bundle agent classic_services(service,state)
 #    "pattern[rhnsd]"        string => "rhnsd";
 # ```
 #
-# ---
-#
 # If *any* of the `(re)?(start|load|stop)command` variables are set for
 # your service, they take _priority_ in case there's conflict of intent
 # with other data.


### PR DESCRIPTION
Manually backported commit 47ab7b0
Ref: https://dev.cfengine.com/issues/7663