### PR TITLE
Add missing override_classes to control/def.cf

### DIFF
--- a/controls/3.6/def.cf
+++ b/controls/3.6/def.cf
@@ -36,6 +36,7 @@ bundle common def
 
       "augments_inputs" slist => getvalues("augments[inputs]");
       "override_vars" slist => getindices("augments[vars]");
+      "override_classes" slist => getindices("augments[classes]");
       "override_data_$(override_vars)" data => mergedata("augments[vars][$(override_vars)]");
       "override_data_s_$(override_vars)" string => format("%S", "override_data_$(override_vars)");
 

--- a/controls/3.7/def.cf
+++ b/controls/3.7/def.cf
@@ -31,6 +31,7 @@ bundle common def
 
       "augments_inputs" slist => getvalues("augments[inputs]");
       "override_vars" slist => getindices("augments[vars]");
+      "override_classes" slist => getvalues("augments[classes]");
       "override_data_$(override_vars)" data => mergedata("augments[vars][$(override_vars)]");
       "override_data_s_$(override_vars)" string => format("%S", "override_data_$(override_vars)");
 


### PR DESCRIPTION
(cherry picked from commit 7838d8081756b54c1f3c4e8564a86cbc9b6f1ab5)

Changelog: Fix definition of classes from augments file