### PR TITLE
CFE-528: changine cf-serverd's control to bind to interface :: for IPv6.

### DIFF
--- a/controls/cf_serverd.cf
+++ b/controls/cf_serverd.cf
@@ -32,6 +32,9 @@ body server control
       # Suggested value >= total number of hosts
       maxconnections        => "200";
 
+      # Bind to all interfaces including ipv6
+      bindtointerface => "::";
+      
       # Allow connections from nodes which are out-of-sync
       denybadclocks         => "false";
 


### PR DESCRIPTION
Related to bug CFE-528