### PR TITLE
Make Database purge schedule more robust

### DIFF
--- a/lib/cfe_internal_hub.cf
+++ b/lib/cfe_internal_hub.cf
@@ -135,33 +135,33 @@ bundle agent cfe_internal_hub_maintain
 
   classes:
       "enable_cfe_internal_reporting_database_purge_old_history" -> { "postgres", "CFEngine Enterprise" }
-        expression => "enterprise_edition.Hr00.Min00_05";
+        expression => "enterprise_edition.Hr00";
 
       "enable_cfe_internal_parition_creation_job" -> { "postgres", "CFEngine Enterprise" }
-        expression => "enterprise_edition.Hr00.Min00_05";
+        expression => "enterprise_edition.Hr00";
 
   methods:
     enable_cfe_internal_reporting_database_purge_old_history::
       "Remove old report history"
       usebundle => cfe_internal_database_cleanup_reports(@(report_settings)),
-      action => if_elapsed(5);
+      action => if_elapsed_day;
 
       "Remove cf-consumer history"
       usebundle => cfe_internal_database_cleanup_consumer_status("50000"),
-      action => if_elapsed(5);
+      action => if_elapsed_day;
 
       "Remove diagnostics history"
       usebundle => cfe_internal_database_cleanup_diagnostics(@(diagnostics_settings)),
-      action => if_elapsed(5);
+      action => if_elapsed_day;
 
       "Remove promise log history"
       usebundle => cfe_internal_database_cleanup_promise_log("7"),
-      action => if_elapsed(5);      
+      action => if_elapsed_day;
 
     enable_cfe_internal_parition_creation_job::
       "Create new partitions for partitioned tables"
       usebundle => cfe_internal_database_partitioning(),
-      action => if_elapsed(5);
+      action => if_elapsed_day;
 }
 
 bundle agent cfe_internal_database_cleanup_reports (settings)


### PR DESCRIPTION
Rather than restricting the database maintenance to specifically
the first 5 minutes of the midnight - 1AM hour, restrict it only
to some point within that hour, and use 'if_elapsed_day' to
prevent multiple runs in a single day.

With the default execution schedule and default splaytime, this
will be effectively the same as before, but this change will
make the DB maintenance promises more robust against execution
schedule changes.  (E.g. if CFEngine only runs every 20 minutes
with an splaytime to match, it may never run in the Min00_05
interval and thus never perform the DB maintenance needed.
This commit fixes that.)