### PR TITLE
Change: Define testing_masterfiles_policy_framework

### DIFF
--- a/tests/acceptance/testall
+++ b/tests/acceptance/testall
@@ -77,4 +77,5 @@ fi
     --cfkey="$CORE/cf-key/cf-key" \
     --rpmvercmp="$CORE/ext/rpmvercmp" \
     --include="$TEST_DIR/../../modules" \
+    --baseclasses="AUTO,testing_masterfiles_policy_framework" \
     "$@"


### PR DESCRIPTION
This defines the testing_masterfiles_policy_framework class. This will
allow us to omit the plucked.cf.sub bundle when running the masterfiles
policy framework. Omitting the bundle allows us to test the framework
directly.

Ref: Jira #CFE-2331