### PR TITLE
Scope edit_line bundle classes

### DIFF
--- a/lib/files.cf
+++ b/lib/files.cf
@@ -770,15 +770,15 @@ bundle edit_line set_line_based(v, sep, bp, kp, cp)
       "^$(cp)($(i)$(bp).*|$(i))$"
              comment => "Uncommented the value '$(i)'",
         replace_with => value("$(i)$(sep)$($(v)[$(i)])"),
-          ifvarclass => "!exists_$(ci[$(i)]).!replace_attempted_$(ci[$(i)]).!multiple_comments_$(ci[$(i)])",
-             classes => always("uncommented_$(ci[$(i)])");
+          ifvarclass => "!exists_$(ci[$(i)]).!replace_attempted_$(ci[$(i)])_reached.!multiple_comments_$(ci[$(i)])",
+             classes => results("bundle", "uncommented_$(ci[$(i)])");
 
       # If the line is there with the wrong value, replace with
       # the correct value
       "^\s*($(i)$(bp)(?!$(ev[$(i)])$).*|$(i))$"
            comment => "Correct the value '$(i)'",
       replace_with => value("$(i)$(sep)$($(v)[$(i)])"),
-           classes => always("replace_attempted_$(ci[$(i)])");
+           classes => results("bundle", "replace_attempted_$(ci[$(i)])");
 
   insert_lines:
       # If the line doesn't exist, or there is more than one occurrence
@@ -787,19 +787,18 @@ bundle edit_line set_line_based(v, sep, bp, kp, cp)
       "$(i)$(sep)$($(v)[$(i)])"
          comment => "Insert the value, marker '$(i)' exists",
         location => after("^$(cp)($(i)$(bp).*|$(i))$"),
-      ifvarclass => "replace_attempted_$(ci[$(i)]).multiple_comments_$(ci[$(i)])";
+      ifvarclass => "replace_attempted_$(ci[$(i)])_reached.multiple_comments_$(ci[$(i)])";
 
       # If the line doesn't exist and there are no occurrences
       # of the LHS commented out, insert a new line at the eof
       "$(i)$(sep)$($(v)[$(i)])"
          comment => "Insert the value, marker '$(i)' doesn't exist",
-      ifvarclass => "replace_attempted_$(ci[$(i)]).!multiple_comments_$(ci[$(i)]).!exists_$(ci[$(i)])";
+      ifvarclass => "replace_attempted_$(ci[$(i)])_reached.!multiple_comments_$(ci[$(i)]).!exists_$(ci[$(i)])";
 
   reports:
     verbose_mode|EXTRA::
       "$(this.bundle): Line for '$(i)' exists" ifvarclass => "exists_$(ci[$(i)])";
       "$(this.bundle): Line for '$(i)' does not exist" ifvarclass => "!exists_$(ci[$(i)])";
-
 }
 
 bundle edit_line set_config_values_matching(v,pat)

--- a/lib/files.cf
+++ b/lib/files.cf
@@ -647,22 +647,31 @@ bundle edit_line set_config_values(v)
       "ev[$(index)]" string => escape("$($(v)[$(index)])");
 
       # Do we have more than one line commented out?
-      "index_comment_matches_$(cindex[$(index)])" int => countlinesmatching("^\s*#\s*($(index)\s+.*|$(index))$","$(edit.filename)");
+      "index_comment_matches_$(cindex[$(index)])"
+        int => countlinesmatching("^\s*#\s*($(index)\s+.*|$(index))$","$(edit.filename)");
 
 
   classes:
       # Check to see if this line exists
-      "line_exists_$(cindex[$(index)])" expression => regline("^\s*($(index)\s.*|$(index))$","$(edit.filename)");
+      "line_exists_$(cindex[$(index)])"
+        expression => regline("^\s*($(index)\s.*|$(index))$","$(edit.filename)"),
+        scope => "bundle";
 
       # if there's more than one comment, just add new (don't know who to use)
