### PR TITLE
CFE-2360: Make apt_get package module version aware

### DIFF
--- a/modules/packages/apt_get
+++ b/modules/packages/apt_get
@@ -16,6 +16,7 @@ import sys
 import os
 import subprocess
 import re
+from distutils.version import LooseVersion
 
 PY3 = sys.version_info > (3,)
 
@@ -28,11 +29,25 @@ dpkg_query_cmd = os.environ.get('CFENGINE_TEST_DPKG_QUERY_CMD', "/usr/bin/dpkg-q
 dpkg_output_format = "Name=${Package}\nVersion=${Version}\nArchitecture=${Architecture}\n"
 dpkg_status_format = "Status=${Status}\n" + dpkg_output_format
 
+apt_get_cmd = os.environ.get('CFENGINE_TEST_APT_GET_CMD', "/usr/bin/apt-get")
+
+# Some options only work with specific versions of apt, so we must know the
+# current version in order to do the right thing.
+apt_version = subprocess.Popen([ apt_get_cmd , '-v'], stdout=subprocess.PIPE).communicate()[0]
+apt_version = apt_version.splitlines()[0].split(' ')[1]
+
 apt_get_options = ["-o", "Dpkg::Options::=--force-confold",
                    "-o", "Dpkg::Options::=--force-confdef",
-                   "-y",
-                   "--force-yes"]
-apt_get_cmd = os.environ.get('CFENGINE_TEST_APT_GET_CMD', "/usr/bin/apt-get")
+                   "-y"]
+
+if LooseVersion(apt_version) < LooseVersion("1.1"):
+    apt_get_options.append("--force-yes")
+
+else:
+    # The --force-yes option was deprecated in apt-get 1.1
+    apt_get_options.extend( [ "--allow-downgrades",
+                              "--allow-remove-essential",
+                              "--allow-change-held-packages"])
 
 os.environ['DEBIAN_FRONTEND'] = "noninteractive"
 os.environ['LC_ALL'] = "C"

--- a/tests/unit/mock_apt_get
+++ b/tests/unit/mock_apt_get
@@ -7,7 +7,24 @@ log = open(os.environ['CFENGINE_TEST_MOCK_LOG'], "a")
 log.write("apt-get " + (" ".join(sys.argv[1:])) + "\n")
 log.close()
 
