### PR TITLE
Change: Guard policy parsing of augments_file

### DIFF
--- a/controls/def.cf
+++ b/controls/def.cf
@@ -7,6 +7,9 @@
 bundle common def
 {
   classes:
+    # If the augments_file is parsed from C then we do not need to do this work
+    # from policy.
+    !feature_augments::
       # all override classes are defined true
       "$(override_classes)" expression => "any", meta => { "override" };
 
@@ -14,19 +17,19 @@ bundle common def
       "have_augments_classes" expression => isvariable("augments[classes]"), scope => "bundle";
       "have_augments_inputs" expression => isvariable("augments[inputs]"), scope => "bundle";
 
-    have_augments_classes::
+    have_augments_classes.!feature_augments::
       "$(augments_classes_data_keys)"
         expression => classmatch("$(augments[classes][$(augments_classes_data_keys)])"),
         meta => { "augments_class", "derived_from=$(augments_file)" };
 
   vars:
 
-    any::
+    !feature_augments::
       "augments_file" string => "$(this.promise_dirname)/../def.json";
 
       "defvars" slist => variablesmatching("default:def\..*", "defvar");
 
-    have_augments_file::
+    have_augments_file.!feature_augments::
       "augments" data => readjson($(augments_file), 100k), ifvarclass => "have_augments_file";
 
       "augments_inputs" slist => getvalues("augments[inputs]");
@@ -35,10 +38,10 @@ bundle common def
       "override_data_$(override_vars)" data => mergedata("augments[vars][$(override_vars)]");
       "override_data_s_$(override_vars)" string => format("%S", "override_data_$(override_vars)");
 
-    !have_augments_file::
+    !have_augments_file.!feature_augments::
       "augments_inputs" slist => {};
 
-    have_augments_classes::
+    have_augments_classes.!feature_augments::
       "augments_classes_data" data => mergedata("augments[classes]");
       "augments_classes_data_keys" slist => getindices("augments_classes_data");
 

--- a/controls/def.cf
+++ b/controls/def.cf
@@ -49,66 +49,81 @@ bundle common def
       # Begin change
 
       # Email settings are currently unable to be set from def.json, and must
-      # be set directly. 
+      # be set directly.
       # Your domain name, for use in access control
       # Note: this default may be inaccurate!
-      "domain"  string => "$(sys.domain)",
-      comment => "Define a global domain for all hosts",
-      handle => "common_def_vars_domain";
+      "domain"
+        string => "$(sys.domain)",
+        comment => "Define a global domain for all hosts",
+        handle => "common_def_vars_domain",
+        ifvarclass => not(isvariable("domain"));
 
       # Mail settings used by body executor control found in controls/cf_execd.cf
-      "mailto" string => "root@$(def.domain)";
+      "mailto"
+        string => "root@$(def.domain)",
+        ifvarclass => not(isvariable("mailto"));
 
-      "mailfrom" string => "root@$(sys.uqhost).$(def.domain)";
+      "mailfrom"
+        string => "root@$(sys.uqhost).$(def.domain)",
+        ifvarclass => not(isvariable("mailfrom"));
 
-      "smtpserver" string => "localhost";
+      "smtpserver"
+        string => "localhost",
+        ifvarclass => not(isvariable("smtpserver"));
 
       # List here the IP masks that we grant access to on the server
 
-      "acl"     slist => getvalues("override_data_acl"),
-      comment => "JSON-sourced: Define an acl for the machines to be granted accesses",
-      handle => "common_def_json_vars_acl",
-      ifvarclass => isvariable("override_data_acl"),
-      meta => { "defvar" };
+      # Only define here if we are not capable of parsing augments from C
+      "acl"
+        slist => getvalues("override_data_acl"),
+        comment => "JSON-sourced: Define an acl for the machines to be granted accesses",
+        handle => "common_def_json_vars_acl",
+        ifvarclass => and(isvariable("override_data_acl"), "!feature_augments"),
+        meta => { "defvar" };
 
-      "acl"     slist => {
-                           # Allow everything in my own domain.
+      "acl"
+        slist => {
+                   # Allow everything in my own domain.
 
-                           # Note that this:
-                           # 1. requires def.domain to be correctly set
-                           # 2. will cause a DNS lookup for every access
-                           # ".*$(def.domain)",
+                   # Note that this:
+                   # 1. requires def.domain to be correctly set
+                   # 2. will cause a DNS lookup for every access
+                   # ".*$(def.domain)",
 
-                           # Assume /16 LAN clients to start with
-                           "$(sys.policy_hub)/16",
+                   # Assume /16 LAN clients to start with
+                   "$(sys.policy_hub)/16",
 
-                           # Uncomment below if HA is used
-                           #"@(def.policy_servers)"
+                   # Uncomment below if HA is used
+                   #"@(def.policy_servers)"
 
-                           #  "2001:700:700:3.*",
-                           #  "217.77.34.18",
-                           #  "217.77.34.19",
-      },
-      comment => "Define an acl for the machines to be granted accesses",
-      handle => "common_def_vars_acl",
-      ifvarclass => not(isvariable("override_data_acl")),
-      meta => { "defvar" };
+                   #  "2001:700:700:3.*",
+                   #  "217.77.34.18",
+                   #  "217.77.34.19",
+        },
+        comment => "Define an acl for the machines to be granted accesses",
+        handle => "common_def_vars_acl",
+        ifvarclass => and(not(isvariable("override_data_acl")), not(isvariable("acl"))),
+        meta => { "defvar" };
 
       # Out of the hosts in allowconnects, trust new keys only from the
       # following ones.  This is open by default for bootstrapping.
 
-      "trustkeysfrom" slist => getvalues("override_data_trustkeysfrom"),
-      comment => "JSON-sourced: define from which machines keys can be trusted",
-      ifvarclass => isvariable("override_data_trustkeysfrom"),
-      meta => { "defvar" };
+      # Only define here if we are not capable of parsing augments from C
+      "trustkeysfrom"
+        slist => getvalues("override_data_trustkeysfrom"),
+        comment => "JSON-sourced: define from which machines keys can be trusted",
+        ifvarclass => and(isvariable("override_data_trustkeysfrom"), "!feature_augments"),
+        meta => { "defvar" };
 
-      "trustkeysfrom" slist => {
-                                 # COMMENT THE NEXT LINE OUT AFTER ALL MACHINES HAVE BEEN BOOTSTRAPPED.
-                                 "0.0.0.0/0", # allow any IP
-      },
-      comment => "Define from which machines keys can be trusted",
-      ifvarclass => not(isvariable("override_data_trustkeysfrom")),
-      meta => { "defvar" };
+      "trustkeysfrom"
+        slist => {
+                   # COMMENT THE NEXT LINE OUT AFTER ALL MACHINES HAVE BEEN BOOTSTRAPPED.
+                   "0.0.0.0/0", # allow any IP
+        },
+        comment => "Define from which machines keys can be trusted",
+        ifvarclass => and(not(isvariable("override_data_trustkeysfrom")),
+                          not(isvariable("trustkeysfrom"))),
+        meta => { "defvar" };
 
     debian::
       "environment_vars"

--- a/controls/def.cf
+++ b/controls/def.cf
@@ -9,7 +9,7 @@ bundle common def
   classes:
     # If the augments_file is parsed from C then we do not need to do this work
     # from policy.
-    !feature_augments::
+    !feature_def_json_preparse::
       # all override classes are defined true
       "$(override_classes)" expression => "any", meta => { "override" };
 
@@ -17,19 +17,19 @@ bundle common def
       "have_augments_classes" expression => isvariable("augments[classes]"), scope => "bundle";
       "have_augments_inputs" expression => isvariable("augments[inputs]"), scope => "bundle";
 
-    have_augments_classes.!feature_augments::
+    have_augments_classes.!feature_def_json_preparse::
       "$(augments_classes_data_keys)"
         expression => classmatch("$(augments[classes][$(augments_classes_data_keys)])"),
         meta => { "augments_class", "derived_from=$(augments_file)" };
 
   vars:
 
-    !feature_augments::
+    !feature_def_json_preparse::
       "augments_file" string => "$(this.promise_dirname)/../def.json";
 
       "defvars" slist => variablesmatching("default:def\..*", "defvar");
 
-    have_augments_file.!feature_augments::
+    have_augments_file.!feature_def_json_preparse::
       "augments" data => readjson($(augments_file), 100k), ifvarclass => "have_augments_file";
 
       "augments_inputs" slist => getvalues("augments[inputs]");
@@ -38,10 +38,10 @@ bundle common def
       "override_data_$(override_vars)" data => mergedata("augments[vars][$(override_vars)]");
       "override_data_s_$(override_vars)" string => format("%S", "override_data_$(override_vars)");
 
-    !have_augments_file.!feature_augments::
+    !have_augments_file.!feature_def_json_preparse::
       "augments_inputs" slist => {};
 
-    have_augments_classes.!feature_augments::
+    have_augments_classes.!feature_def_json_preparse::
       "augments_classes_data" data => mergedata("augments[classes]");
       "augments_classes_data_keys" slist => getindices("augments_classes_data");
 
@@ -78,7 +78,7 @@ bundle common def
         slist => getvalues("override_data_acl"),
         comment => "JSON-sourced: Define an acl for the machines to be granted accesses",
         handle => "common_def_json_vars_acl",
-        ifvarclass => and(isvariable("override_data_acl"), "!feature_augments"),
+        ifvarclass => and(isvariable("override_data_acl"), "!feature_def_json_preparse"),
         meta => { "defvar" };
 
       "acl"
@@ -112,7 +112,7 @@ bundle common def
       "trustkeysfrom"
         slist => getvalues("override_data_trustkeysfrom"),
         comment => "JSON-sourced: define from which machines keys can be trusted",
-        ifvarclass => and(isvariable("override_data_trustkeysfrom"), "!feature_augments"),
+        ifvarclass => and(isvariable("override_data_trustkeysfrom"), "!feature_def_json_preparse"),
         meta => { "defvar" };
 
       "trustkeysfrom"
@@ -334,9 +334,9 @@ bundle common def
 
       "$(const.t) $(defvars) = $($(defvars))";
       "DEBUG $(this.bundle): Agent parsed augments_file"
-        ifvarclass => "have_augments_file.feature_augments";
+        ifvarclass => "have_augments_file.feature_def_json_preparse";
       "DEBUG $(this.bundle): Policy parsed augments_file"
-        ifvarclass => "have_augments_file.!feature_augments";
+        ifvarclass => "have_augments_file.!feature_def_json_preparse";
 }
 
 bundle common inventory_control

