### PR TITLE
apt_get option --force-yes is deprecated since version 1.1

### DIFF
--- a/modules/packages/apt_get
+++ b/modules/packages/apt_get
@@ -16,7 +16,9 @@ dpkg_status_format = "Status=${Status}\n" + dpkg_output_format
 apt_get_options = ["-o", "Dpkg::Options::=--force-confold",
                    "-o", "Dpkg::Options::=--force-confdef",
                    "-y",
-                   "--force-yes"]
+                   "--allow-downgrades",
+                   "--allow-remove-essential",
+                   "--allow-change-held-packages"]
 apt_get_cmd = os.environ.get('CFENGINE_TEST_APT_GET_CMD', "/usr/bin/apt-get")
 
 os.environ['DEBIAN_FRONTEND'] = "noninteractive"


### PR DESCRIPTION
Check bugreport CFE-2360
This PR changes options unconditionally. Older apt_get versions (<1.1) if supported by current cfengine LTS masterfiles should be checked to change options accordingly...
