### PR TITLE
CFE-953 policy changes for custom ports.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ stamp-h1
 /revision
 /ylwrap
 /test-driver
+CFVERSION
 
 # Misc.
 /cf_promises_*

--- a/cfe_internal/update/update_bins.cf
+++ b/cfe_internal/update/update_bins.cf
@@ -323,7 +323,7 @@ bundle agent cfe_internal_update_bins
     !am_policy_hub.enterprise.trigger_upgrade.(cfengine_3_6_0|cfengine_3_6_1)::
       "$(sys.bindir)/cf-upgrade"
       handle => "cfe_internal_update_bins_files_cf_upgrade_i386_linux",
-      copy_from => u_rcp("$(master_software_location)/cf-upgrade/linux.i386/cf-upgrade", @(update_def.policy_servers)),
+      copy_from => u_rcp("$(master_software_location)/cf-upgrade/linux.i386/cf-upgrade", @(update_def.policy_servers), "$(sys.policy_hub_port)"),
       perms => u_m("0755"),
       ifvarclass => "linux.i686",
       comment => "The cf-upgrade binary that shipped with 3.6.0 and 3.6.1 was
@@ -333,7 +333,7 @@ bundle agent cfe_internal_update_bins
       "$(sys.workdir)/bin/cf-upgrade"
       comment => "Copy cf-upgrade binary from policy hub for x86_64 linux",
       handle => "cfe_internal_update_bins_files_cf_upgrade_x86_64_linux",
-      copy_from => u_rcp("$(master_software_location)/cf-upgrade/linux.x86_64/cf-upgrade", @(update_def.policy_servers)),
+      copy_from => u_rcp("$(master_software_location)/cf-upgrade/linux.x86_64/cf-upgrade", @(update_def.policy_servers), "$(sys.policy_hub_port)"),
       perms => u_m("0755"),
       ifvarclass => "linux.x86_64",
       comment => "The cf-upgrade binary that shipped with 3.6.0 and 3.6.1 was

--- a/cfe_internal/update/update_policy.cf
+++ b/cfe_internal/update/update_policy.cf
@@ -216,8 +216,10 @@ body copy_from u_rcp(from,server)
       trustkey    => "false";
 
     !am_policy_hub::
-
       servers => { "$(server)" };
+
+    !am_policy_hub.sys_policy_hub_port_exists::
+      portnumber => "$(sys.policy_hub_port)";
 
     cfengine_internal_encrypt_transfers::
       encrypt => "true";

--- a/controls/update_def.cf.in
+++ b/controls/update_def.cf.in
@@ -9,7 +9,8 @@ bundle common update_def
       "$(augments_classes_data_keys)"
         expression => classmatch("$(augments[classes][$(augments_classes_data_keys)])"),
         meta => { "augments_class", "derived_from=$(augments_file)" };
-
+    any::
+      "sys_policy_hub_port_exists" expression => isvariable("sys.policy_hub_port");
   vars:
       "current_version" string => "@VERSION@";
 


### PR DESCRIPTION
@nickanderson Would like review on this. Some changes to make custom ports work for cf-serverd and cf-agent. Not sure if this is the best way, but it seems to be working.

Ref: cfengine/core#2699