### PR TITLE
Add path to bhyvectl on FreeBSD

### DIFF
--- a/lib/paths.cf
+++ b/lib/paths.cf
@@ -220,6 +220,7 @@ bundle common paths
 
     freebsd::
 
+      "path[bhyvectl]" string => "/usr/sbin/bhyvectl";
       "path[getfacl]"  string => "/bin/getfacl";
       "path[dtrace]"   string => "/usr/sbin/dtrace";
       "path[service]"  string => "/usr/sbin/service";


### PR DESCRIPTION
This will define $(paths.path[bhyvectl]) on FreeBSD