### PR TITLE
Add log rotation policy for state/classes.jsonl log.

### DIFF
--- a/controls/def.cf
+++ b/controls/def.cf
@@ -198,6 +198,7 @@ bundle common def
         "$(sys.workdir)/state/cf_value.log",
         "$(sys.workdir)/outputs/dc-scripts.log",
         "$(sys.workdir)/state/promise_log.jsonl",
+        "$(sys.workdir)/state/classes.jsonl",
       };
 
       "hub_log_files" slist =>


### PR DESCRIPTION
Redmine: #7951