### PR TITLE
ENT-3040: Fix opportunistic monitoring of files

### DIFF
--- a/cfe_internal/enterprise/file_change.cf
+++ b/cfe_internal/enterprise/file_change.cf
@@ -42,7 +42,7 @@ bundle agent change_management
 
       "$(watch_files_report_change)" -> { "InfoSec" }
         changes => detect_content_using("sha256"),
-        ifvarclass => fileexists( $(watch_files_report_diffs) ),
+        ifvarclass => fileexists( $(watch_files_report_change) ),
         comment => "Unplanned changes of these files may indicate a security
                     breach. (Diffs are not reported in case those with access
                     to this report should not have access to shadow entries.)";


### PR DESCRIPTION
The restriction was causing these files (/etc/shadow) to never be
monitored since it was iterating over the wrong list of files.