-      "multiple_comments_$(cindex[$(index)])" expression => isgreaterthan("$(index_comment_matches_$(cindex[$(index)]))","1");
-
+      "multiple_comments_$(cindex[$(index)])"
+        expression => isgreaterthan("$(index_comment_matches_$(cindex[$(index)]))","1"),
+        scope => "bundle";
 
   replace_patterns:
       # If the line is commented out, uncomment and replace with
       # the correct value
       "^\s*#\s*($(index)\s+.*|$(index))$"
-             comment => "Uncommented the value $(index)",
+        comment => "If we find a single commented entry we can uncomment it to
+                    keep the settings near any inline documentation. If there
+                    are multiple comments, then we don't try to replace them and
+                    instead will later append the new value after the first
+                    commented occurance of $(index).",
+        handle => "set_config_values_replace_commented_line",
         replace_with => value("$(index) $($(v)[$(index)])"),
           ifvarclass => "!line_exists_$(cindex[$(index)]).!replace_attempted_$(cindex[$(index)])_reached.!multiple_comments_$(cindex[$(index)])",
              classes => results("bundle", "uncommented_$(cindex[$(index)])");

--- a/lib/files.cf
+++ b/lib/files.cf
@@ -836,11 +836,11 @@ bundle edit_line set_config_values_matching(v,pat)
       "^\s*($(index)\s+(?!$($(v)[$(index)])).*|# ?$(index)\s+.*)$"
       comment => "Correct the value",
       replace_with => value("$(index) $($(v)[$(index)])"),
-      classes => always("replace_attempted_$(cindex[$(index)])");
+      classes => results("bundle", "replace_attempted_$(cindex[$(index)])");
 
   insert_lines:
       "$(index) $($(v)[$(index)])"
-      ifvarclass => "replace_attempted_$(cindex[$(index)])";
+      ifvarclass => "replace_attempted_$(cindex[$(index)])_reached";
 
 }
 

--- a/lib/files.cf
+++ b/lib/files.cf
@@ -574,7 +574,7 @@ bundle edit_line set_variable_values(v)
 #
 #     files:
 #        "myfile"
-#          edit_line => set_quoted_values(stuff)
+#          edit_line => set_variable_values(stuff)
 # ```
 #
 # **See also:** `set_quoted_values()`

--- a/lib/files.cf
+++ b/lib/files.cf
@@ -395,7 +395,7 @@ bundle edit_line manage_variable_values_ini(tab, sectionName)
       "$(index)\s*=.*"
       edit_field => col("=","2","$($(tab)[$(sectionName)][$(index)])","set"),
       select_region => INI_section("$(sectionName)"),
-      classes => if_ok("manage_variable_values_ini_not_$(cindex[$(index)])"),
+      classes => results("bundle", "manage_variable_values_ini_not_$(cindex[$(index)])"),
       ifvarclass => "edit_$(cindex[$(index)])";
 
   delete_lines:
@@ -410,7 +410,7 @@ bundle edit_line manage_variable_values_ini(tab, sectionName)
 
       "$(index)=$($(tab)[$(sectionName)][$(index)])"
       select_region => INI_section("$(sectionName)"),
-      ifvarclass => "!manage_variable_values_ini_not_$(cindex[$(index)]).edit_$(cindex[$(index)])";
+        ifvarclass => "!(manage_variable_values_ini_not_$(cindex[$(index)])_kept|manage_variable_values_ini_not_$(cindex[$(index)])_repaired).edit_$(cindex[$(index)])";
 
 }
 

--- a/lib/files.cf
+++ b/lib/files.cf
@@ -542,13 +542,13 @@ bundle edit_line set_quoted_values(v)
       # match a line starting like the key = something
       "\s*$(index)\s*=.*"
       edit_field => col("=","2",'"$($(v)[$(index)])"',"set"),
-      classes    => if_ok("$(cindex[$(index)])_in_file"),
+      classes    => results("bundle", "$(cindex[$(index)])_in_file"),
       comment    => "Match a line starting like key = something";
 
   insert_lines:
       '$(index)="$($(v)[$(index)])"'
       comment    => "Insert a variable definition",
-      ifvarclass => "!$(cindex[$(index)])_in_file";
+        ifvarclass => "!($(cindex[$(index)])_in_file_kept|$(cindex[$(index)])_in_file_repaired)";
 }
 
 ##

