### PR TITLE
Add repo options to yum package module for inventory

### DIFF
--- a/modules/packages/yum
+++ b/modules/packages/yum
@@ -103,8 +103,12 @@ def list_installed():
 
 
 def list_updates(online):
-    # Ignore everything.
-    sys.stdin.readlines()
+    for line in sys.stdin:
+        if line.startswith("options="):
+            option = line[8:]
+            if option.startswith(("enablerepo=","disablerepo=")):
+                global yum_options
+                yum_options += ["--" + option]
 
     online_flag = []
     if not online:

--- a/modules/packages/yum
+++ b/modules/packages/yum
@@ -106,7 +106,7 @@ def list_updates(online):
     for line in sys.stdin:
         if line.startswith("options="):
             option = line[8:]
-            if option.startswith(("enablerepo=","disablerepo=")):
+            if option.startswith("enablerepo=") or option.startswith("disablerepo="):
                 global yum_options
                 yum_options += ["--" + option]
 


### PR DESCRIPTION
I've only implemented this for the 'list-updates' command, because
that is the only one needed for inventory.  It would need additional
work to allow _installation_ with specific 'enablerepo' and 'disablerepo'
flags.

Example usage:

Make a copy of the package module (see CFE-2103 for why you need to make
a copy).

Call the copy 'yum_inventory'

Define the package module body like so:

body package_module yum_inventory {
  default_options => { "disablerepo=*", "enablerepo=UPDATES" };
}

Define the yum_inventory package module as the one to use for inventory:

body common control {
  package_inventory => { "yum_inventory" };
}

Your "available updates" inventory will now be done using your "UPDATES"
yum repository only, even if that repo is usually disabled.  All your
package promises will be unaffected.
