### PR TITLE
CFE-2519: Fix ability to manage an INI section and select the end of region

### DIFF
--- a/lib/files.cf
+++ b/lib/files.cf
@@ -1209,6 +1209,10 @@ body select_region INI_section(x)
 {
       select_start => "\[$(x)\]\s*";
       select_end => "\[.*\]\s*";
+
+@if minimum_version(3.10)
+      select_end_match_eof => "true";
+@endif
 }
 
 ##-------------------------------------------------------


### PR DESCRIPTION
In order to be able to select a section that contains some special
characters we need to escape it.

Changelog: Title