### PR TITLE
Fix: Services starting or stopping unnecessarily

### DIFF
--- a/lib/services.cf
+++ b/lib/services.cf
@@ -166,6 +166,9 @@ bundle agent standard_services(service,state)
     chkconfig.have_init::
       "running" expression => returnszero("$(init) status > /dev/null", "useshell");
 
+    sysvservice.have_init::
+      "running" expression => returnszero("$(paths.service) $(service) status > /dev/null", "useshell");
+
     chkconfig.SuSE::
       "onboot"
         expression => returnszero("$(paths.chkconfig) $(service) | $(paths.grep) 'on$' >/dev/null", "usehell"),
@@ -273,13 +276,42 @@ bundle agent standard_services(service,state)
       "$(init) $(state)"
       contain => silent;
 
-    sysvservice.non_disabling::
-      "$(paths.service) $(service) $(state)"
-      classes => kept_successful_command;
+    sysvservice.start.!running::
+      "$(paths.service) $(service) start"
+      handle => "standard_services_sysvservice_not_running_start",
+      classes => kept_successful_command,
+      comment => "If the service should be running and it is not
+                  currently running then we should issue the standard service
+                  command to start the service.";
 
-    sysvservice.disable::
+    sysvservice.restart::
+      "$(paths.service) $(service) restart"
+      handle => "standard_services_sysvservice_restart",
+      classes => kept_successful_command,
+      comment => "If the service should be restarted we issue the
+                  standard service command to restart or reload the service.
+                  There is no restriction based on the services current state as
+                  restart can start a service that was not already
+                  running.";
+
+    sysvservice.reload.running::
+      "$(paths.service) $(service) reload"
+      handle => "standard_services_sysvservice_reload",
+      classes => kept_successful_command,
+      comment => "If the service should be reloaded we issue the
+                  standard service command to reload the service.
+                  It is restricted to when the service is running as a reload
+                  should not start services that are not already running. This
+                  may not be triggered as service state parameters are limited
+                  and translated to the closest meaning.";
+
+    sysvservice.((stop|disable).running)::
       "$(paths.service) $(service) stop"
-      classes => kept_successful_command;
+      handle => "standard_services_sysvservice_stop",
+      classes => kept_successful_command,
+      comment => "If the service should be stopped or disabled and it is
+                  currently running then we should issue the standard service
+                  command to stop the service.";
 
     smf::
       "$(paths.svcadm) $(svcadm_mode) $(service)"


### PR DESCRIPTION
Hosts using sysv init without chkconfig were not detecting their current
state and were not discriminating service state changes against the
currently detected state.

Jira #CFE-2421
Changelog: Title

(cherry picked from commit a44d8af6614a241672c3c4b59fbf12bc01ddb7d8)