### PR TITLE
Redmine #7737: Error while reading cf-consumer.pid file.

### DIFF
--- a/lib/3.7/cfe_internal_hub.cf
+++ b/lib/3.7/cfe_internal_hub.cf
@@ -262,8 +262,10 @@ bundle agent cfe_internal_postgresql_maintenance
       handle => "cfe_internal_postgresql_maintenance_vacuum_full";
 
     policy_server.enterprise.!cfengine_3_5::
-      "cf_consumer_pid" string => readfile("$(sys.workdir)/cf-consumer.pid", 0),
-      comment => "Read cf-consumer.pid for the main cf-consumer PID";
+      "cf_consumer_pid" 
+        string => readfile("$(sys.workdir)/cf-consumer.pid", 0),
+        ifvarclass => fileexists( "$(sys.workdir)/cf-consumer.pid" ),
+        comment => "Read cf-consumer.pid for the main cf-consumer PID";
 
   classes:
       "cf_consumer_pid_correct" expression => isvariable("cf_consumer_pid"),


### PR DESCRIPTION
Fix error messages while reading file during bootstrap.

(cherry picked from commit 2b47f31c64435b9bc15df75584bb2d826890e667)