### PR TITLE
Fix: Only parse services/autorun/*.cf when services_autorun is defined

### DIFF
--- a/promises.cf
+++ b/promises.cf
@@ -297,7 +297,7 @@ bundle common cfengine_controls
 bundle common services_autorun
 {
   vars:
-    !cfengine_3_7::
+    !cfengine_3_7.services_autorun::
       # Both 3.6 and 3.8+ can use local_libdir
       # 3.6 will use the split library in the version specific path
       # 3.8+ will use the common lib as it supports the @if macro
@@ -305,7 +305,7 @@ bundle common services_autorun
       "found_inputs" slist => lsdir("$(this.promise_dirname)/services/autorun", ".*\.cf", "true");
       "bundles" slist => { "autorun" }; # run loaded bundles
 
-    cfengine_3_7::
+    cfengine_3_7.services_autorun::
       # We have to point 3.7 at the unified library because sys.local_libdir in
       # 3.7 binaries it is set to a version specific path. However since 3.7
       # knows about the @if macro it is safe to share the same policy as 3.8+

--- a/promises.cf
+++ b/promises.cf
@@ -297,11 +297,6 @@ bundle common cfengine_controls
 bundle common services_autorun
 {
   vars:
-    !services_autorun::
-      "inputs" slist => { };
-      "found_inputs" slist => {};
-      "bundles" slist => { "services_autorun" }; # run self
-
     !cfengine_3_7::
       # Both 3.6 and 3.8+ can use local_libdir
       # 3.6 will use the split library in the version specific path
@@ -318,9 +313,21 @@ bundle common services_autorun
       "found_inputs" slist => lsdir("$(this.promise_dirname)/services/autorun", ".*\.cf", "true");
       "bundles" slist => { "autorun" }; # run loaded bundles
 
+    !services_autorun::
+      # If services_autorun is not enabled, then we should not extend inputs
+      # automatically.
+      "inputs" slist => { };
+      "found_inputs" slist => {};
+      "bundles" slist => { "services_autorun" }; # run self
 
   reports:
     DEBUG|DEBUG_services_autorun::
+      "DEBUG $(this.bundle): Services Autorun Disabled"
+        ifvarclass => "!services_autorun";
+
+      "DEBUG $(this.bundle): Services Autorun Enabled"
+        ifvarclass => "services_autorun";
+
       "DEBUG $(this.bundle): adding input='$(inputs)'"
         ifvarclass => isvariable("inputs");
 

--- a/tests/acceptance/promises/autorun-def_json.cf
+++ b/tests/acceptance/promises/autorun-def_json.cf
@@ -35,7 +35,9 @@ bundle agent test
 
   # We need to lay down the def.json that will enable autorun.
   files:
-      "$(init.def_json_path)" edit_line => enable_autorun;
+      "$(init.def_json_path)"
+        create => "true",
+        edit_line => enable_autorun;
 }
 
 bundle edit_line enable_autorun

--- a/tests/acceptance/promises/autorun-def_json.cf
+++ b/tests/acceptance/promises/autorun-def_json.cf
@@ -25,37 +25,23 @@ bundle agent init
       "promises_cf_path" string => nth(promises_cf_slist, 0);
 
       "masterfiles_path" string => dirname("$(promises_cf_path)");
-      "def_cf_path"      string => concat("$(masterfiles_path)", "/controls/def.cf");
+      "def_json_path"    string => concat("$(masterfiles_path)", "def.json");
 }
 
 bundle agent test
 {
   meta:
+    "description" string => "Test that def.json can enable autorun as expected.";
 
-
-      "description"
-        string => "Test that enabling autorun from policy is not sufficient for activation.
-
-In order to prevent the parsing of files unnecessarily we guard that with the
-definition of the services_autorun class. If that class is defined from
-policy, as in this test it currently happens too late in order to pick up
-the policy in the services/autorun directory. It would be OK for this
-behavior to change so that defining from policy worked as desired. This
-test is intended to track that specific case and if ever fixed, simply
-update this test to allow it to pass.";
-
-      "test_soft_fail"
-        string => "any",
-        meta => { "jiraCFE2135"};
-
+  # We need to lay down the def.json that will enable autorun.
   files:
-      "$(init.def_cf_path)" edit_line => enable_autorun;
+      "$(init.def_json_path)" edit_line => enable_autorun;
 }
 
 bundle edit_line enable_autorun
 {
   insert_lines:
-      'bundle common __autorun_enable { classes: "services_autorun" expression => "any"; }';
+      '{ "classes": { "services_autorun": ["any"] } }';
 }
 
 #######################################################

--- a/tests/acceptance/promises/autorun-def_json.cf
+++ b/tests/acceptance/promises/autorun-def_json.cf
@@ -25,7 +25,7 @@ bundle agent init
       "promises_cf_path" string => nth(promises_cf_slist, 0);
 
       "masterfiles_path" string => dirname("$(promises_cf_path)");
-      "def_json_path"    string => concat("$(masterfiles_path)", "def.json");
+      "def_json_path"    string => concat("$(masterfiles_path)", "/def.json");
 }
 
 bundle agent test

--- a/tests/acceptance/promises/autorun.cf
+++ b/tests/acceptance/promises/autorun.cf
@@ -46,7 +46,7 @@ update this test to allow it to pass.";
 
       "test_soft_fail"
         string => "any",
-        meta => { "jiraCFE2135"};
+        meta => { "redmine7572", "jiraCFE2135"};
 
   files:
       "$(init.def_cf_path)" edit_line => enable_autorun;


### PR DESCRIPTION
Ref: CFE-2135

This includes changes to one test so that it is expected to fail if
services_autorun is defined from policy. This also includes a new test that
when services_autorun is defined from def.json it does what is expected similar
to the test when services_autorun is defined as a command line option.