### PR TITLE
Make package manager unit tests parallel-safe.

### DIFF
--- a/tests/unit/test_package_module_apt_get
+++ b/tests/unit/test_package_module_apt_get
@@ -17,7 +17,7 @@ os.environ['CFENGINE_TEST_DPKG_CMD'] = cwd + "/mock_dpkg"
 os.environ['CFENGINE_TEST_DPKG_DEB_CMD'] = cwd + "/mock_dpkg_deb"
 os.environ['CFENGINE_TEST_DPKG_QUERY_CMD'] = cwd + "/mock_dpkg_query"
 os.environ['CFENGINE_TEST_APT_GET_CMD'] = cwd + "/mock_apt_get"
-mock_log = cwd + "/mock_output.log"
+mock_log = cwd + "/apt_get_mock_output.log"
 os.environ['CFENGINE_TEST_MOCK_LOG'] = mock_log
 try:
     os.unlink(mock_log)

--- a/tests/unit/test_package_module_yum
+++ b/tests/unit/test_package_module_yum
@@ -15,7 +15,7 @@ cwd = os.getcwd()
 # Will cause the package module to call these instead.
 os.environ['CFENGINE_TEST_RPM_CMD'] = cwd + "/mock_rpm"
 os.environ['CFENGINE_TEST_YUM_CMD'] = cwd + "/mock_yum"
-mock_log = cwd + "/mock_output.log"
+mock_log = cwd + "/yum_mock_output.log"
 os.environ['CFENGINE_TEST_MOCK_LOG'] = mock_log
 try:
     os.unlink(mock_log)


### PR DESCRIPTION
Signed-off-by: Kristian Amlie <kristian.amlie@cfengine.com>