### PR TITLE
Remove sanity checking for 3.6 version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 env:
 - CF_VERSION=3.8.0
 - CF_VERSION=3.7.2
-- CF_VERSION=3.6.6
 
 install:
 - wget https://cfengine-package-repos.s3.amazonaws.com/community_binaries/cfengine-community_$CF_VERSION-1_amd64.deb


### PR DESCRIPTION
3.9 won't be compatible with 3.6 so we need to remove 3.6 check from Travis.