### PR TITLE
Change: Specify Protocol Version

### DIFF
--- a/promises.cf
+++ b/promises.cf
@@ -67,9 +67,6 @@ body common control
       #    package_inventory => { $(package_module_knowledge.platform_default) };
       #    package_module => $(package_module_knowledge.platform_default);
 
-      # Uncomment to connect to the hub using latest protocol.
-      #protocol_version => "latest";
-
       #   goal_categories => { "goals", "targets", "milestones" };
       #   goal_patterns   => { "goal_.*", "target.*","milestone.*" };
 }

--- a/update.cf
+++ b/update.cf
@@ -28,9 +28,6 @@ body common control
                   "cfe_internal/update/update_policy.cf",
                   "cfe_internal/update/update_processes.cf"
       };
-
-      # Uncomment to connect to the hub using latest protocol.
-      #protocol_version => "latest";
 }
 
 #############################################################################


### PR DESCRIPTION
This was previously commented out because older agents did not
understand the syntax. All currently supported versions understand this
syntax now, so it is safe to uncomment and set to a specific protocol
version.