### PR TITLE
Skip new package promise tests on CentOS 4, which is not supported.

### DIFF
--- a/tests/acceptance/17_packages/10_new/unsafe/the_great_package_test.cf
+++ b/tests/acceptance/17_packages/10_new/unsafe/the_great_package_test.cf
@@ -29,7 +29,7 @@ bundle agent init
       # No package modules written for platforms besides RedHat and Debian.
       "test_skip_needs_work" string => "!debian.!redhat";
       # The package module does not support RedHat 4 or Debian 4 (Etch).
-      "test_skip_unsupported" string => "redhat_4|debian_4|debian_etch";
+      "test_skip_unsupported" string => "centos_4|redhat_4|debian_4|debian_etch";
 }
 
 bundle agent log_test_case(msg)

--- a/tests/acceptance/17_packages/10_new/unsafe/the_great_package_test_generator.py
+++ b/tests/acceptance/17_packages/10_new/unsafe/the_great_package_test_generator.py
@@ -112,7 +112,7 @@ bundle agent init
       # No package modules written for platforms besides RedHat and Debian.
       "test_skip_needs_work" string => "!debian.!redhat";
       # The package module does not support RedHat 4 or Debian 4 (Etch).
-      "test_skip_unsupported" string => "redhat_4|debian_4|debian_etch";
+      "test_skip_unsupported" string => "centos_4|redhat_4|debian_4|debian_etch";
 }
 
 bundle agent log_test_case(msg)


### PR DESCRIPTION
Signed-off-by: Kristian Amlie <kristian.amlie@cfengine.com>