### PR TITLE
Fixes CFE-2445: Make apt_get module compatible with Ubuntu 16.04

### DIFF
--- a/modules/packages/apt_get
+++ b/modules/packages/apt_get
@@ -1,10 +1,23 @@
-#!/usr/bin/python
+#!/bin/sh
+"true" '''\'
+PYTHON_BINS="/usr/bin/python /usr/bin/python3"
+
+for python_bin in $PYTHON_BINS;
+do
+  if [ -f "$python_bin" ]; then
+    exec "$python_bin" "$0" "$@"
+  fi
+done
+
+exit 127
+'''
 
 import sys
 import os
 import subprocess
 import re
 
+PY3 = sys.version_info > (3,)
 
 dpkg_cmd = os.environ.get('CFENGINE_TEST_DPKG_CMD', "/usr/bin/dpkg")
 dpkg_deb_cmd = os.environ.get('CFENGINE_TEST_DPKG_DEB_CMD', "/usr/bin/dpkg-deb")
@@ -118,6 +131,8 @@ def list_installed():
     process = subprocess_Popen([dpkg_query_cmd, "--showformat", dpkg_status_format, "-W"], stdout=subprocess.PIPE)
     installed_package = False
     for line in process.stdout:
+        if PY3:
+            line = line.decode("utf-8")
         line = line.rstrip("\n")
         # The space before "installed" is important, because it can be "not-installed".
         if line.startswith("Status=") and line.split("=", 1)[1].find(" installed") >= 0:
@@ -141,6 +156,8 @@ def list_updates(online):
 
     process = subprocess_Popen([apt_get_cmd] + apt_get_options + ["-s", "upgrade"], stdout=subprocess.PIPE)
     for line in process.stdout:
+        if PY3:
+            line = line.decode("utf-8")
         # Example of lines that we try to match:
         #        (name)  (old version (ignored))  (new version)     (repository(ies) (ignored))  (arch)
         #           |              |                    |                        |                 |
@@ -178,6 +195,8 @@ def list_updates(online):
 def get_platform_arch():
     process = subprocess_Popen([dpkg_cmd, "--print-architecture"], stdout=subprocess.PIPE)
     for line in process.stdout:
+        if PY3:
+            line = line.decode("utf-8")
         return line.rstrip()
     return None
 
@@ -196,6 +215,8 @@ def one_package_argument(name, arch, version, is_apt_install):
                                     "-W", name + ":*"],
                                    stdout=subprocess.PIPE, stderr=NULLFILE)
         for line in process.stdout:
+            if PY3:
+              line = line.decode("utf-8")
             # The space before "installed" is important, because it can be "not-installed".
             if "=" in line:
                 arch, stat = line.split("=", 1)


### PR DESCRIPTION
This commit allows using the python3 executable when python
executable is not there, like in the default with Ubuntu 16.04
install. It also fixes some incompatibilities of the code with Python 3.