### PR TITLE
Update FreeBSD package handling.

### DIFF
--- a/lib/packages.cf
+++ b/lib/packages.cf
@@ -1494,7 +1494,7 @@ body package_method freebsd
       package_changes => "individual";
 
       # Could use rpm for this
-      package_list_command => "/usr/sbin/pkg_info";
+      package_list_command => "/usr/sbin/pkg info";
 
       # Remember to escape special characters like |
 
@@ -1508,8 +1508,8 @@ body package_method freebsd
 
       package_name_convention => "$(name)-$(version)";
 
-      package_add_command => "/usr/sbin/pkg_add -r";
-      package_delete_command => "/usr/sbin/pkg_delete";
+      package_add_command => "/usr/sbin/pkg install -y";
+      package_delete_command => "/usr/sbin/pkg delete -y";
 }
 
 body package_method freebsd_portmaster
@@ -1537,7 +1537,7 @@ body package_method freebsd_portmaster
 {
       package_changes => "individual";
 
-      package_list_command => "/usr/sbin/pkg_info";
+      package_list_command => "/usr/sbin/pkg info";
 
       package_list_name_regex    => "([^\s]+)-.*";
       package_list_version_regex => "[^\s]+-([^\s]+).*";
@@ -1860,15 +1860,15 @@ body package_method generic
 
     freebsd::
       package_changes => "individual";
-      package_list_command => "/usr/sbin/pkg_info";
+      package_list_command => "/usr/sbin/pkg info";
       package_list_name_regex    => "([^\s]+)-.*";
       package_list_version_regex => "[^\s]+-([^\s]+).*";
       package_name_regex    => "([^\s]+)-.*";
       package_version_regex => "[^\s]+-([^\s]+).*";
       package_installed_regex => ".*";
       package_name_convention => "$(name)-$(version)";
-      package_add_command => "/usr/sbin/pkg_add -r";
-      package_delete_command => "/usr/sbin/pkg_delete";
+      package_add_command => "/usr/sbin/pkg install -y";
+      package_delete_command => "/usr/sbin/pkg delete";
 
     alpinelinux::
       package_changes => "bulk";

--- a/modules/packages/pkg
+++ b/modules/packages/pkg
@@ -59,12 +59,19 @@ read_options() {
                     fi
                     continue
                     ;;
+                PackageType*)
+                    TYP="${VALUE}"
+                    ;;
                 *)
                     fatal "Invalid input: '${KEYWORD}'."
                     ;;
             esac
             if [ -n "${KEYWORD}" ] && [ -n "${VALUE}" ] ; then
-                INPUTLIST="${INPUTLIST} ${KEYWORD}=${VALUE}"
+                if [ -n "${INPUTLIST}" ] ; then
+                    INPUTLIST="${INPUTLIST} ${KEYWORD}=${VALUE}"
+                else
+                    INPUTLIST="${KEYWORD}=${VALUE}"
+                fi
             fi
         fi
     done
@@ -102,6 +109,9 @@ process_inputs() {
                     fatal "Bad Input: Architecture ${VALUE} does not match ${DEFARCH}."
                 fi
                 ;;
+            PackageType*)
+                TYP="${VALUE}"
+                ;;
             *)
                 fatal "Invalid input: '${INPUT}'."
                 ;;
@@ -110,6 +120,9 @@ process_inputs() {
 }
 
 get_package_data() {
+    if [ -n "${NAM}" ] && [ -z "${PKG}" ] ; then
+        PKG="${NAM}"
+    fi
     if [ -n "${PKG}" ] ; then
         case "${PKG}" in
             /*) # File Path.  It's a file
@@ -129,7 +142,7 @@ get_package_data() {
         if [ "${TYP}" = 'repo' ] ; then
             PKGNAM=`basename "${PKG}" | sed -r -e 's/^([A-Za-z0-9_-]+)-[0-9a-z.,_]+/\1/'`
             PKGVER=`basename "${PKG}" | sed -r -e 's/^[A-Za-z0-9_-]+-([0-9a-z.,_]+)/\1/' -e 's/\.(tgz|(tar\.)?gz|txz|zip)$//'`
-            if [ -z "`echo ${PKGVER} | grep -E '[0-9]'`" ] ; then 
+            if [ -z "`echo ${PKGVER} | grep -E '^[0-9]'`" ] ; then 
                 if [ "${PKGNAM}" != "${PKGVER}" ] ;  then
                     PKGNAM="${PKGNAM}-${PKGVER}"
                 fi


### PR DESCRIPTION
I finally got over the hump of implementing Policy Framework on my testing network, which gave a chance to do real-world testing with the pkg module.  It needed some tweaking.

The changes to packages.cf are because the pkg command has replaced the entire pkg_* suite of tools for all supported versions of FreeBSD.
