### PR TITLE
CFE-2466: adapt tests for new behaviour

### DIFF
--- a/tests/acceptance/lib/files/set_config_values.cf
+++ b/tests/acceptance/lib/files/set_config_values.cf
@@ -38,8 +38,6 @@ bundle agent test
   meta:
     "description" string => "Test that set_config_values works as expected";
 
-    "test_soft_fail" string => "any", meta => { "CFE-2466" };
-
   vars:
        # should create a new line right after existing commented-out Protocol lines
       "config[Protocol]" string => "2";

--- a/tests/acceptance/lib/files/set_config_values.cf.finish
+++ b/tests/acceptance/lib/files/set_config_values.cf.finish
@@ -136,4 +136,4 @@ Subsystem	sftp	/usr/lib64/misc/sftp-server
 #	AllowTcpForwarding no
 #	ForceCommand cvs server
 AddressFamily any
-BlankOption
+BlankOption 

--- a/tests/acceptance/lib/files/set_line_based_config_values.cf
+++ b/tests/acceptance/lib/files/set_line_based_config_values.cf
@@ -31,9 +31,6 @@ bundle agent init
 
 bundle agent test
 {
-  meta:
-      "test_soft_fail" string => "any", meta => { "CFE-2466" };
-
   vars:
        # should create a new line right after existing commented-out Protocol lines
       "config[Protocol]" string => "2";

--- a/tests/acceptance/lib/files/set_line_based_config_values.cf.finish
+++ b/tests/acceptance/lib/files/set_line_based_config_values.cf.finish
@@ -136,4 +136,4 @@ Subsystem	sftp	/usr/lib64/misc/sftp-server
 #	AllowTcpForwarding no
 #	ForceCommand cvs server
 AddressFamily any
-BlankOption
+BlankOption 

--- a/tests/style_check.sh
+++ b/tests/style_check.sh
@@ -8,6 +8,7 @@ echo
 ########## Trailing Whitespace Check ##########
 
 git ls-files  \
+    |  grep -v 'set_config_values.cf.finish\|set_line_based_config_values.cf.finish'  \
     |  xargs grep --binary-files=without-match -n ' $'
 
 if [ $? = 0 ]


### PR DESCRIPTION
Changelog: Behaviour change: when used with CFEngine 3.10.0 or greater,
bundles set_config_values() and set_line_based() are appending a
trailing space when inserting a configuration option with empty value.