### PR TITLE
CFE-2332 Use new package promise by default.

### DIFF
--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -560,8 +560,7 @@ bundle agent cfe_autorun_inventory_packages
   packages:
     # From 3.7 onwards there is a new package promise implementation using package
     # modules, in which case installing non_existing_package is not needed any more.
-    #(cfengine_3_5|cfengine_3_6).debian::
-    debian::
+    (cfengine_3_5|cfengine_3_6).debian::
       "cfe_internal_non_existing_package"
       package_policy => "add",
       package_method => inventory_apt_get($(refresh)),
@@ -569,8 +568,7 @@ bundle agent cfe_autorun_inventory_packages
 
     # From 3.7 onwards there is a new package promise implementation using package
     # modules, in which case installing non_existing_package is not needed any more.
-    #(cfengine_3_5|cfengine_3_6).redhat::
-    redhat::
+    (cfengine_3_5|cfengine_3_6).redhat::
       "cfe_internal_non_existing_package"
       package_policy => "add",
       package_method => inventory_yum_rpm($(refresh)),

--- a/promises.cf.in
+++ b/promises.cf.in
@@ -61,11 +61,9 @@ body common control
       # modules in which you MUST provide package modules used to generate
       # software inventory reports. You can also provide global default package module 
       # instead of specifying it in all package promises.
-      # Please also note that software inventory reports is CFEngine enterprise only
-      # feature and core users can remove package_inventory line.
-      #debian|redhat::
-      #    package_inventory => { $(package_module_knowledge.platform_default) };
-      #    package_module => $(package_module_knowledge.platform_default);
+      debian|redhat::
+          package_inventory => { $(package_module_knowledge.platform_default) };
+          package_module => $(package_module_knowledge.platform_default);
 
       #   goal_categories => { "goals", "targets", "milestones" };
       #   goal_patterns   => { "goal_.*", "target.*","milestone.*" };


### PR DESCRIPTION
From 3.9 on the new package promise is the default package promise
implementation used by CFEngine.

Changelog: Use new package promise as default package promise
implementation. (CFE-2332)