### PR TITLE
Remove: Definition of override_classes

### DIFF
--- a/controls/def.cf
+++ b/controls/def.cf
@@ -10,8 +10,6 @@ bundle common def
     # If the augments_file is parsed from C then we do not need to do this work
     # from policy.
     !feature_def_json_preparse::
-      # all override classes are defined true
-      "$(override_classes)" expression => "any", meta => { "override" };
 
       "have_augments_file" expression => fileexists($(augments_file)), scope => "bundle";
       "have_augments_classes" expression => isvariable("augments[classes]"), scope => "bundle";
@@ -34,7 +32,6 @@ bundle common def
 
       "augments_inputs" slist => getvalues("augments[inputs]");
       "override_vars" slist => getindices("augments[vars]");
-      "override_classes" slist => getvalues("augments[classes]");
       "override_data_$(override_vars)" data => mergedata("augments[vars][$(override_vars)]");
       "override_data_s_$(override_vars)" string => format("%S", "override_data_$(override_vars)");
 


### PR DESCRIPTION
Classes are supposed to be defined only if their restricitons match a
class. This is already done by the following promise:

   have_augments_classes.!feature_def_json_preparse::
      "$(augments_classes_data_keys)"
        expression =>
classmatch("$(augments[classes][$(augments_classes_data_keys)])"),
        meta => { "augments_class", "derived_from=$(augments_file)" };