### PR TITLE
Fix python3 incompatibility.

### DIFF
--- a/modules/packages/apt_get
+++ b/modules/packages/apt_get
@@ -27,7 +27,8 @@ apt_get_cmd = os.environ.get('CFENGINE_TEST_APT_GET_CMD', "/usr/bin/apt-get")
 
 # Some options only work with specific versions of apt, so we must know the
 # current version in order to do the right thing.
-apt_version = subprocess.Popen([ apt_get_cmd , '-v'], stdout=subprocess.PIPE).communicate()[0]
+apt_version = subprocess.Popen([ apt_get_cmd , '-v'],
+    stdout=subprocess.PIPE, universal_newlines=True).communicate()[0]
 apt_version = apt_version.splitlines()[0].split(' ')[1]
 
 apt_get_options = ["-o", "Dpkg::Options::=--force-confold",


### PR DESCRIPTION
Popen() returns a "bytes" object in python3 which fails to
split(). Passing the universal_newlines parameter makes it return a
string.