--- a/lib/files.cf
+++ b/lib/files.cf
@@ -604,7 +604,7 @@ bundle edit_line set_variable_values(v)
       "\s*$(index)\s*=.*"
 
       edit_field => col("\s*$(index)\s*=","2","$($(v)[$(index)])","set"),
-      classes => if_ok("$(cv)_$(cindex[$(index)])_in_file"),
+      classes => results("bundle", "$(cv)_$(cindex[$(index)])_in_file"),
       comment => "Match a line starting like key = something";
 
   insert_lines:
@@ -612,7 +612,7 @@ bundle edit_line set_variable_values(v)
       "$(index)=$($(v)[$(index)])"
 
       comment => "Insert a variable definition",
-      ifvarclass => "!$(cv)_$(cindex[$(index)])_in_file";
+        ifvarclass => "!($(cv)_$(cindex[$(index)])_in_file_kept|$(cv)_$(cindex[$(index)])_in_file_repaired)";
 }
 
 bundle edit_line set_config_values(v)

--- a/lib/files.cf
+++ b/lib/files.cf
@@ -452,7 +452,7 @@ bundle edit_line set_variable_values_ini(tab, sectionName)
       "$(index)\s*=.*"
       edit_field => col("=","2","$($(tab)[$(sectionName)][$(index)])","set"),
       select_region => INI_section("$(sectionName)"),
-      classes => if_ok("set_variable_values_ini_not_$(cindex[$(index)])"),
+      classes => results("bundle", "set_variable_values_ini_not_$(cindex[$(index)])"),
       ifvarclass => "edit_$(cindex[$(index)])";
 
   insert_lines:
@@ -462,7 +462,7 @@ bundle edit_line set_variable_values_ini(tab, sectionName)
 
       "$(index)=$($(tab)[$(sectionName)][$(index)])"
       select_region => INI_section("$(sectionName)"),
-      ifvarclass => "!set_variable_values_ini_not_$(cindex[$(index)]).edit_$(cindex[$(index)])";
+        ifvarclass => "!(set_variable_values_ini_not_$(cindex[$(index)])_kept|set_variable_values_ini_not_$(cindex[$(index)])_repaired).edit_$(cindex[$(index)])";
 
 }
 

--- a/lib/files.cf
+++ b/lib/files.cf
@@ -664,15 +664,15 @@ bundle edit_line set_config_values(v)
       "^\s*#\s*($(index)\s+.*|$(index))$"
              comment => "Uncommented the value $(index)",
         replace_with => value("$(index) $($(v)[$(index)])"),
-          ifvarclass => "!line_exists_$(cindex[$(index)]).!replace_attempted_$(cindex[$(index)]).!multiple_comments_$(cindex[$(index)])",
-             classes => always("uncommented_$(cindex[$(index)])");
-      
+          ifvarclass => "!line_exists_$(cindex[$(index)]).!replace_attempted_$(cindex[$(index)])_reached.!multiple_comments_$(cindex[$(index)])",
+             classes => results("bundle", "uncommented_$(cindex[$(index)])");
+
       # If the line is there with the wrong value, replace with
       # the correct value
       "^\s*($(index)\s+(?!$(ev[$(index)])$).*|$(index))$"
            comment => "Correct the value $(index)",
       replace_with => value("$(index) $($(v)[$(index)])"),
-           classes => always("replace_attempted_$(cindex[$(index)])");
+           classes => results("bundle", "replace_attempted_$(cindex[$(index)])");
 
   insert_lines:
       # If the line doesn't exist, or there is more than one occurance
@@ -681,13 +681,13 @@ bundle edit_line set_config_values(v)
       "$(index) $($(v)[$(index)])"
          comment => "Insert the value, marker exists $(index)",
         location => after("^\s*#\s*($(index)\s+.*|$(index))$"),
-      ifvarclass => "replace_attempted_$(cindex[$(index)]).multiple_comments_$(cindex[$(index)])";
+      ifvarclass => "replace_attempted_$(cindex[$(index)])_reached.multiple_comments_$(cindex[$(index)])";
 
