### PR TITLE
Adapt autoconf code to autoconf 2.63.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,20 +6,20 @@ dnl # Run ./autogen.sh to build configure script
 dnl #
 dnl ##########################################################################
 
-AC_PREREQ(2.59)
+AC_PREREQ(2.63)
 
-m4_define([revision], m4_esyscmd_s([git rev-list -1 --abbrev-commit HEAD]))
+m4_define([revision], m4_normalize(m4_esyscmd([git rev-list -1 --abbrev-commit HEAD])))
 
-m4_define([cfversion_from_env], m4_esyscmd_s([echo $EXPLICIT_VERSION]))
-m4_ifblank(cfversion_from_env, [
-    m4_define([cfversion_from_detect], m4_esyscmd_s([3rdparty/core/determine-version.py]))
+m4_define([cfversion_from_env], m4_normalize(m4_esyscmd([echo $EXPLICIT_VERSION])))
+m4_ifval(cfversion_from_env, [
+    m4_define([cfversion], cfversion_from_env)
+], [
+    m4_define([cfversion_from_detect], m4_normalize(m4_esyscmd([3rdparty/core/determine-version.py])))
     m4_if(m4_sysval, 0, [], [
         m4_fatal([Could not determine CFEngine version. Please set EXPLICIT_VERSION in the environment.])
     ])
     m4_define([cfversion], cfversion_from_detect[]a1.revision)
     m4_undefine([cfversion_from_detect])
-], [
-    m4_define([cfversion], cfversion_from_env)
 ])
 
 AC_INIT([cfengine-masterfiles], cfversion)


### PR DESCRIPTION
Autoconf 2.63 is lacking both m4_ifblank and m4_esyscmd_s, so work
around the former with m4_ifval (which has reversed semantics) and the
latter with m4_normalize.

Also bump the version requirement while we're at it. Although I don't
know if the new macros were introduced in 2.63, we at least know they
are present there. Bump to 2.63 because:

* 2.64 has been (secretly) required for a long time, since the macros
  I replaced in this commit were only available in that version and
  later. I doubt anyone is using anything older.

* 2.63 is already eight years old.

* At least 2.63 is tested, we don't know about the older ones.

* It doesn't affect tarballs.