### PR TITLE
Clarify comment on "ifelapsed" in controls/cf_agent.cf

### DIFF
--- a/controls/cf_agent.cf
+++ b/controls/cf_agent.cf
@@ -15,8 +15,8 @@ body agent control
 
     any::
 
-      # This should normally be set to an interval like 1-5 mins
-      # We set it to one initially to avoid confusion.
+      # Minimum time (in minutes) which should have passed since the last time
+      # the promise was verified before it is checked again.
 
       ifelapsed => "1";
 


### PR DESCRIPTION
It was confusing because it said "ifelapsed" takes an interval, but it doesn't; it takes an integer.