### PR TITLE
Fixed ACLs for hostnames in cf-serverd (CFE-2495)

### DIFF
--- a/controls/def.cf
+++ b/controls/def.cf
@@ -92,7 +92,7 @@ bundle common def
                    # ".*$(def.domain)",
 
                    # Assume /16 LAN clients to start with
-                   "$(sys.policy_hub)/16",
+                   "$(sys.policy_hub_ip)/16",
 
                    # Uncomment below if HA is used
                    #"@(def.policy_servers)"

--- a/example_def.json
+++ b/example_def.json
@@ -16,7 +16,7 @@
 
     "inputs": [ "$(sys.libdir)/bundles.cf" ],
     "vars": {
-        "acl": [ ".*$(def.domain)", "$(sys.policy_hub)/16" ],
+        "acl": [ ".*$(def.domain)", "$(sys.policy_hub_ip)/16" ],
         "control_agent_maxconnections": 100,
 
         "control_common_bundlesequence_end": [ "my_bundle", "my_other_bundle" ],


### PR DESCRIPTION
Using the IP in policy is the fastest way to get this working. The only drawback is it will not change the ACL before policy is re-evaluated. This can in some cases (but not all) cause connections to be refused after the hostname policy server has changed IP. 

Note that if the hostname policy server is within the same ACL, for example 192.168.x.x, it should still work fine.