### PR TITLE
services: allow explicit use of standard_services

### DIFF
--- a/lib/services.cf
+++ b/lib/services.cf
@@ -97,9 +97,11 @@ body service_method standard_services
 # By default this service_method is *not* used. The call for standard_services
 # is within the core and not here. In case you use a promise like:
 #
-## services:
-##     "ssh"
-##       service_policy => "start";
+# ```cf3
+# services:
+#     "ssh"
+#       service_policy => "start";
+# ```
 #
 # Then this method is skipped and CFEngine calls standard_services bundle
 # directly. This is here as a helper in case you wan't to be explicit
@@ -118,7 +120,7 @@ body service_method standard_services
 #       service_method => standard_services;
 # ```
 {
-      service_bundle => standard_services("$(this.promiser)","$(this.service_policy)");
+        service_bundle => standard_services( $(this.promiser), $(this.service_policy) );
 }
 
 ##

--- a/lib/services.cf
+++ b/lib/services.cf
@@ -91,6 +91,36 @@ body service_method force_deps
       service_type => "windows";
 }
 
+body service_method standard_services
+# @brief Default services_method for when you wan't to call it explicitly
+#
+# By default this service_method is *not* used. The call for standard_services
+# is within the core and not here. In case you use a promise like:
+#
+## services:
+##     "ssh"
+##       service_policy => "start";
+#
+# Then this method is skipped and CFEngine calls standard_services bundle
+# directly. This is here as a helper in case you wan't to be explicit
+# with your service promise and point it to standard_services (for readability,
+# documentation, etc).
+#
+# Do note that any options defined in this method does not apply to service
+# promises without explicit template_method call for standard_services.
+#
+# **Example:**
+#
+# ```cf3
+# services:
+#     "ssh"
+#       service_policy => "start",
+#       service_method => standard_services;
+# ```
+{
+      service_bundle => standard_services("$(this.promiser)","$(this.service_policy)");
+}
+
 ##
 
 bundle agent standard_services(service,state)


### PR DESCRIPTION
This will add a minimalist `standard_services` method.

I have multiple service libraries and wanted to be explicit about which one I use. Alas, I couldn't do that with the `standard_services`. Only way to use it is to omit the `service_method` entirely. Attempting to use it directly and you end up with:

* `error: Undefined body standard_services with type service_method`

Don't know if you wan't this in libs as it can be confusing for users. This would imply that you could change the method in libs and reap the benefits even if you don't use `service_method => standard_services` explicitly. Didn't test that tho, might even work like that ;)