### PR TITLE
Remove: Support for email settings from augments_file

### DIFF
--- a/controls/def.cf
+++ b/controls/def.cf
@@ -44,25 +44,20 @@ bundle common def
     any::
       # Begin change
 
+      # Email settings are currently unable to be set from def.json, and must
+      # be set directly. 
       # Your domain name, for use in access control
-      "domain"  string => ifelse(isvariable("override_data_domain"), "$(override_data_domain)",
-                                "$(sys.domain)"), # this default may be inaccurate!
+      # Note: this default may be inaccurate!
+      "domain"  string => "$(sys.domain)",
       comment => "Define a global domain for all hosts",
-      handle => "common_def_vars_domain",
-      meta => { "defvar" };
+      handle => "common_def_vars_domain";
 
       # Mail settings used by body executor control found in controls/cf_execd.cf
-      "mailto" string => ifelse(isvariable("override_data_mailto"), "$(override_data_mailto)",
-                               "root@$(def.domain)"),
-      meta => { "defvar" };
+      "mailto" string => "root@$(def.domain)";
 
-      "mailfrom" string => ifelse(isvariable("override_data_mailfrom"), "$(override_data_mailfrom)",
-                                 "root@$(sys.uqhost).$(def.domain)"),
-      meta => { "defvar" };
+      "mailfrom" string => "root@$(sys.uqhost).$(def.domain)";
 
-      "smtpserver" string => ifelse(isvariable("override_data_smtpserver"), "$(override_data_smtpserver)",
-                                   "localhost"),
-      meta => { "defvar" };
+      "smtpserver" string => "localhost";
 
       # List here the IP masks that we grant access to on the server
 

--- a/example_def.json
+++ b/example_def.json
@@ -11,17 +11,12 @@
         "my_debian_role": [ "debian.*" ],
         "services_autorun": [ "any" ],
         "cfengine_internal_disable_agent_email": [ "enterprise_edition" ],
-        "cfe_internal_core_watchdog_enabled": [ "any" ],
+        "cfe_internal_core_watchdog_enabled": [ "any" ]
     },
 
     "inputs": [ "$(sys.libdir)/bundles.cf" ],
     "vars": {
         "acl": [ ".*$(def.domain)", "$(sys.policy_hub)/16" ],
-
-        "domain": "mydomain-com",
-        "mailto": "people@mydomain-com",
-        "mailfrom": "me@mydomain-com",
-        "smtpserver": "smtp.mydomain-com",
 
         "input_name_patterns": [ ".*\\.cf",".*\\.dat",".*\\.txt", ".*\\.conf", ".*\\.mustache",
                                  ".*\\.sh", ".*\\.pl", ".*\\.py", ".*\\.rb",


### PR DESCRIPTION
- Values do not resolve early enough for execd to make use of them

Ref: https://dev.cfengine.com/issues/7682

Changelog: Title
(cherry picked from commit f2f33f31f2bd92fb7a4af431bd7c90f007b7eb55)