-      # If the line doesn't exist and there are no occurances
+      # If the line doesn't exist and there are no occurrences
       # of the LHS commented out, insert a new line at the eof
       "$(index) $($(v)[$(index)])"
          comment => "Insert the value, marker doesn't exist $(index)",
-      ifvarclass => "replace_attempted_$(cindex[$(index)]).!multiple_comments_$(cindex[$(index)])";
+      ifvarclass => "replace_attempted_$(cindex[$(index)])_reached.!multiple_comments_$(cindex[$(index)])";
 
 }
 

--- a/lib/files.cf
+++ b/lib/files.cf
@@ -1037,7 +1037,7 @@ bundle edit_line replace_or_add(pattern,line)
       "^(?!$(eline)$)$(pattern)$"
       comment => "Replace a pattern here",
       replace_with => value("$(line)"),
-      classes => scoped_classes_generic("bundle", "replace_$(cline)");
+      classes => results("bundle", "replace_$(cline)");
 
   insert_lines:
       "$(line)"

--- a/tests/acceptance/lib/files/set_config_values.cf
+++ b/tests/acceptance/lib/files/set_config_values.cf
@@ -16,16 +16,28 @@ body common control
 bundle agent init
 {
   files:
-      "$(G.testfile).expected"
+    # We want to test editing multiple similar files so that we know we do not
+    # have a problem with namespace scoped classes colliding unintentionally.
+
+      "$(G.testfile)-1.expected"
       copy_from => local_cp("$(this.promise_filename).finish");
-      "$(G.testfile).actual"
+      "$(G.testfile)-1.actual"
       copy_from => local_cp("$(this.promise_filename).start");
+
+      "$(G.testfile)-2.expected"
+      copy_from => local_cp("$(this.promise_filename).finish");
+      "$(G.testfile)-2.actual"
+      copy_from => local_cp("$(this.promise_filename).start");
+
 }
 
 #######################################################
 
 bundle agent test
 {
+  meta:
+    "description" string => "Test that set_config_values works as expected";
+
   vars:
        # should create a new line right after existing commented-out Protocol lines
       "config[Protocol]" string => "2";
@@ -39,7 +51,10 @@ bundle agent test
       "config[BlankOption]" string => "";
 
   files:
-      "$(G.testfile).actual"
+      "$(G.testfile)-1.actual"
+      edit_line => set_config_values("test.config");
+
+      "$(G.testfile)-2.actual"
       edit_line => set_config_values("test.config");
 }
 
@@ -47,8 +62,29 @@ bundle agent test
 
 bundle agent check
 {
+  vars:
+      "files" slist => { "1", "2" };
+
+  classes:
+      "pass" and => { "1_pass", "2_pass" };
+
   methods:
-      "any" usebundle => dcs_check_diff("$(G.testfile).actual",
-                                            "$(G.testfile).expected",
-                                            "$(this.promise_filename)");
+
+      "check"
+        usebundle => dcs_if_diff( "$(G.testfile)-$(files).actual", "$(G.testfile)-$(files).expected",
+                                  "$(files)_pass", "$(files)_fail");
+
+      # Fail the test if any of the files fail.
+      "fail"
+        usebundle => dcs_fail( $(this.promise_filename) ),
+        ifvarclass => "$(files)_fail";
+
+    pass::
+      "pass"
+        usebundle => dcs_pass( $(this.promise_filename) );
+
+  reports:
+      DEBUG::
+        "$(files)_fail"
+          ifvarclass => "$(files)_fail";
 }

--- a/tests/acceptance/lib/files/set_line_based_config_values.cf
+++ b/tests/acceptance/lib/files/set_line_based_config_values.cf
@@ -16,10 +16,15 @@ body common control
 bundle agent init
 {
   files:
-      "$(G.testfile).expected"
+      "$(G.testfile)-1.expected"
       copy_from => local_cp("$(this.promise_filename).finish");
-      "$(G.testfile).actual"
+      "$(G.testfile)-1.actual"
       copy_from => local_cp("$(this.promise_filename).start");
+
+      "$(G.testfile)-2.expected"
+        copy_from => local_cp("$(this.promise_filename).finish");
+      "$(G.testfile)-2.actual"
+        copy_from => local_cp("$(this.promise_filename).start");
 }
 
 #######################################################