--- a/controls/def.cf
+++ b/controls/def.cf
@@ -333,6 +333,10 @@ bundle common def
       ifvarclass => "$(augments_classes_data_keys)";
 
       "$(const.t) $(defvars) = $($(defvars))";
+      "DEBUG $(this.bundle): Agent parsed augments_file"
+        ifvarclass => "have_augments_file.feature_augments";
+      "DEBUG $(this.bundle): Policy parsed augments_file"
+        ifvarclass => "have_augments_file.!feature_augments";
 }
 
 bundle common inventory_control

--- a/controls/update_def.cf
+++ b/controls/update_def.cf
@@ -1,25 +1,27 @@
 bundle common update_def
 {
   classes:
+    !feature_augments::
       # all override classes are defined true
       "$(override_classes)" expression => "any", meta => { "override" };
 
       "have_augments_file" expression => fileexists($(augments_file)), scope => "bundle";
       "have_augments_classes" expression => isvariable("augments[classes]"), scope => "bundle";
 
-    have_augments_classes::
+    have_augments_classes.!feature_augments::
       "$(augments_classes_data_keys)"
         expression => classmatch("$(augments[classes][$(augments_classes_data_keys)])"),
         meta => { "augments_class", "derived_from=$(augments_file)" };
 
   vars:
       "current_version" string => "3.7.0";
-    any::
+
+    !feature_augments::
       "augments_file" string => "$(this.promise_dirname)/../../def.json";
 
       "defvars" slist => variablesmatching("default:update_def\..*", "defvar");
 
-    have_augments_file::
+    have_augments_file.!feature_augments::
       "augments" data => readjson($(augments_file), 100k), ifvarclass => "have_augments_file";
 
       "override_vars" slist => getindices("augments[vars]");
@@ -27,7 +29,7 @@ bundle common update_def
       "override_data_$(override_vars)" data => mergedata("augments[vars][$(override_vars)]");
       "override_data_s_$(override_vars)" string => format("%S", "override_data_$(override_vars)");
 
-    have_augments_classes::
+    have_augments_classes.!feature_augments::
       "augments_classes_data" data => mergedata("augments[classes]");
       "augments_classes_data_keys" slist => getindices("augments_classes_data");
 

--- a/controls/update_def.cf
+++ b/controls/update_def.cf
@@ -1,14 +1,14 @@
 bundle common update_def
 {
   classes:
-    !feature_augments::
+    !feature_def_json_preparse::
       # all override classes are defined true
       "$(override_classes)" expression => "any", meta => { "override" };
 
       "have_augments_file" expression => fileexists($(augments_file)), scope => "bundle";
       "have_augments_classes" expression => isvariable("augments[classes]"), scope => "bundle";
 
-    have_augments_classes.!feature_augments::
+    have_augments_classes.!feature_def_json_preparse::
       "$(augments_classes_data_keys)"
         expression => classmatch("$(augments[classes][$(augments_classes_data_keys)])"),
         meta => { "augments_class", "derived_from=$(augments_file)" };
@@ -16,12 +16,12 @@ bundle common update_def
   vars:
       "current_version" string => "3.7.0";
 
-    !feature_augments::
+    !feature_def_json_preparse::
       "augments_file" string => "$(this.promise_dirname)/../../def.json";
 
       "defvars" slist => variablesmatching("default:update_def\..*", "defvar");
 
-    have_augments_file.!feature_augments::
+    have_augments_file.!feature_def_json_preparse::
       "augments" data => readjson($(augments_file), 100k), ifvarclass => "have_augments_file";
 
       "override_vars" slist => getindices("augments[vars]");
@@ -29,7 +29,7 @@ bundle common update_def
       "override_data_$(override_vars)" data => mergedata("augments[vars][$(override_vars)]");
       "override_data_s_$(override_vars)" string => format("%S", "override_data_$(override_vars)");
 
-    have_augments_classes.!feature_augments::
+    have_augments_classes.!feature_def_json_preparse::
       "augments_classes_data" data => mergedata("augments[classes]");
       "augments_classes_data_keys" slist => getindices("augments_classes_data");
 
@@ -42,8 +42,8 @@ bundle common update_def
         slist => getvalues("override_data_input_name_patterns"),
         comment => "JSON-sourced filename patterns to match when updating the policy
                     (see update/update_policy.cf)",
-        handle => "common_def_json_vars_input_name_patterns_without_feature_augments",
-        ifvarclass => and(isvariable("override_data_input_name_patterns"), "!feature_augments"),
+        handle => "common_def_json_vars_input_name_patterns_without_feature_def_json_preparse",
+        ifvarclass => and(isvariable("override_data_input_name_patterns"), "!feature_def_json_preparse"),
         meta => { "defvar" };
 
       # Default the input name patterns, if we don't find it defined in def
@@ -66,7 +66,7 @@ bundle common update_def
         slist => { @(def.input_name_patterns) },
         comment => "Filename patterns to match when updating the policy
                     (see update/update_policy.cf)",
-        handle => "common_def_vars_input_name_patterns_from_def_with_feature_augments",
+        handle => "common_def_vars_input_name_patterns_from_def_with_feature_def_json_preparse",
         ifvarclass => and( isvariable("def.input_name_patterns"),
                            not(isvariable("input_name_patterns"))),
         meta => { "defvar" };
@@ -191,8 +191,8 @@ bundle common update_def
       "$(const.t) override class $(override_classes)";
       "$(const.t) $(defvars) = $($(defvars))";
       "DEBUG $(this.bundle): Agent parsed augments_file"
-        ifvarclass => "have_augments_file.feature_augments";
+        ifvarclass => "have_augments_file.feature_def_json_preparse";
       "DEBUG $(this.bundle): Policy parsed augments_file"
-        ifvarclass => "have_augments_file.!feature_augments";
+        ifvarclass => "have_augments_file.!feature_def_json_preparse";
       "DEBUG $(this.bundle): input_name_pattern = '$(input_name_patterns)'";
 }

--- a/controls/update_def.cf
+++ b/controls/update_def.cf
@@ -36,19 +36,40 @@ bundle common update_def
     any::
       # Begin change
 
-      "input_name_patterns" slist => getvalues("override_data_input_name_patterns"),
-      comment => "JSON-sourced filename patterns to match when updating the policy (see update/update_policy.cf)",
-      handle => "common_def_json_vars_input_name_patterns",
-      ifvarclass => isvariable("override_data_input_name_patterns"),
-      meta => { "defvar" };
+      # When parsing the augments_file from policy, we set input_name_patterns
+      # based on the data extracted from within policy
+      "input_name_patterns"
+        slist => getvalues("override_data_input_name_patterns"),
+        comment => "JSON-sourced filename patterns to match when updating the policy
+                    (see update/update_policy.cf)",
+        handle => "common_def_json_vars_input_name_patterns_without_feature_augments",
+        ifvarclass => and(isvariable("override_data_input_name_patterns"), "!feature_augments"),
+        meta => { "defvar" };
 
-      "input_name_patterns" slist => { ".*\.cf",".*\.dat",".*\.txt", ".*\.conf", ".*\.mustache",
-                                       ".*\.sh", ".*\.pl", ".*\.py", ".*\.rb",
-                                       "cf_promises_release_id", ".*\.json", ".*\.yaml" },
-      comment => "Filename patterns to match when updating the policy (see update/update_policy.cf)",
-      handle => "common_def_vars_input_name_patterns",
-      ifvarclass => not(isvariable("override_data_input_name_patterns")),
-      meta => { "defvar" };
+      # Default the input name patterns, if we don't find it defined in def
+      # (from the augments_file).
+      "input_name_patterns"
+        slist => { ".*\.cf",".*\.dat",".*\.txt", ".*\.conf", ".*\.mustache",
+                   ".*\.sh", ".*\.pl", ".*\.py", ".*\.rb",
+                   "cf_promises_release_id", ".*\.json", ".*\.yaml" },
+        comment => "Filename patterns to match when updating the policy
+                    (see update/update_policy.cf)",
+        handle => "common_def_vars_input_name_patterns_policy_default",
+        ifvarclass => and(and(not(isvariable("override_data_acl")),
+                          not(isvariable("input_name_patterns"))),
+                          not(isvariable("def.input_name_patterns"))),
+        meta => { "defvar" };
+
+      # define based on data in def (which comes from augments file), if
+      # present and input_name_patterns is not yet defined.).
+      "input_name_patterns"
+        slist => { @(def.input_name_patterns) },
+        comment => "Filename patterns to match when updating the policy
+                    (see update/update_policy.cf)",
+        handle => "common_def_vars_input_name_patterns_from_def_with_feature_augments",
+        ifvarclass => and( isvariable("def.input_name_patterns"),
+                           not(isvariable("input_name_patterns"))),
+        meta => { "defvar" };
 
       # the permissions for your masterfiles, which will propagate to inputs
       "masterfiles_perms_mode" string => "0600",

--- a/controls/update_def.cf
+++ b/controls/update_def.cf
@@ -190,4 +190,9 @@ bundle common update_def
 
       "$(const.t) override class $(override_classes)";
       "$(const.t) $(defvars) = $($(defvars))";
+      "DEBUG $(this.bundle): Agent parsed augments_file"
+        ifvarclass => "have_augments_file.feature_augments";
+      "DEBUG $(this.bundle): Policy parsed augments_file"
+        ifvarclass => "have_augments_file.!feature_augments";
+      "DEBUG $(this.bundle): input_name_pattern = '$(input_name_patterns)'";
 }


### PR DESCRIPTION
So that variables defined from the augments_file wins, specific
variables that are defaulted in bundle agent def.cf have been guarded
with isvariable. Additionally if the agent is capable of parsing the
augments file directly, skip doing the work.