### PR TITLE
Change: Guard debug report so as not to mislead

### DIFF
--- a/controls/3.6/def.cf
+++ b/controls/3.6/def.cf
@@ -216,7 +216,7 @@ bundle common def
         "$(sys.workdir)/reports",
       };
 
-    # enable_cfengine_enterprise_hub_ha is defined below 
+    # enable_cfengine_enterprise_hub_ha is defined below
     # Disabled by default
 
     enable_cfengine_enterprise_hub_ha::
@@ -305,7 +305,8 @@ bundle common def
     DEBUG|DEBUG_def::
       "DEBUG: $(this.bundle)";
 
-      "$(const.t) def.json was found at $(augments_file)";
+      "$(const.t) def.json was found at $(augments_file)"
+        ifvarclass => fileexists( $(augments_file) );
 
       "$(const.t) override request $(override_vars) to '$(override_data_s_$(override_vars))'; new value '$($(override_vars))'"
       ifvarclass => isvariable("override_data_$(override_vars)");

--- a/controls/def.cf
+++ b/controls/def.cf
@@ -327,7 +327,8 @@ bundle common def
     DEBUG|DEBUG_def::
       "DEBUG: $(this.bundle)";
 
-      "$(const.t) def.json was found at $(augments_file)";
+      "$(const.t) def.json was found at $(augments_file)"
+        ifvarclass => fileexists( $(augments_file) );
 
       "$(const.t) override request $(override_vars) to '$(override_data_s_$(override_vars))'; new value '$($(override_vars))'"
       ifvarclass => isvariable("override_data_$(override_vars)");


### PR DESCRIPTION
The debug report indicated a file was found even if the file didn't
exist.

(cherry picked from commit 1eb592d85098938cbc52a7aa2f5d09e033f205ea)