-if sys.argv.count("upgrade"):
+if sys.argv[1] == '-v':
+    sys.stdout.write("""apt 1.2.15 (amd64)
+Supported modules:
+*Ver: Standard .deb
+*Pkg:  Debian dpkg interface (Priority 30)
+ Pkg:  Debian APT solver interface (Priority -1000)
+ S.L: 'deb' Debian binary tree
+ S.L: 'deb-src' Debian source tree
+ Idx: Debian Source Index
+ Idx: Debian Package Index
+ Idx: Debian Translation Index
+ Idx: Debian dpkg status file
+ Idx: Debian deb file
+ Idx: Debian dsc file
+ Idx: Debian control file
+ Idx: EDSP scenario file
+""")
+elif sys.argv.count("upgrade"):
     # Subset of a real run of "apt-get upgrade".
     sys.stdout.write('''NOTE: This is only a simulation!
       apt-get needs root privileges for real execution.

--- a/tests/unit/test_package_module_apt_get
+++ b/tests/unit/test_package_module_apt_get
@@ -87,12 +87,16 @@ def check(operation, input, no_lines, expected_output, mock_lines, mock_output):
 
     return True
 
-apt_get_options = "-o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-confdef -y --force-yes"
+apt_get_options = "-o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-confdef -y --allow-downgrades --allow-remove-essential --allow-change-held-packages"
 
-assert check("supports-api-version", [], 1, ["1"], 0, [])
+assert check("supports-api-version", [], 1, ["1"], 1, ["apt-get -v"])
 
-assert check("file-install", ["File=/path/to/pkg"], 0, [], 1, ["dpkg --force-confold --force-confdef -i /path/to/pkg"])
-assert check("file-install", ["File=/path/to/pkg","File=/path/to/pkg2"], 0, [], 1, ["dpkg --force-confold --force-confdef -i /path/to/pkg /path/to/pkg2"])
+assert check("file-install", ["File=/path/to/pkg"], 0, [], 3, ["""apt-get -v
+apt-get -v
+dpkg --force-confold --force-confdef -i /path/to/pkg"""])
+assert check("file-install", ["File=/path/to/pkg","File=/path/to/pkg2"], 0, [], 3, ["""apt-get -v
+apt-get -v
+dpkg --force-confold --force-confdef -i /path/to/pkg /path/to/pkg2"""])
 
 assert check("repo-install", ["Name=a\nVersion=1\nArchitecture=x",
                               "Name=b\nArchitecture=y",
@@ -100,7 +104,9 @@ assert check("repo-install", ["Name=a\nVersion=1\nArchitecture=x",
                               "Name=netcat",
                               "Name=netcat\nVersion=3",
                               "Name=d"],
-             0, [], 15, ["""dpkg --print-architecture
+             0, [], 17, ["""apt-get -v
+apt-get -v
+dpkg --print-architecture
 dpkg --print-architecture
 dpkg --print-architecture
 dpkg-query --showformat ${Architecture}=${Status}
@@ -114,22 +120,26 @@ dpkg-query --showformat ${Architecture}=${Status}
 dpkg --print-architecture
 dpkg-query --showformat ${Architecture}=${Status}
  -W d:*
-apt-get -o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-confdef -y --force-yes install a:x=1 b:y c=3 netcat:amd64 netcat:i386 netcat:amd64=3 netcat:i386=3 d
+apt-get """ + apt_get_options + """ install a:x=1 b:y c=3 netcat:amd64 netcat:i386 netcat:amd64=3 netcat:i386=3 d
 """])
 
 assert check("repo-install", [ "Name=netcat",
                               "options=-qq"],
-             0, [], 4, ["""dpkg --print-architecture
+             0, [], 6, ["""apt-get -v
+apt-get -v
+dpkg --print-architecture
 dpkg-query --showformat ${Architecture}=${Status}
  -W netcat:*
-apt-get -o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-confdef -y --force-yes -qq install netcat:amd64 netcat:i386
+apt-get """ + apt_get_options + """ -qq install netcat:amd64 netcat:i386
 """])
 
 assert check("remove", ["Name=a\nVersion=1\nArchitecture=x",
                         "Name=b\nArchitecture=y",
                         "Name=c\nVersion=3",
                         "Name=d"],
-             0, [], 9, ["""dpkg --print-architecture
+             0, [], 11, ["""apt-get -v
+apt-get -v
+dpkg --print-architecture
 dpkg --print-architecture
 dpkg --print-architecture
 dpkg-query --showformat ${Architecture}=${Status}
@@ -165,7 +175,10 @@ assert check("list-updates", [], 75,
               "Name=libx11-dev\nVersion=2:1.4.99.1-0ubuntu2.3\nArchitecture=amd64",
               "Name=libx11-6\nVersion=2:1.4.99.1-0ubuntu2.3\nArchitecture=amd64",
               "Name=libx11-6\nVersion=2:1.4.99.1-0ubuntu2.3\nArchitecture=i386"],
-             2, ["apt-get " + apt_get_options + " update\napt-get " + apt_get_options + " -s upgrade"])
+             4, ["""apt-get -v
+apt-get -v
+apt-get """ + apt_get_options + """ update
+apt-get """ + apt_get_options + """ -s upgrade"""])
 
 assert check("list-updates-local", [], 75,
              ["Name=dpkg\nVersion=1.16.1.2ubuntu7.6\nArchitecture=amd64",
@@ -193,19 +206,34 @@ assert check("list-updates-local", [], 75,
               "Name=libx11-dev\nVersion=2:1.4.99.1-0ubuntu2.3\nArchitecture=amd64",
               "Name=libx11-6\nVersion=2:1.4.99.1-0ubuntu2.3\nArchitecture=amd64",
               "Name=libx11-6\nVersion=2:1.4.99.1-0ubuntu2.3\nArchitecture=i386"],
-             1, ["apt-get " + apt_get_options + " -s upgrade"])
+             3, ["""apt-get -v
+apt-get -v
+apt-get """ + apt_get_options + """ -s upgrade"""])
 
 assert check("list-installed", [], 6,
              ["Name=netcat\nVersion=1.2.3.5\nArchitecture=amd64",
               "Name=yum\nVersion=3.2.29-43.el6_5\nArchitecture=all"],
-             5, ["dpkg-query --showformat Status=${Status}\nName=${Package}\nVersion=${Version}\nArchitecture=${Architecture}\n -W"])
+             7, ["""apt-get -v
+apt-get -v
+dpkg-query --showformat Status=${Status}
+Name=${Package}
+Version=${Version}
+Architecture=${Architecture}
+ -W"""])
 
 assert check("get-package-data", ["File=/path/to/pkg"], 4,
              ["PackageType=file\nName=file_pkg\nVersion=10.0\nArchitecture=x86_64"],
-             4, ["dpkg-deb --showformat Name=${Package}\nVersion=${Version}\nArchitecture=${Architecture}\n -W /path/to/pkg"])
+             6, ["""apt-get -v
+apt-get -v
+dpkg-deb --showformat Name=${Package}
+Version=${Version}
+Architecture=${Architecture}
+ -W /path/to/pkg"""])
 assert check("get-package-data", ["File=repo_pkg"], 2,
-             ["PackageType=repo\nName=repo_pkg"],
-             0, [])
+             ["""PackageType=repo
+Name=repo_pkg"""],
+             1, ["apt-get -v"])
 assert check("get-package-data", ["File=repo/pkg"], 2,
-             ["PackageType=repo\nName=repo/pkg"],
-             0, [])
+             ["""PackageType=repo
+Name=repo/pkg"""],
+             1, ["apt-get -v"])


### PR DESCRIPTION
Options for behaviour we expect have changed in newer versions of
apt-get. This makes it version aware so that the correct options are
used by default.

Changelog: Title

Modified-by: Kristian Amlie <kristian.amlie@cfengine.com>
* Adapted unit test to accept new "apt-get -v" calls.

Signed-off-by: Kristian Amlie <kristian.amlie@cfengine.com>