### PR TITLE
CFE-2602: Disable package inventory via modules on redhat like systems with unsupported python versions

### DIFF
--- a/inventory/redhat.cf
+++ b/inventory/redhat.cf
@@ -11,4 +11,12 @@ bundle common inventory_redhat
       "redhat_derived" expression => "redhat.!redhat_pure",
       comment => "derived from Red Hat",
       meta => { "inventory", "attribute_name=none" };
+
+      "cfe_yum_package_module_supported" -> { "CFE-2602" }
+        comment => "Here we see if the version of python found is acceptable for
+                    the yum package module. We use this guard to prevent errors
+                    related to missing python modules.",
+        expression => returnszero("python -V 2>&1 | grep ^Python | cut -d' ' -f 2 | ( IFS=. read v1 v2 v3 ; [ $v1 -ge 3 ] || [ $v1 -eq 2 -a $v2 -ge 4 ] )",
+                                  useshell);
+
 }

--- a/promises.cf.in
+++ b/promises.cf.in
@@ -62,10 +62,15 @@ body common control
       # modules in which you MUST provide package modules used to generate
       # software inventory reports. You can also provide global default package module
       # instead of specifying it in all package promises.
-      (debian|redhat).!disable_inventory_package_refresh::
+    debian.!disable_inventory_package_refresh::
           package_inventory => { $(package_module_knowledge.platform_default) };
 
-      (debian|redhat)::
+      # We only define pacakge_invetory on redhat like systems that have a
+      # python version that works with the package module.
+    (redhat|centos).cfe_yum_package_module_supported.!disable_inventory_package_refresh::
+        package_inventory => { $(package_module_knowledge.platform_default) };
+
+    (debian|redhat)::
           package_module => $(package_module_knowledge.platform_default);
 
 }


### PR DESCRIPTION
Changelog: Title
(cherry picked from commit 8e222ac947674344fe37417821d41857d3e59908)