### PR TITLE
Change: Add systemd services bundle

### DIFF
--- a/lib/services.cf
+++ b/lib/services.cf
@@ -125,6 +125,99 @@ body service_method standard_services
 
 ##
 
+body service_method systemd_services
+{
+      service_autostart_policy => "none";
+      service_dependence_chain => "ignore";
+      service_type => "generic";
+      service_args => "";
+}
+
+bundle agent systemd_services(service,state)
+# @brief Manage standard systemd services
+{
+  vars:
+
+    # We explicitly guard for systemd to avoid unnecessary agent time in
+    # pre-eval
+
+    systemd::
+      "call_systemctl" string => "$(paths.systemctl) --no-ask-password --global --system";
+      "systemd_properties" string => "-pLoadState,CanStop,UnitFileState,ActiveState,LoadState,CanStart,CanReload";
+      "systemd_service_info" slist => string_split(execresult("$(call_systemctl) $(systemd_properties) show $(service)", "noshell"), "\n", "10");
+
+  classes:
+
+    systemd::
+
+      # define a class named after the desired state
+      "$(state)" expression => "any";
+      "non_disabling" or => { "start", "stop", "restart", "reload" };
+
+# A collection of classes to determine the capabilities of a given systemd
+# service, then start, stop, etc. the service. Also supports a custom action
+# for anything not supported
+
+      "service_enabled" expression => reglist(@(systemd_service_info), "UnitFileState=enabled");
+      "service_active"  expression => reglist(@(systemd_service_info), "ActiveState=active");
+      "service_loaded"  expression => reglist(@(systemd_service_info), "LoadState=loaded");
+      "service_notfound" expression => reglist(@(systemd_service_info), "LoadState=not-found");
+
+      "can_stop_service"   expression => reglist(@(systemd_service_info), "CanStop=yes");
+      "can_start_service"  expression => reglist(@(systemd_service_info), "CanStart=yes");
+      "can_reload_service" expression => reglist(@(systemd_service_info), "CanReload=yes");
+
+      "request_start"   expression => strcmp("start", "$(state)");
+      "request_stop"    expression => strcmp("stop", "$(state)");
+      "request_reload"  expression => strcmp("reload", "$(state)");
+      "request_restart" expression => strcmp("restart", "$(state)");
+
+      "action_custom"  expression => "!(request_start|request_stop|request_reload|request_restart)";
+      "action_start"   expression => "request_start.!service_active.can_start_service";
+      "action_stop"    expression => "request_stop.service_active.can_stop_service";
+      "action_reload"  expression => "request_reload.service_active.can_reload_service";
+      "action_restart"         or => {
+                                      "request_restart.service_active",
+
+                                      # Possibly undesirable... if a reload is
+                                      # requested, and the service "can't" be
+                                      # reloaded, then we restart it instead.
+                                      "request_reload.!can_reload_service.service_active",
+                                     };
+
+      # Starting a service implicitly enables it
+      "action_enable"  expression => "request_start.!service_enabled";
+
+      # Respectively, stopping it implicitly disables it
+      "action_disable" expression => "request_stop.service_enabled";
+
+  commands:
+    systemd.service_loaded:: # note this class is defined in `inventory/linux.cf`
+      # conveniently, systemd states map to `services` states, except
+      # for `enable`
+
+      "$(call_systemctl) -q start $(service)"   ifvarclass => "action_start";
+      "$(call_systemctl) -q stop $(service)"    ifvarclass => "action_stop";
+      "$(call_systemctl) -q reload $(service)"  ifvarclass => "action_reload";
+      "$(call_systemctl) -q restart $(service)" ifvarclass => "action_restart";
+      "$(call_systemctl) -q enable $(service)"  ifvarclass => "action_enable";
+      "$(call_systemctl) -q disable $(service)" ifvarclass => "action_disable";
+
+      # Custom action for any of the non-standard systemd actions such a
+      # status, try-restart, isolate, et al.
+      "$(call_systemctl) $(state) $(service)" ifvarclass => "action_custom";
+
+  reports:
+    DEBUG|DEBUG_systemd_service::
+      "DEBUG $(this.bundle): using systemd layer to $(state) $(service)";
+
+      "DEBUG $(this.bundle): Service $(service) unit file is not loaded; doing nothing"
+        ifvarclass => "systemd.!service_loaded";
+
+      "DEBUG $(this.bundle): Could not find service: $(service)"
+        ifvarclass => "systemd.service_notfound";
+}
+
 bundle agent standard_services(service,state)
 # @brief Standard services bundle, used by CFEngine by default
 # @author CFEngine AS
