### PR TITLE
CFE-2468: Pass package promise options to underlying apt-get call

### DIFF
--- a/modules/packages/apt_get
+++ b/modules/packages/apt_get
@@ -251,6 +251,10 @@ def package_arguments_builder(is_apt_install):
         elif line.startswith("Architecture="):
             arch = line.split("=", 1)[1].rstrip()
 
+        elif line.startswith("Options="):
+            global apt_get_options
+            apt_get_options.append(line.split("=", 1)[1].rstrip())
+
     if name:
         args.extend(one_package_argument(name, arch, version, is_apt_install))
 
@@ -258,9 +262,9 @@ def package_arguments_builder(is_apt_install):
 
 
 def repo_install():
-    cmd_line = [apt_get_cmd] + apt_get_options + ["install"]
-
     args = package_arguments_builder(True)
+
+    cmd_line = [apt_get_cmd] + apt_get_options + ["install"]
 
     if (not args):
         return 0
@@ -276,9 +280,9 @@ def repo_install():
     return 0
 
 def remove():
-    cmd_line = [apt_get_cmd] + apt_get_options + ["remove"]
-
     args = package_arguments_builder(False)
+
+    cmd_line = [apt_get_cmd] + apt_get_options + ["remove"]
 
     if (not args):
         return 0

--- a/modules/packages/apt_get
+++ b/modules/packages/apt_get
@@ -251,7 +251,7 @@ def package_arguments_builder(is_apt_install):
         elif line.startswith("Architecture="):
             arch = line.split("=", 1)[1].rstrip()
 
-        elif line.startswith("Options="):
+        elif line.startswith("options="):
             global apt_get_options
             apt_get_options.append(line.split("=", 1)[1].rstrip())
 

--- a/tests/unit/test_package_module_apt_get
+++ b/tests/unit/test_package_module_apt_get
@@ -117,6 +117,14 @@ dpkg-query --showformat ${Architecture}=${Status}
 apt-get -o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-confdef -y --force-yes install a:x=1 b:y c=3 netcat:amd64 netcat:i386 netcat:amd64=3 netcat:i386=3 d
 """])
 
+assert check("repo-install", [ "Name=netcat",
+                              "Options=-qq"],
+             0, [], 4, ["""dpkg --print-architecture
+dpkg-query --showformat ${Architecture}=${Status}
+ -W netcat:*
+apt-get -o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-confdef -y --force-yes -qq install netcat:amd64 netcat:i386
+"""])
+
 assert check("remove", ["Name=a\nVersion=1\nArchitecture=x",
                         "Name=b\nArchitecture=y",
                         "Name=c\nVersion=3",


### PR DESCRIPTION
Changelog: Title

Commit can be cherry-picked cleanly into 3.7.x, 3.8.x, 3.9.x as well.