### PR TITLE
Add: missing pkg and nimclient package modules

### DIFF
--- a/modules/packages/Makefile.am
+++ b/modules/packages/Makefile.am
@@ -1,3 +1,3 @@
 package_modulesdir = $(prefix)/modules/packages
 
-dist_package_modules_SCRIPTS = apt_get yum pkgsrc freebsd_ports
+dist_package_modules_SCRIPTS = apt_get yum pkg nimclient pkgsrc freebsd_ports


### PR DESCRIPTION
@BasementTrix we forgot to add these to the Makefile so that they would
be shipped with the package.