### PR TITLE
Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: c
+sudo: required
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,18 @@ matrix:
 script:
 - INSTDIR=$HOME/cf_install
 - cd $TRAVIS_BUILD_DIR
-- if [ x$STYLE_CHECK_JOB = x1 ]; then sh tests/style_check.sh; exit; fi
+#     If we are on a foreign clone, fetch the tags from upstream;
+#     Needed for determine-version.py to work
+- if ! git remote -v | grep ^origin | grep cfengine/masterfiles;
+  then
+      git remote add upstream https://github.com/cfengine/masterfiles.git;
+      git fetch upstream 'refs/tags/*:refs/tags/*';
+  fi
+- if [ x$STYLE_CHECK_JOB = x1 ];
+  then
+      sh tests/style_check.sh;
+      exit;
+  fi
 - ./autogen.sh --without-core --prefix=$INSTDIR
 - make install
 - /var/cfengine/bin/cf-promises --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,13 @@ script:
 - export DIST_TARBALL=`echo cfengine-masterfiles-*.tar.gz`
 - make tar-package
 - export PKG_TARBALL=`echo cfengine-masterfiles-*.pkg.tar.gz`
+- if echo $DIST_TARBALL | grep -E -q '[0-9]{1,2}\.[0-9]{1,2}\.tar\.gz';
+  then
+      IS_PRERELEASE=false;
+  else
+      IS_PRERELEASE=true;
+  fi;
+  export IS_PRERELEASE
 
 
 # We deploy when setting tags only, which basically never happens
@@ -63,6 +70,8 @@ deploy:
   provider: releases
   # Remember to set it as private variable in Travis-CI settings
   api_key: $GITHUB_RELEASE_TOKEN
+# Does not work, I get the error that "true" is not a boolean
+#  prerelease: $IS_PRERELEASE
   file:
   - "$DIST_TARBALL"
   - "$PKG_TARBALL"

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,9 +49,9 @@ script:
 - /var/cfengine/bin/cf-promises -c -I -f $INSTDIR/masterfiles/update.cf
 - /var/cfengine/bin/cf-promises -c -I -f $INSTDIR/masterfiles/promises.cf
 - make dist
-- export DIST_TARBALL=cfengine-masterfiles-*.tar.gz
+- export DIST_TARBALL=`echo cfengine-masterfiles-*.tar.gz`
 - make tar-package
-- export PKG_TARBALL=cfengine-masterfiles-*.pkg.tar.gz
+- export PKG_TARBALL=`echo cfengine-masterfiles-*.pkg.tar.gz`
 
 
 # We deploy when setting tags only, which basically never happens
@@ -62,7 +62,7 @@ deploy:
   skip_cleanup: true
   provider: releases
   # Remember to set it as private variable in Travis-CI settings
-  api_key: "$GITHUB_RELEASE_TOKEN"
+  api_key: $GITHUB_RELEASE_TOKEN
   file:
   - "$DIST_TARBALL"
   - "$PKG_TARBALL"

--- a/3rdparty/core/determine-version.py
+++ b/3rdparty/core/determine-version.py
@@ -119,17 +119,25 @@ else:
         usage()
     REV = sys.argv[1]
 
+# Find the abbreviated version of the commit
+git = subprocess.Popen(["git", "rev-list", "-1", "--abbrev-commit", REV],
+                       stdout=subprocess.PIPE)
+abbrev_rev = git.stdout.readlines()[0].strip()
+verbose_print("REV        = %s" % REV)
+verbose_print("abbrev_rev = %s" % abbrev_rev)
+
 
 # If the commit is referenced exactly in a tag, then use that tag as is
 git = subprocess.Popen(["git", "describe", "--tags", "--exact-match", "--abbrev=0", REV],
                        stdout=subprocess.PIPE, stderr=DEVNULL)
 try:
     exact_tag = git.stdout.readlines()[0].strip()
-    verbose_print("exact_tag = %s" % exact_tag)
+    verbose_print("exact_tag  = %s" % exact_tag)
     (version_major, version_minor, version_patch, version_extra) = extract_version_components(exact_tag)
     print("%s.%s.%s%s" % (version_major, version_minor, version_patch, version_extra))
     exit(0)
 except IndexError:                          # command returned no output
+    verbose_print("exact_tag  = not found")
     pass
 
 # Find the most recent tag reachable from this commit.
