### PR TITLE
Fix double-parsing of options

### DIFF
--- a/modules/packages/nimclient
+++ b/modules/packages/nimclient
@@ -138,7 +138,7 @@ while IFS= read -r line; do
   #   comes through the protocol as options=lpp_source=aix7783
   #   and here we define lpp_source=aix7783
   if [ -n "$options" ]; then
-    eval $options
+    eval "$options"
   fi
 done
 


### PR DESCRIPTION
Passing un-double quoted $options to eval is not what was intended here.

The contents of "options" in the previous version will be subjected to split, glob, and then *again* split, glob.