@@ -167,8 +260,6 @@ bundle agent standard_services(service,state)
 # ```
 {
   vars:
-      "call_systemctl" string => "$(paths.systemctl) --no-ask-password --global --system";
-      "systemd_properties" string => "-pLoadState,CanStop,UnitFileState,ActiveState,LoadState,CanStart,CanReload";
       "init" string => "/etc/init.d/$(service)";
       "c_service" string => canonify("$(service)");
 
@@ -179,9 +270,6 @@ bundle agent standard_services(service,state)
     stop|disable::
       "chkconfig_mode" string => "off";
       "svcadm_mode" string => "disable";
-
-    systemd::
-      "systemd_service_info" slist => string_split(execresult("$(call_systemctl) $(systemd_properties) show $(service)", "noshell"), "\n", "10");
 
   classes:
       # define a class named after the desired state
@@ -216,77 +304,7 @@ bundle agent standard_services(service,state)
                     service is not registered it must be added.  Note we do not
                     automatically try to add the service at this time.";
 
-### BEGIN ###
-# @brief probe the state of a systemd service
-# @author Bryan Burke
-#
-# A collection of classes to determine the capabilities of a given systemd
-# service, then start, stop, etc. the service. Also supports a custom action
-# for anything not supported
-#
-    systemd::
-      "service_enabled" expression => reglist(@(systemd_service_info), "UnitFileState=enabled");
-      "service_active"  expression => reglist(@(systemd_service_info), "ActiveState=active");
-      "service_loaded"  expression => reglist(@(systemd_service_info), "LoadState=loaded");
-      "service_notfound" expression => reglist(@(systemd_service_info), "LoadState=not-found");
-
-      "can_stop_service"   expression => reglist(@(systemd_service_info), "CanStop=yes");
-      "can_start_service"  expression => reglist(@(systemd_service_info), "CanStart=yes");
-      "can_reload_service" expression => reglist(@(systemd_service_info), "CanReload=yes");
-
-      "request_start"   expression => strcmp("start", "$(state)");
-      "request_stop"    expression => strcmp("stop", "$(state)");
-      "request_reload"  expression => strcmp("reload", "$(state)");
-      "request_restart" expression => strcmp("restart", "$(state)");
-
-      "action_custom"  expression => "!(request_start|request_stop|request_reload|request_restart)";
-      "action_start"   expression => "request_start.!service_active.can_start_service";
-      "action_stop"    expression => "request_stop.service_active.can_stop_service";
-      "action_reload"  expression => "request_reload.service_active.can_reload_service";
-      "action_restart"         or => {
-                                      "request_restart.service_active",
-
-                                      # Possibly undesirable... if a reload is
-                                      # requested, and the service "can't" be
-                                      # reloaded, then we restart it instead.
-                                      "request_reload.!can_reload_service.service_active",
-                                     };
-
-      # Starting a service implicitly enables it
-      "action_enable"  expression => "request_start.!service_enabled";
-
-      # Respectively, stopping it implicitly disables it
-      "action_disable" expression => "request_stop.service_enabled";
-
   commands:
-    systemd.service_loaded:: # note this class is defined in `inventory/linux.cf`
-      # conveniently, systemd states map to `services` states, except
-      # for `enable`
-
-      "$(call_systemctl) -q start $(service)"
-        ifvarclass => "action_start";
-
-      "$(call_systemctl) -q stop $(service)"
-        ifvarclass => "action_stop";
-
-      "$(call_systemctl) -q reload $(service)"
-        ifvarclass => "action_reload";
-
-      "$(call_systemctl) -q restart $(service)"
-        ifvarclass => "action_restart";
-
-      "$(call_systemctl) -q enable $(service)"
-        ifvarclass => "action_enable";
-
-      "$(call_systemctl) -q disable $(service)"
-        ifvarclass => "action_disable";
-
-      # Custom action for any of the non-standard systemd actions such a
-      # status, try-restart, isolate, et al.
-      "$(call_systemctl) $(state) $(service)"
-        ifvarclass => "action_custom";
-
-### END systemd section ###
 
     chkconfig.stop.onboot::
       # Only chkconfig disable if it's currently set to start on boot
@@ -321,11 +339,10 @@ bundle agent standard_services(service,state)
     fallback::
       "classic" usebundle => classic_services($(service), $(state));
 
+    systemd::
+      "systemd" usebundle => systemd_services($(service), $(state) );
+
   reports:
-    verbose_mode.systemd::
-      "$(this.bundle): using systemd layer to $(state) $(service)";
-    verbose_mode.systemd.!service_loaded::
-      "$(this.bundle): Service $(service) unit file is not loaded; doing nothing";
     verbose_mode.chkconfig::
       "$(this.bundle): using chkconfig layer to $(state) $(service) (chkconfig mode $(chkconfig_mode))"
         ifvarclass => "!chkconfig_$(c_service)_unregistered.((start.!onboot)|(stop.onboot))";
@@ -338,9 +355,6 @@ bundle agent standard_services(service,state)
       "$(this.bundle): using Solaris SMF to $(state) $(service) (svcadm mode $(svcadm_mode))";
     verbose_mode.fallback::
       "$(this.bundle): falling back to classic_services to $(state) $(service)";
-
-    systemd.service_notfound::
-        "$(this.bundle): Could not find service: $(service)";
 }
 
 bundle agent classic_services(service,state)


### PR DESCRIPTION
Changelog: Title

This refactors standard_services pulling systemd related policy into its
own bundle. standard_services will call the systemd_services bundle if
systemd is detected.

This should improve maintainability of the systemd services
implementation.
