### PR TITLE
Add: lib/3.7/README.md to install path

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -169,6 +169,11 @@ do
     done
 done
 
+dnl The lib/3.7/README.md is special, so that 3.7 agents can load the stdlib after the version split reunion
+for i in lib/3.7/README.md
+do
+    MASTERFILES_INSTALL_TARGETS="$MASTERFILES_INSTALL_TARGETS $i"
+done
 AC_SUBST(MASTERFILES_INSTALL_TARGETS)
 
 


### PR DESCRIPTION
Without this lib/3.7 directory 3.7 agents running the latest masterfiles
will be unable to locate the stdlib. Since some version control systems
automatically stop tracking empty directories we have this README
present to explain the directories presence, and keep it around.

Ref: https://dev.cfengine.com/issues/7680
(cherry picked from commit 97e77d8f04e5c0a99cdf40d2155e1c6c51806037)