### PR TITLE
masterfiles#654 pkgsrc package module sometimes matches wrong package

### DIFF
--- a/modules/packages/pkgsrc
+++ b/modules/packages/pkgsrc
@@ -102,7 +102,7 @@ get_package_data () {
         # or version, return nothing.
         # There's possibly a bug here because we're already emitting that the
         # PackageType is repo.
-        parse_pkg_data "$(pkgin -pP avail | grep "^$File" | grep "$Version;" | sort -n | tail -1)"
+        parse_pkg_data "$(pkgin -pP avail | grep "^${File}-" | grep "$Version;" | sort -n | tail -1)"
     fi
 }
 

--- a/modules/packages/pkgsrc
+++ b/modules/packages/pkgsrc
@@ -102,7 +102,7 @@ get_package_data () {
         # or version, return nothing.
         # There's possibly a bug here because we're already emitting that the
         # PackageType is repo.
-        parse_pkg_data "$(pkgin -pP avail | grep "^${File}-" | grep "$Version;" | sort -n | tail -1)"
+        parse_pkg_data "$(pkgin -pP avail | grep "^${File}-" | grep "$Version;" | sort -n | tail -1)" | grep Name
     fi
 }
 

--- a/modules/packages/pkgsrc
+++ b/modules/packages/pkgsrc
@@ -9,7 +9,7 @@
 ## pkgsrc package module for cfengine
 
 # Set up mock environment if necessary
-if [ -n $CFENGINE_TEST_PKGSRC_MOCK ]; then
+if [ -n "$CFENGINE_TEST_PKGSRC_MOCK" ]; then
     alias pkgin='./mock_pkgin'
     alias pkg_info='./mock_pkg_info'
 fi


### PR DESCRIPTION
Fixes #654, #656, #657.

```
$ echo File=mtr | ./pkgsrc get-package-data
PackageType=repo
Name=mtr
```