### PR TITLE
ENT-3061: Add default report collection exclusion based on promise handle

### DIFF
--- a/controls/reports.cf
+++ b/controls/reports.cf
@@ -80,6 +80,7 @@ body report_data_select default_data_select_host
 {
       metatags_include => { "inventory", "report" };
       metatags_exclude => { "noreport" };
+      promise_handle_exclude => { "noreport_.*" };
       monitoring_include => { "" };
 }
 
@@ -92,5 +93,6 @@ body report_data_select default_data_select_policy_hub
 {
       metatags_include => { "inventory", "report" };
       metatags_exclude => { "noreport" };
+      promise_handle_exclude => { "noreport_.*" };
       monitoring_include => { "" };
 }


### PR DESCRIPTION
Changelog: Title

This change adds a default exclusion for any promise with handle
matching noreport_.*. Any promise with a matching handle will not have
its promise outcomes collected by enterprise reporting. This aligns with
the pre-existing exclusions for variables and classes using a noreport
meta tag.

(cherry picked from commit 6d8f210acbf7ccc38ead5565253476dc47a0c904)