### PR TITLE
CFE-2587: Make stock policy update more resiliant

### DIFF
--- a/cfe_internal/update/update_policy.cf
+++ b/cfe_internal/update/update_policy.cf
@@ -184,7 +184,16 @@ bundle agent cfe_internal_update_policy
       copy_from => u_rcp("$(master_location)", @(update_def.policy_servers)),
       depth_search => u_recurse("inf"),
       file_select  => u_input_files,
-      action => u_immediate;
+      action => u_immediate,
+      classes => u_results("bundle", "update_inputs");
+
+    update_inputs_not_kept::
+
+      "$(inputs_dir)/cf_promises_validated" -> { "CFE-2587" }
+        delete => u_tidy,
+        comment => "If there is any problem copying to $(inputs_dir) then purge
+                    the cf_promises_validated file must be purged so that
+                    subsequent agent runs will perform a full scan.";
 
     !policy_server.enable_cfengine_enterprise_hub_ha::
       "$(sys.workdir)/policy_server.dat"
@@ -379,6 +388,104 @@ body classes u_if_else(yes,no)
 
 #########################################################
 
+body classes u_results(scope, class_prefix)
+# @brief Define classes prefixed with `class_prefix` and suffixed with
+# appropriate outcomes: _kept, _repaired, _not_kept, _error, _failed,
+# _denied, _timeout, _reached
+#
+# @param scope The scope in which the class should be defined (`bundle` or `namespace`)
+# @param class_prefix The prefix for the classes defined
+#
+# This body can be applied to any promise and sets global
+# (`namespace`) or local (`bundle`) classes based on its outcome. For
+# instance, with `class_prefix` set to `abc`:
+#
+# * if the promise is to change a file's owner to `nick` and the file
+# was already owned by `nick`, the classes `abc_reached` and
+# `abc_kept` will be set.
+#
+# * if the promise is to change a file's owner to `nick` and the file
+# was owned by `adam` and the change succeeded, the classes
+# `abc_reached` and `abc_repaired` will be set.
+#
+# This body is a simpler, more consistent version of the body
+# `scoped_classes_generic`, which see. The key difference is that
+# fewer classes are defined, and only for outcomes that we can know.
+# For example this body does not define "OK/not OK" outcome classes,
+# since a promise can be both kept and failed at the same time.
+#
+# It's important to understand that promises may do multiple things,
+# so a promise is not simply "OK" or "not OK." The best way to
+# understand what will happen when your specific promises get this
+# body is to test it in all the possible combinations.
+#
+# **Suffix Notes:**
+#
+# * `_reached` indicates the promise was tried. Any outcome will result
+#   in a class with this suffix being defined.
+#
+# * `_kept` indicates some aspect of the promise was kept
+#
+# * `_repaired` indicates some aspect of the promise was repaired
+#
+# * `_not_kept` indicates some aspect of the promise was not kept.
+#   error, failed, denied and timeout outcomes will result in a class
+#   with this suffix being defined
+#
+# * `_error` indicates the promise repair encountered an error
+#
+# * `_failed` indicates the promise failed
+#
+# * `_denied` indicates the promise repair was denied
+#
+# * `_timeout` indicates the promise timed out
+#
+# **Example:**
+#
+# ```cf3
+# bundle agent example
+# {
+#   commands:
+#     "/bin/true"
+#       classes => results("bundle", "my_class_prefix");
+#
+#   reports:
+#     my_class_prefix_kept::
+#       "My promise was kept";
+#
+#     my_class_prefix_repaired::
+#       "My promise was repaired";
+# }
+# ```
+#
+# **See also:** `scope`, `scoped_classes_generic`, `classes_generic`
+{
+  scope => "$(scope)";
+
+  promise_kept => { "$(class_prefix)_reached",
+                    "$(class_prefix)_kept" };
+
+  promise_repaired => { "$(class_prefix)_reached",
+                        "$(class_prefix)_repaired" };
+
+  repair_failed => { "$(class_prefix)_reached",
+                     "$(class_prefix)_error",
+                     "$(class_prefix)_not_kept",
+                     "$(class_prefix)_failed" };
+
+  repair_denied => { "$(class_prefix)_reached",
+                     "$(class_prefix)_error",
+                     "$(class_prefix)_not_kept",
+                     "$(class_prefix)_denied" };
+
+  repair_timeout => { "$(class_prefix)_reached",
+                      "$(class_prefix)_error",
+                      "$(class_prefix)_not_kept",
+                      "$(class_prefix)_timeout" };
+}
+
+#########################################################
+
 body contain u_in_shell
 {
       useshell => "true";
@@ -443,3 +550,4 @@ body delete u_tidy
 }
 
 #########################################################
+


### PR DESCRIPTION
Changelog: Title

This change ensures that a promise failure while updating inputs does
not leave the remote agent with the impression that
cf_promises_validated is reflective of the current state.

(cherry picked from commit b6386d7bddfac43582f07051cbf1b75dac3a187e)