### PR TITLE
Change: re-enable hub process maintainance

### DIFF
--- a/cfe_internal/update/update_processes.cf
+++ b/cfe_internal/update/update_processes.cf
@@ -49,7 +49,7 @@ bundle agent cfe_internal_update_processes
 
   methods:
 
-    am_policy_hub.enterprise.!systemd::
+    am_policy_hub.enterprise::
 
       "TAKING CARE CFE HUB PROCESSES"
       usebundle => maintain_cfe_hub_process,


### PR DESCRIPTION
The systemd units do not currently cover all hub process maintanance.
This policy is still required for proper hub functioning.

Changelog: Title
(cherry picked from commit 7dc3f337bb9dd5be9bdaa005dd2a249ed2b09740)