@@ -39,16 +44,47 @@ bundle agent test
       "config[BlankOption]" string => "";
 
   files:
-      "$(G.testfile).actual"
-      edit_line => set_line_based("test.config", " ", "\s+", ".*", "\s*#\s*");
+      "$(G.testfile)-1.actual"
+        edit_line => set_line_based("test.config", " ", "\s+", ".*", "\s*#\s*");
+
+      "$(G.testfile)-2.actual"
+        edit_line => set_line_based("test.config", " ", "\s+", ".*", "\s*#\s*");
 }
 
 #######################################################
 
+#bundle agent check
+#{
+#  methods:
+#      "any" usebundle => dcs_check_diff("$(G.testfile).actual",
+#                                            "$(G.testfile).expected",
+#                                            "$(this.promise_filename)");
+#}
 bundle agent check
 {
+  vars:
+      "files" slist => { "1", "2" };
+
+  classes:
+      "pass" and => { "1_pass", "2_pass" };
+
   methods:
-      "any" usebundle => dcs_check_diff("$(G.testfile).actual",
-                                            "$(G.testfile).expected",
-                                            "$(this.promise_filename)");
+
+      "check"
+        usebundle => dcs_if_diff( "$(G.testfile)-$(files).actual", "$(G.testfile)-$(files).expected",
+                                  "$(files)_pass", "$(files)_fail");
+
+      # Fail the test if any of the files fail.
+      "fail"
+        usebundle => dcs_fail( $(this.promise_filename) ),
+        ifvarclass => "$(files)_fail";
+
+    pass::
+      "pass"
+        usebundle => dcs_pass( $(this.promise_filename) );
+
+  reports:
+    DEBUG::
+      "$(files)_fail"
+        ifvarclass => "$(files)_fail";
 }

--- a/tests/acceptance/lib/files/set_line_based_variable_values.cf
+++ b/tests/acceptance/lib/files/set_line_based_variable_values.cf
@@ -16,10 +16,16 @@ body common control
 bundle agent init
 {
   files:
-      "$(G.testfile).expected"
+      "$(G.testfile)-1.expected"
       copy_from => local_cp("$(this.promise_filename).finish");
-      "$(G.testfile).actual"
+      "$(G.testfile)-1.actual"
       copy_from => local_cp("$(this.promise_filename).start");
+
+      "$(G.testfile)-2.expected"
+        copy_from => local_cp("$(this.promise_filename).finish");
+      "$(G.testfile)-2.actual"
+        copy_from => local_cp("$(this.promise_filename).start");
+
 }
 
 #######################################################
@@ -40,16 +46,44 @@ bundle agent test
       "config[spaces]" string => "x";
 
   files:
-      "$(G.testfile).actual"
+      "$(G.testfile)-1.actual"
       edit_line => set_line_based("test.config", "=", "\s*=\s*", ".*", "\s*#\s*");
+
+      "$(G.testfile)-2.actual"
+        edit_line => set_line_based("test.config", "=", "\s*=\s*", ".*", "\s*#\s*");
 }
 
 #######################################################
 
 bundle agent check
 {
+  vars:
+      "files" slist => { "1", "2" };
+
+  classes:
+      "pass" and => { "1_pass", "2_pass" };
+
   methods:
-      "any" usebundle => sorted_check_diff("$(G.testfile).actual",
-                                           "$(G.testfile).expected",
-                                           "$(this.promise_filename)");
+      "sort actual"
+        usebundle => dcs_sort("$(G.testfile)-$(files).actual", "$(G.testfile)-$(files).actual.sort");
+
+      "sort expected"
+        usebundle => dcs_sort("$(G.testfile)-$(files).expected", "$(G.testfile)-$(files).expected.sort");
+      "check"
+        usebundle => dcs_if_diff( "$(G.testfile)-$(files).actual.sort", "$(G.testfile)-$(files).expected.sort",
+                                  "$(files)_pass", "$(files)_fail");
+
+      # Fail the test if any of the files fail.
+      "fail"
+        usebundle => dcs_fail( $(this.promise_filename) ),
+        ifvarclass => "$(files)_fail";
+
+    pass::
+      "pass"
+        usebundle => dcs_pass( $(this.promise_filename) );
+
+  reports:
+    DEBUG::
+      "$(files)_fail"
+        ifvarclass => "$(files)_fail";
 }

