### PR TITLE
ENT-3047: Do not symlink agents to /usr/local/bin on coreos

### DIFF
--- a/cfe_internal/update/update_bins.cf
+++ b/cfe_internal/update/update_bins.cf
@@ -55,8 +55,11 @@ bundle agent cfe_internal_bins
       depth_search => u_recurse_basedir("inf"),
       action => u_immediate;
 
-      "/usr/local/sbin/$(agents)"
-      comment => "Create symlinks of CFE binaries in /usr/local/sbin",
+    !coreos::
+      "/usr/local/sbin/$(agents)" -> { "ENT-3046" }
+
+      comment => "Create symlinks of CFE binaries in /usr/local/sbin. But not on
+                  coreos hosts since the fs is read only.",
       handle => canonify("cfe_internal_bins_files_sbin_$(agents)"),
       move_obstructions => "true",
       link_from => u_ln_s("$(sys.workdir)/bin/$(agents)");


### PR DESCRIPTION
Changelog: Title

CoreOS has a read only filesystem there.