### PR TITLE
Change: Make sure that 3.7 lib dir gets deployed

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,7 +10,7 @@ endif
 nobase_dist_masterfiles_DATA = @MASTERFILES_INSTALL_TARGETS@
 masterfilesdir=$(datadir)
 
-EXTRA_DIST = README.md inventory/README.md lib/README.md CONTRIBUTING.md LICENSE
+EXTRA_DIST = README.md inventory/README.md lib/README.md lib/3.7/README.md CONTRIBUTING.md LICENSE
 
 # Do not reveal usernames of the buildslave
 TAR_OPTIONS = --owner=0 --group=0


### PR DESCRIPTION
Without this directory being deployed 3.7 agents running new policy will
error when running the policy.

Ref: https://dev.cfengine.com/issues/7680
(cherry picked from commit 0fcea444d8e84dfbfc2fbca9fd01cc445899bd1c)