--- a/tests/acceptance/lib/files/set_variable_values.cf
+++ b/tests/acceptance/lib/files/set_variable_values.cf
@@ -16,10 +16,17 @@ body common control
 bundle agent init
 {
   files:
-      "$(G.testfile).expected"
+      "$(G.testfile)-1.expected"
       copy_from => local_cp("$(this.promise_filename).finish");
-      "$(G.testfile).actual"
+      "$(G.testfile)-1.actual"
       copy_from => local_cp("$(this.promise_filename).start");
+
+      "$(G.testfile)-2.expected"
+        copy_from => local_cp("$(this.promise_filename).finish");
+      "$(G.testfile)-2.actual"
+        copy_from => local_cp("$(this.promise_filename).start");
+
+
 }
 
 #######################################################
@@ -38,16 +45,52 @@ bundle agent test
       "config[blank option]" string => "";
 
   files:
-      "$(G.testfile).actual"
+      "$(G.testfile)-1.actual"
       edit_line => set_variable_values("test.config");
+
+      "$(G.testfile)-2.actual"
+        edit_line => set_variable_values("test.config");
 }
 
 #######################################################
 
+#bundle agent check
+#{
+#  methods:
+#      "any" usebundle => sorted_check_diff("$(G.testfile).actual",
+#                                           "$(G.testfile).expected",
+#                                           "$(this.promise_filename)");
+#}
+
 bundle agent check
 {
+  vars:
+      "files" slist => { "1", "2" };
+
+  classes:
+      "pass" and => { "1_pass", "2_pass" };
+
   methods:
-      "any" usebundle => sorted_check_diff("$(G.testfile).actual",
-                                           "$(G.testfile).expected",
-                                           "$(this.promise_filename)");
+      "sort actual"
+        usebundle => dcs_sort("$(G.testfile)-$(files).actual", "$(G.testfile)-$(files).actual.sort");
+
+      "sort expected"
+        usebundle => dcs_sort("$(G.testfile)-$(files).expected", "$(G.testfile)-$(files).expected.sort");
+      "check"
+        usebundle => dcs_if_diff( "$(G.testfile)-$(files).actual.sort", "$(G.testfile)-$(files).expected.sort",
+                                  "$(files)_pass", "$(files)_fail");
+
+      # Fail the test if any of the files fail.
+      "fail"
+        usebundle => dcs_fail( $(this.promise_filename) ),
+        ifvarclass => "$(files)_fail";
+
+    pass::
+      "pass"
+        usebundle => dcs_pass( $(this.promise_filename) );
+
+  reports:
+    DEBUG::
+      "$(files)_fail"
+        ifvarclass => "$(files)_fail";
 }

--- a/tests/acceptance/lib/files/set_variable_values.cf
+++ b/tests/acceptance/lib/files/set_variable_values.cf
@@ -54,14 +54,6 @@ bundle agent test
 
 #######################################################
 
-#bundle agent check
-#{
-#  methods:
-#      "any" usebundle => sorted_check_diff("$(G.testfile).actual",
-#                                           "$(G.testfile).expected",
-#                                           "$(this.promise_filename)");
-#}
-
 bundle agent check
 {
   vars:


### PR DESCRIPTION
Ref: https://tracker.mender.io/browse/CFE-1959
To prevent class collisions between editing two files with similar formats we
scope the internal implementation classes to bundle scope. By default classes
defined from classes bodies are namespace scoped, so editing two files with
similar formats using the same edit_line bundle can be troublesome.

All of the edit_line bundles are now using the results classes body
consistently.  The results body was chosen for clarity. Note that previous ifok
body usage now uses (_kept|_repaired).