@@ -138,6 +146,7 @@ git = subprocess.Popen(["git", "describe", "--tags", "--abbrev=0", REV],
 recent_tag = git.stdout.readlines()[0].strip()
 verbose_print("recent_tag = %s" % recent_tag)
 
+# Find the revision corresponding to the tag
 git = subprocess.Popen(["git", "rev-parse", recent_tag + "^{}"],
                        stdout=subprocess.PIPE)
 recent_rev = git.stdout.readlines()[0].strip()
@@ -154,11 +163,13 @@ else:
     (recent_major, recent_minor, recent_patch, recent_extra) = recent_version
     tag_finder = ["git", "tag", "--contains", recent_tag]
 
-git_tag_list = subprocess.Popen(tag_finder, stdout=subprocess.PIPE)
+git_tag_list = subprocess.Popen(tag_finder,
+                                stdout=subprocess.PIPE)
 all_tags = []
 for tag in git_tag_list.stdout.readlines():
     tag = tag.strip()
-    git_rev = subprocess.Popen(["git", "rev-parse", tag + "^{}"], stdout=subprocess.PIPE)
+    git_rev = subprocess.Popen(["git", "rev-parse", tag + "^{}"],
+                               stdout=subprocess.PIPE)
     rev = git_rev.stdout.readlines()[0].strip()
     if rev == recent_rev:
         # Ignore tags that point at the same commit.
@@ -168,18 +179,21 @@ for tag in git_tag_list.stdout.readlines():
         # Ignore non-version tags.
         continue
     all_tags.append(match)
+
 all_tags = sorted(all_tags, cmp=version_cmp, reverse=True)
+verbose_print("all_tags   =", all_tags)
 
 if len(all_tags) > 1:
     # This is a new minor version
-    print("%s.%d.%s" % (all_tags[0][0], int(all_tags[0][1]) + 1, 0))
+    print("%s.%d.0a.%s" % (all_tags[0][0], int(all_tags[0][1]) + 1, abbrev_rev))
 else:
     # This is a new patch version.
     # A "pure" version with no extra tag info is considered higher than
     # an "impure" one, IOW "3.8.0" > "3.8.0b1".
     if recent_extra != "":
-        print("%s.%s.%d" % (recent_major, recent_minor, int(recent_patch)))
+        patch_version = int(recent_patch)
     else:
-        print("%s.%s.%d" % (recent_major, recent_minor, int(recent_patch) + 1))
+        patch_version = int(recent_patch) + 1
+    print("%s.%s.%da.%s" % (recent_major, recent_minor, patch_version, abbrev_rev))
 
 sys.exit(0)

--- a/3rdparty/core/determine-version.py
+++ b/3rdparty/core/determine-version.py
@@ -4,6 +4,13 @@ from __future__ import print_function
 import re
 import subprocess
 import sys
+import os
+
+try:
+    from subprocess import DEVNULL # py3k
+except ImportError:
+    DEVNULL = open(os.devnull, 'wb')
+
 
 # Determines which version we should call this build.
 #
@@ -115,7 +122,7 @@ else:
 
 # If the commit is referenced exactly in a tag, then use that tag as is
 git = subprocess.Popen(["git", "describe", "--tags", "--exact-match", "--abbrev=0", REV],
-                       stdout=subprocess.PIPE)
+                       stdout=subprocess.PIPE, stderr=DEVNULL)
 try:
     exact_tag = git.stdout.readlines()[0].strip()
     verbose_print("exact_tag = %s" % exact_tag)

--- a/3rdparty/core/determine-version.py
+++ b/3rdparty/core/determine-version.py
@@ -114,7 +114,7 @@ else:
 
 
 # If the commit is referenced exactly in a tag, then use that tag as is
-git = subprocess.Popen(["git", "describe", "--tag", "--exact-match", "--abbrev=0", REV],
+git = subprocess.Popen(["git", "describe", "--tags", "--exact-match", "--abbrev=0", REV],
                        stdout=subprocess.PIPE)
 try:
     exact_tag = git.stdout.readlines()[0].strip()
@@ -126,7 +126,7 @@ except IndexError:                          # command returned no output
     pass
 
 # Find the most recent tag reachable from this commit.
-git = subprocess.Popen(["git", "describe", "--tag", "--abbrev=0", REV],
+git = subprocess.Popen(["git", "describe", "--tags", "--abbrev=0", REV],
                        stdout=subprocess.PIPE)
 recent_tag = git.stdout.readlines()[0].strip()
 verbose_print("recent_tag = %s" % recent_tag)

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,6 @@ dnl ##########################################################################
 
 AC_PREREQ(2.63)
 
-m4_define([revision], m4_normalize(m4_esyscmd([git rev-list -1 --abbrev-commit HEAD])))
 
 m4_define([cfversion_from_env], m4_normalize(m4_esyscmd([echo $EXPLICIT_VERSION])))
 m4_ifval(cfversion_from_env, [
@@ -18,15 +17,17 @@ m4_ifval(cfversion_from_env, [
     m4_if(m4_sysval, 0, [], [
         m4_fatal([Could not determine CFEngine version. Please set EXPLICIT_VERSION in the environment.])
     ])
-    m4_define([cfversion], cfversion_from_detect[]a1.revision)
+    m4_define([cfversion], cfversion_from_detect)
     m4_undefine([cfversion_from_detect])
 ])
 
 AC_INIT([cfengine-masterfiles], cfversion)
 
-m4_undefine([revision])
+cfengine_version=cfversion
+
 m4_undefine([cfversion])
 m4_undefine([cfversion_from_env])
+
 
 AC_CANONICAL_TARGET
 
@@ -145,7 +146,8 @@ dnl Print summary
 dnl ######################################################################
 
 AC_MSG_RESULT()
-AC_MSG_RESULT(Summary of options:)
+AC_MSG_RESULT(Summary:)
+AC_MSG_RESULT(Version              -> $cfengine_version)
 AM_COND_IF(HAVE_CORE,
     AC_MSG_RESULT(Core directory       -> $core_dir),
     AC_MSG_RESULT(Core directory       -> not set - tests are disabled)

--- a/tests/style_check.sh
+++ b/tests/style_check.sh
@@ -1,14 +1,23 @@
 #!/bin/sh
 
+retval=0                                            # success by default
+echo
+echo
+
+
+########## Trailing Whitespace Check ##########
 
 git ls-files  \
     |  xargs grep --binary-files=without-match -n ' $'
 
 if [ $? = 0 ]
 then
-    echo "\n\nFAIL: trailing whitespace found\n"  1>&2
-    exit 1
+    echo "FAIL: trailing whitespace was found"  1>&2
+    retval=1
 else
-    echo "\n\nPASS: trailing whitespace check OK\n"  1>&2
-    exit 0
+    echo "PASS: trailing whitespace check OK"  1>&2
 fi
+
+
+echo
+exit $retval


### PR DESCRIPTION
More work on automating travis builds and deployment to github releases.

The changes to the files `determine_version.py`, `.travis.yml` and `configure.ac` should be cherry-picked to maintained branches, and also to all branches of cfengine/core.