### PR TITLE
Fix: Only parse services/autorun/*.cf when services_autorun is defined

### DIFF
--- a/promises.cf
+++ b/promises.cf
@@ -300,11 +300,6 @@ bundle common cfengine_controls
 bundle common services_autorun
 {
   vars:
-    !services_autorun::
-      "inputs" slist => { };
-      "found_inputs" slist => {};
-      "bundles" slist => { "services_autorun" }; # run self
-
     !cfengine_3_7::
       # Both 3.6 and 3.8+ can use local_libdir
       # 3.6 will use the split library in the version specific path
@@ -321,9 +316,21 @@ bundle common services_autorun
       "found_inputs" slist => lsdir("$(this.promise_dirname)/services/autorun", ".*\.cf", "true");
       "bundles" slist => { "autorun" }; # run loaded bundles
 
+    !services_autorun::
+      # If services_autorun is not enabled, then we should not extend inputs
+      # automatically.
+      "inputs" slist => { };
+      "found_inputs" slist => {};
+      "bundles" slist => { "services_autorun" }; # run self
 
   reports:
     DEBUG|DEBUG_services_autorun::
+      "DEBUG $(this.bundle): Services Autorun Disabled"
+        ifvarclass => "!services_autorun";
+
+      "DEBUG $(this.bundle): Services Autorun Enabled"
+        ifvarclass => "services_autorun";
+
       "DEBUG $(this.bundle): adding input='$(inputs)'"
         ifvarclass => isvariable("inputs");
 


### PR DESCRIPTION
CFE-2135 #close Done

Changelog: Title
(cherry picked from commit 91c66e2b3217bb6211c343512bc14cf91afe01c7)