### PR TITLE
Add: Definition of from_cfexecd for cf-execd initiated runs

### DIFF
--- a/controls/3.5/cf_execd.cf
+++ b/controls/3.5/cf_execd.cf
@@ -31,23 +31,23 @@ body executor control
       # cf-twin needs its own safe environment because of the update mechanism
 
     windows.cfengine_3_5::
-      exec_command => "$(sys.cf_twin) -f \"$(sys.workdir)\inputs\update.cf\" & $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "$(sys.cf_twin) -Dfrom_cfexecd,cf_execd_initiated -f \"$(sys.workdir)\inputs\update.cf\" & $(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated";
     windows.!cfengine_3_5::
-      exec_command => "$(sys.cf_agent) -f \"$(sys.update_policy_path)\" & $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "$(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated -f \"$(sys.update_policy_path)\" & $(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated";
 
     hpux.cfengine_3_5::
-      exec_command => "SHLIB_PATH=\"$(sys.workdir)/lib-twin\" $(sys.cf_twin) -f \"$(sys.workdir)/inputs/update.cf\" ; $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "SHLIB_PATH=\"$(sys.workdir)/lib-twin\" $(sys.cf_twin) -Dfrom_cfexecd,cf_execd_initiated -f \"$(sys.workdir)/inputs/update.cf\" ; $(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated";
     hpux.!cfengine_3_5::
-      exec_command => "$(sys.cf_agent) -f \"$(sys.update_policy_path)\" ; $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "$(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated -f \"$(sys.update_policy_path)\" ; $(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated";
 
     aix.cfengine_3_5::
-      exec_command => "LIBPATH=\"$(sys.workdir)/lib-twin\" $(sys.cf_twin) -f \"$(sys.workdir)/inputs/update.cf\" ; $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "LIBPATH=\"$(sys.workdir)/lib-twin\" $(sys.cf_twin) -Dfrom_cfexecd,cf_execd_initiated -f \"$(sys.workdir)/inputs/update.cf\" ; $(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated";
     aix.!cfengine_3_5::
-      exec_command => "$(sys.cf_agent) -f \"$(sys.update_policy_path)\" ; $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "$(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated -f \"$(sys.update_policy_path)\" ; $(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated";
 
     !(windows|hpux|aix).cfengine_3_5::
-      exec_command => "LD_LIBRARY_PATH=\"$(sys.workdir)/lib-twin\" $(sys.cf_twin) -f \"$(sys.workdir)/inputs/update.cf\" ; $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "LD_LIBRARY_PATH=\"$(sys.workdir)/lib-twin\" $(sys.cf_twin) -Dfrom_cfexecd,cf_execd_initiated -f \"$(sys.workdir)/inputs/update.cf\" ; $(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated";
     !(windows|hpux|aix).!cfengine_3_5::
-      exec_command => "$(sys.cf_agent) -f \"$(sys.update_policy_path)\" ; $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "$(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated -f \"$(sys.update_policy_path)\" ; $(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated";
 
 }

--- a/controls/3.6/cf_execd.cf
+++ b/controls/3.6/cf_execd.cf
@@ -31,23 +31,23 @@ body executor control
       # cf-twin needs its own safe environment because of the update mechanism
 
     windows.cfengine_3_5::
-      exec_command => "$(sys.cf_twin) -f \"$(sys.workdir)\inputs\update.cf\" & $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "$(sys.cf_twin) -Dfrom_cfexecd,cf_execd_initiated -f \"$(sys.workdir)\inputs\update.cf\" & $(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated";
     windows.!cfengine_3_5::
-      exec_command => "$(sys.cf_agent) -f \"$(sys.update_policy_path)\" & $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "$(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated -f \"$(sys.update_policy_path)\" & $(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated";
 
     hpux.cfengine_3_5::
-      exec_command => "SHLIB_PATH=\"$(sys.workdir)/lib-twin\" $(sys.cf_twin) -f \"$(sys.workdir)/inputs/update.cf\" ; $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "SHLIB_PATH=\"$(sys.workdir)/lib-twin\" $(sys.cf_twin) -Dfrom_cfexecd,cf_execd_initiated -f \"$(sys.workdir)/inputs/update.cf\" ; $(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated";
     hpux.!cfengine_3_5::
-      exec_command => "$(sys.cf_agent) -f \"$(sys.update_policy_path)\" ; $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "$(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated -f \"$(sys.update_policy_path)\" ; $(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated";
 
     aix.cfengine_3_5::
-      exec_command => "LIBPATH=\"$(sys.workdir)/lib-twin\" $(sys.cf_twin) -f \"$(sys.workdir)/inputs/update.cf\" ; $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "LIBPATH=\"$(sys.workdir)/lib-twin\" $(sys.cf_twin) -Dfrom_cfexecd,cf_execd_initiated -f \"$(sys.workdir)/inputs/update.cf\" ; $(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated";
     aix.!cfengine_3_5::
-      exec_command => "$(sys.cf_agent) -f \"$(sys.update_policy_path)\" ; $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "$(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated -f \"$(sys.update_policy_path)\" ; $(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated";
 
     !(windows|hpux|aix).cfengine_3_5::
-      exec_command => "LD_LIBRARY_PATH=\"$(sys.workdir)/lib-twin\" $(sys.cf_twin) -f \"$(sys.workdir)/inputs/update.cf\" ; $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "LD_LIBRARY_PATH=\"$(sys.workdir)/lib-twin\" $(sys.cf_twin) -Dfrom_cfexecd,cf_execd_initiated -f \"$(sys.workdir)/inputs/update.cf\" ; $(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated";
     !(windows|hpux|aix).!cfengine_3_5::
-      exec_command => "$(sys.cf_agent) -f \"$(sys.update_policy_path)\" ; $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "$(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated -f \"$(sys.update_policy_path)\" ; $(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated";
 
 }

--- a/controls/3.7/cf_execd.cf
+++ b/controls/3.7/cf_execd.cf
@@ -31,23 +31,23 @@ body executor control
       # cf-twin needs its own safe environment because of the update mechanism
 
     windows.cfengine_3_5::
-      exec_command => "$(sys.cf_twin) -f \"$(sys.workdir)\inputs\update.cf\" & $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "$(sys.cf_twin) -Dfrom_cfexecd,cf_execd_initiated -f \"$(sys.workdir)\inputs\update.cf\" & $(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated";
     windows.!cfengine_3_5::
-      exec_command => "$(sys.cf_agent) -f \"$(sys.update_policy_path)\" & $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "$(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated -f \"$(sys.update_policy_path)\" & $(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated";
 
     hpux.cfengine_3_5::
-      exec_command => "SHLIB_PATH=\"$(sys.workdir)/lib-twin\" $(sys.cf_twin) -f \"$(sys.workdir)/inputs/update.cf\" ; $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "SHLIB_PATH=\"$(sys.workdir)/lib-twin\" $(sys.cf_twin) -Dfrom_cfexecd,cf_execd_initiated -f \"$(sys.workdir)/inputs/update.cf\" ; $(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated";
     hpux.!cfengine_3_5::
-      exec_command => "$(sys.cf_agent) -f \"$(sys.update_policy_path)\" ; $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "$(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated -f \"$(sys.update_policy_path)\" ; $(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated";
 
     aix.cfengine_3_5::
-      exec_command => "LIBPATH=\"$(sys.workdir)/lib-twin\" $(sys.cf_twin) -f \"$(sys.workdir)/inputs/update.cf\" ; $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "LIBPATH=\"$(sys.workdir)/lib-twin\" $(sys.cf_twin) -Dfrom_cfexecd,cf_execd_initiated -f \"$(sys.workdir)/inputs/update.cf\" ; $(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated";
     aix.!cfengine_3_5::
-      exec_command => "$(sys.cf_agent) -f \"$(sys.update_policy_path)\" ; $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "$(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated -f \"$(sys.update_policy_path)\" ; $(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated";
 
     !(windows|hpux|aix).cfengine_3_5::
-      exec_command => "LD_LIBRARY_PATH=\"$(sys.workdir)/lib-twin\" $(sys.cf_twin) -f \"$(sys.workdir)/inputs/update.cf\" ; $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "LD_LIBRARY_PATH=\"$(sys.workdir)/lib-twin\" $(sys.cf_twin) -Dfrom_cfexecd,cf_execd_initiated -f \"$(sys.workdir)/inputs/update.cf\" ; $(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated";
     !(windows|hpux|aix).!cfengine_3_5::
-      exec_command => "$(sys.cf_agent) -f \"$(sys.update_policy_path)\" ; $(sys.cf_agent) -Dcf_execd_initiated";
+      exec_command => "$(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated -f \"$(sys.update_policy_path)\" ; $(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated";
 
 }


### PR DESCRIPTION
The agent will automatically append ' -Dfrom_cfexecd' if it is not found
in exec_command. This causes unexpected behavior when the appended
option replaces any custom definitions.

Jira #CFE-2386
Changelog: Title

(cherry picked from commit 33b0879e13757d7c854c68fe6a3500d554438ad4)