### PR TITLE
ENT-3016: Disable ssl stapling by default

### DIFF
--- a/cfe_internal/enterprise/templates/httpd.conf.mustache
+++ b/cfe_internal/enterprise/templates/httpd.conf.mustache
@@ -155,10 +155,11 @@ LogLevel warn
   SSLSessionTickets Off
 
   # OCSP stapling is an extension that aims to improve SSL negotiation
-  # performance while mainting visitor privacy.
+  # performance while mainting visitor privacy. Disabled because of
+  # issues with self signed certs.
 
-  SSLUseStapling on
-  SSLStaplingCache "shmcb:logs/stabling-cache(150000)"
+  SSLUseStapling off
+  # SSLStaplingCache "shmcb:logs/stabling-cache(150000)"
 
   # TLS Compression should be disabled to avoid CRIME
   # https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2012-4929


### PR DESCRIPTION
Stapling is problematic with self signed certificates, and since we use
a self signed cert by default we disable it.