### PR TITLE
sys.policy_hub renamed to sys.policy_hub_ip

### DIFF
--- a/cfe_internal/enterprise/ha/ha_def.cf
+++ b/cfe_internal/enterprise/ha/ha_def.cf
@@ -31,7 +31,7 @@ bundle common ha_def
 
 
   classes:
-      "ha_replication_only_node" expression => some($(sys.policy_hub), replication_only_nodes);
+      "ha_replication_only_node" expression => some($(sys.policy_hub_ip), replication_only_nodes);
 
 
   reports:

--- a/controls/3.6/def.cf
+++ b/controls/3.6/def.cf
@@ -83,7 +83,7 @@ bundle common def
                            # ".*$(def.domain)",
 
                            # Assume /16 LAN clients to start with
-                           "$(sys.policy_hub)/16",
+                           "$(sys.policy_hub_ip)/16",
 
                            # Uncomment below if HA is used
                            #"@(def.policy_servers)"
@@ -220,11 +220,11 @@ bundle common def
     # Disabled by default
 
     enable_cfengine_enterprise_hub_ha::
-      "standby_servers" slist => filter("$(sys.policy_hub)", "ha_def.ips", false, true, 10);
-      "policy_servers" slist => { "$(sys.policy_hub)", "@(standby_servers)" };
+      "standby_servers" slist => filter("$(sys.policy_hub_ip)", "ha_def.ips", false, true, 10);
+      "policy_servers" slist => { "$(sys.policy_hub_ip)", "@(standby_servers)" };
 
     !enable_cfengine_enterprise_hub_ha::
-      "policy_servers" slist => {"$(sys.policy_hub)"};
+      "policy_servers" slist => {"$(sys.policy_hub_ip)"};
 
   classes:
 

--- a/controls/3.6/update_def.cf.in
+++ b/controls/3.6/update_def.cf.in
@@ -67,11 +67,11 @@ bundle common update_def
     # Disabled by default
 
     enable_cfengine_enterprise_hub_ha::
-      "standby_servers" slist => filter("$(sys.policy_hub)", "ha_def.ips", false, true, 10);
-      "policy_servers" slist => { "$(sys.policy_hub)", "@(standby_servers)" };
+      "standby_servers" slist => filter("$(sys.policy_hub_ip)", "ha_def.ips", false, true, 10);
+      "policy_servers" slist => { "$(sys.policy_hub_ip)", "@(standby_servers)" };
 
     !enable_cfengine_enterprise_hub_ha::
-      "policy_servers" slist => {"$(sys.policy_hub)"};
+      "policy_servers" slist => {"$(sys.policy_hub_ip)"};
 
   classes:
 

--- a/controls/def.cf
+++ b/controls/def.cf
@@ -92,7 +92,7 @@ bundle common def
                    # ".*$(def.domain)",
 
                    # Assume /16 LAN clients to start with
-                   "$(sys.policy_hub)/16",
+                   "$(sys.policy_hub_ip)/16",
 
                    # Uncomment below if HA is used
                    #"@(def.policy_servers)"
@@ -247,11 +247,11 @@ bundle common def
   # Disabled by default
 
     enable_cfengine_enterprise_hub_ha::
-      "standby_servers" slist => filter("$(sys.policy_hub)", "ha_def.ips", false, true, 10);
-      "policy_servers" slist => { "$(sys.policy_hub)", "@(standby_servers)" };
+      "standby_servers" slist => filter("$(sys.policy_hub_ip)", "ha_def.ips", false, true, 10);
+      "policy_servers" slist => { "$(sys.policy_hub_ip)", "@(standby_servers)" };
 
     !enable_cfengine_enterprise_hub_ha::
-      "policy_servers" slist => {"$(sys.policy_hub)"};
+      "policy_servers" slist => {"$(sys.policy_hub_ip)"};
 
   classes:
 

--- a/controls/update_def.cf.in
+++ b/controls/update_def.cf.in
@@ -101,11 +101,11 @@ bundle common update_def
     # Disabled by default
 
     enable_cfengine_enterprise_hub_ha::
-      "standby_servers" slist => filter("$(sys.policy_hub)", "ha_def.ips", false, true, 10);
-      "policy_servers" slist => { "$(sys.policy_hub)", "@(standby_servers)" };
+      "standby_servers" slist => filter("$(sys.policy_hub_ip)", "ha_def.ips", false, true, 10);
+      "policy_servers" slist => { "$(sys.policy_hub_ip)", "@(standby_servers)" };
 
     !enable_cfengine_enterprise_hub_ha::
-      "policy_servers" slist => {"$(sys.policy_hub)"};
+      "policy_servers" slist => {"$(sys.policy_hub_ip)"};
 
   classes:
 

--- a/example_def.json
+++ b/example_def.json
@@ -16,7 +16,7 @@
 
     "inputs": [ "$(sys.libdir)/bundles.cf" ],
     "vars": {
-        "acl": [ ".*$(def.domain)", "$(sys.policy_hub)/16" ],
+        "acl": [ ".*$(def.domain)", "$(sys.policy_hub_ip)/16" ],
         "control_agent_maxconnections": 100,
         "input_name_patterns": [ ".*\\.cf",".*\\.dat",".*\\.txt", ".*\\.conf", ".*\\.mustache",
                                  ".*\\.sh", ".*\\.pl", ".*\\.py", ".*\\.rb",

--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -813,7 +813,7 @@ body copy_from inventory_cmdb_copy_from
 {
     !cfe_inventory_cmdb_override_file::
       source      => "me.json";
-      servers     => { "$(sys.policy_hub)" };
+      servers     => { "$(sys.policy_hub_ip)" };
     cfe_inventory_cmdb_override_file::
       source      => "$(sys.inputdir)/me.json";
     any::

--- a/templates/host_info_report.mustache
+++ b/templates/host_info_report.mustache
@@ -10,7 +10,7 @@ Version: CFEngine {{#classes.enterprise}}Enterprise{{/classes.enterprise}} {{var
 Last Agent Run: {{vars.host_info_report_cfengine.last_agent_run}}
 Policy Release ID: {{vars.host_info_report_cfengine.cf_promises_release_id.releaseId}}
 Policy Last Updated: {{vars.host_info_report_cfengine.cf_promises_validated_timestamp_formatted}}
-Bootstrapped to: {{vars.sys.policy_hub}}
+Bootstrapped to: {{vars.sys.policy_hub_ip}}
 
 ## OS
 Architecture: {{vars.sys.arch}}


### PR DESCRIPTION
Must merge with: cfengine/core#2727

This change is done so I can reintroduce sys.policy_hub to be same as policy_server.dat.
