### PR TITLE
Fix issue with regenerating MP certificate.

### DIFF
--- a/cfe_internal/enterprise/mission_portal.cf
+++ b/cfe_internal/enterprise/mission_portal.cf
@@ -283,6 +283,7 @@ bundle agent cfe_enterprise_selfsigned_cert
 
     "$(SSLCertificateFileSymlink)" -> { "jira:ENT-760" }
       link_from => ln_s( $(SSLCertificateFile) ),
+      move_obstructions => "true",
       comment => "Mission Portal reads the certificate from this stable
                   location, so it must always point to the current certificate.";
 


### PR DESCRIPTION
This is fixing error error:
Link '/var/cfengine/ssl/cert.pem' points to '
/var/cfengine/httpd/ssl/certs/localhost.cert' not
'/var/cfengine/httpd/ssl/certs/localhost.localdomain.cert',
not authorized to override

Signed-off-by: Marcin Pasinski <marcin.pasinski@cfengine.com>