### PR TITLE
Change: Remove definition of override_classes

### DIFF
--- a/controls/3.6/def.cf
+++ b/controls/3.6/def.cf
@@ -12,9 +12,6 @@ body file control
 bundle common def
 {
   classes:
-      # all override classes are defined true
-      "$(override_classes)" expression => "any", meta => { "override" };
-
       "have_augments_file" expression => fileexists($(augments_file)), scope => "bundle";
       "have_augments_classes" expression => isvariable("augments[classes]"), scope => "bundle";
       "have_augments_inputs" expression => isvariable("augments[inputs]"), scope => "bundle";

--- a/controls/3.6/update_def.cf
+++ b/controls/3.6/update_def.cf
@@ -1,9 +1,6 @@
 bundle common update_def
 {
   classes:
-      # all override classes are defined true
-      "$(override_classes)" expression => "any", meta => { "override" };
-
       "have_augments_file" expression => fileexists($(augments_file)), scope => "bundle";
 
   vars:
@@ -17,7 +14,6 @@ bundle common update_def
       "augments" data => readjson($(augments_file), 100k), ifvarclass => "have_augments_file";
 
       "override_vars" slist => getindices("augments[vars]");
-      "override_classes" slist => getvalues("augments[classes]");
       "override_data_$(override_vars)" data => mergedata("augments[vars][$(override_vars)]");
       "override_data_s_$(override_vars)" string => format("%S", "override_data_$(override_vars)");
 
@@ -152,6 +148,5 @@ bundle common update_def
       "$(const.t) defined class role/byrole $(roles_byrole_keys) because of classmatch('$(extra_roles[byrole][$(roles_byrole_keys)])')"
         ifvarclass => "$(roles_byrole_keys)";
 
-      "$(const.t) override class $(override_classes)";
       "$(const.t) $(defvars) = $($(defvars))";
 }

--- a/controls/update_def.cf
+++ b/controls/update_def.cf
@@ -2,9 +2,6 @@ bundle common update_def
 {
   classes:
     !feature_def_json_preparse::
-      # all override classes are defined true
-      "$(override_classes)" expression => "any", meta => { "override" };
-
       "have_augments_file" expression => fileexists($(augments_file)), scope => "bundle";
       "have_augments_classes" expression => isvariable("augments[classes]"), scope => "bundle";
 
@@ -25,7 +22,6 @@ bundle common update_def
       "augments" data => readjson($(augments_file), 100k), ifvarclass => "have_augments_file";
 
       "override_vars" slist => getindices("augments[vars]");
-      "override_classes" slist => getvalues("augments[classes]");
       "override_data_$(override_vars)" data => mergedata("augments[vars][$(override_vars)]");
       "override_data_s_$(override_vars)" string => format("%S", "override_data_$(override_vars)");
 
@@ -188,7 +184,6 @@ bundle common update_def
       "$(const.t) defined class role/byrole $(roles_byrole_keys) because of classmatch('$(extra_roles[byrole][$(roles_byrole_keys)])')"
         ifvarclass => "$(roles_byrole_keys)";
 
-      "$(const.t) override class $(override_classes)";
       "$(const.t) $(defvars) = $($(defvars))";
       "DEBUG $(this.bundle): Agent parsed augments_file"
         ifvarclass => "have_augments_file.feature_def_json_preparse";


### PR DESCRIPTION
Classes are supposed to be defined only if their restricitons match
class. override_classes were being defined all the time. The proper way
to augment classes is like this:

have_augments_classes.!feature_def_json_preparse::
  "$(augments_classes_data_keys)"
    expression => classmatch("$(augments[classes][$(augments_classes_data_keys)])"),
    meta => { "augments_class", "derived_from=$(augments_file)" };