### PR TITLE
Add: Definition of from_cfexecd for cf-execd initiated runs

### DIFF
--- a/controls/3.6/cf_execd.cf
+++ b/controls/3.6/cf_execd.cf
@@ -31,15 +31,15 @@ body executor control
       # cf-twin needs its own safe environment because of the update mechanism
 
     windows::
-      exec_command => "$(sys.cf_agent) -f \"$(sys.update_policy_path)\" & $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "$(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated -f \"$(sys.update_policy_path)\" & $(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated";
 
     hpux::
-      exec_command => "$(sys.cf_agent) -f \"$(sys.update_policy_path)\" ; $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "$(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated -f \"$(sys.update_policy_path)\" ; $(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated";
 
     aix::
-      exec_command => "$(sys.cf_agent) -f \"$(sys.update_policy_path)\" ; $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "$(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated -f \"$(sys.update_policy_path)\" ; $(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated";
 
     !(windows|hpux|aix)::
-      exec_command => "$(sys.cf_agent) -f \"$(sys.update_policy_path)\" ; $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "$(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated -f \"$(sys.update_policy_path)\" ; $(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated";
 
 }

--- a/controls/cf_execd.cf
+++ b/controls/cf_execd.cf
@@ -35,9 +35,9 @@ body executor control
       # cf-twin needs its own safe environment because of the update mechanism
 
     windows::
-      exec_command => "$(sys.cf_agent) -f \"$(sys.update_policy_path)\" & $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "$(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated -f \"$(sys.update_policy_path)\" & $(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated";
 
     !windows::
-      exec_command => "$(sys.cf_agent) -f \"$(sys.update_policy_path)\" ; $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "$(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated -f \"$(sys.update_policy_path)\" ; $(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated";
 
 }


### PR DESCRIPTION
The agent will automatically append ' -Dfrom_cfexecd' if it is not found
in exec_command. This causes unexpected behavior when the appended
option replaces any custom definitions.

Jira #CFE-2386
Changelog: Title

(cherry picked from commit 33b0879e13757d7c854c68fe6a3500d554438ad4)