### PR TITLE
Change: Enable strict transport security

### DIFF
--- a/cfe_internal/enterprise/templates/httpd.conf.mustache
+++ b/cfe_internal/enterprise/templates/httpd.conf.mustache
@@ -144,6 +144,10 @@ LogLevel warn
     SSLCertificateFile "{{{vars.cfe_internal_hub_vars.SSLCertificateFile}}}"
     SSLCertificateKeyFile "{{{vars.cfe_internal_hub_vars.SSLCertificateKeyFile}}}"
 
+    # Enable Strict Transport Security to prevent HTTPS users from
+    # accessing http content.
+    Header always set Strict-Transport-Security "max-age=63072000; includeSubdomains; preload"
+
     <FilesMatch "\.(cgi|shtml|phtml|php)$">
         SSLOptions +StdEnvVars
     </FilesMatch>


### PR DESCRIPTION
This helps to prevent potential man in the middle attacks.
Changelog: Title

(cherry picked from commit 76d7bf3b95c188de6c8f8bac4b9d0acd46cc10c9)