### PR TITLE
Switch to POSIX compliant shell tool paths on Solaris 9 and 10.

### DIFF
--- a/controls/def.cf
+++ b/controls/def.cf
@@ -386,6 +386,9 @@ bundle common def
                     the disk may fill up or cause additional collection
                     issues.";
 
+      # Enable paths to POSIX tools instead of native tools when possible.
+      "mpf_stdlib_use_posix_utils" expression => "any";
+
   reports:
     DEBUG|DEBUG_def::
       "DEBUG: $(this.bundle)";

--- a/lib/paths.cf
+++ b/lib/paths.cf
@@ -239,7 +239,6 @@ bundle common paths
 
     solaris::
 
-      "path[awk]"      string => "/usr/bin/awk";
       "path[bc]"       string => "/usr/bin/bc";
       "path[cat]"      string => "/usr/bin/cat";
       "path[cksum]"    string => "/usr/bin/cksum";
@@ -248,21 +247,13 @@ bundle common paths
       "path[curl]"     string => "/usr/bin/curl";
       "path[cut]"      string => "/usr/bin/cut";
       "path[dc]"       string => "/usr/bin/dc";
-      "path[df]"       string => "/usr/bin/df";
       "path[diff]"     string => "/usr/bin/diff";
       "path[dig]"      string => "/usr/sbin/dig";
       "path[echo]"     string => "/usr/bin/echo";
-      "path[egrep]"    string => "/usr/bin/egrep";
-      "path[find]"     string => "/usr/bin/find";
-      "path[grep]"     string => "/usr/bin/grep";
-      "path[ls]"       string => "/usr/bin/ls";
       "path[netstat]"  string => "/usr/bin/netstat";
       "path[ping]"     string => "/usr/bin/ping";
       "path[perl]"     string => "/usr/bin/perl";
       "path[printf]"   string => "/usr/bin/printf";
-      "path[sed]"      string => "/usr/bin/sed";
-      "path[sort]"     string => "/usr/bin/sort";
-      "path[tr]"       string => "/usr/bin/tr";
       "path[wget]"     string => "/usr/bin/wget";
       #
       "path[svcs]"     string => "/usr/bin/svcs";
@@ -278,6 +269,28 @@ bundle common paths
       "path[pkgrm]"    string => "/usr/sbin/pkgrm";
       "path[zoneadm]"  string => "/usr/sbin/zoneadm";
       "path[zonecfg]"  string => "/usr/sbin/zonecfg";
+
+    solaris.(mpf_stdlib_use_posix_utils.!disable_mpf_stdlib_use_posix_utils)::
+      "path[awk]"      string => "/usr/xpg4/bin/awk";
+      "path[df]"       string => "/usr/xpg4/bin/df";
+      "path[egrep]"    string => "/usr/xpg4/bin/egrep";
+      "path[find]"     string => "/usr/xpg4/bin/find";
+      "path[grep]"     string => "/usr/xpg4/bin/grep";
+      "path[ls]"       string => "/usr/xpg4/bin/ls";
+      "path[sed]"      string => "/usr/xpg4/bin/sed";
+      "path[sort]"     string => "/usr/xpg4/bin/sort";
+      "path[tr]"       string => "/usr/xpg4/bin/tr";
+
+    solaris.!(mpf_stdlib_use_posix_utils.!disable_mpf_stdlib_use_posix_utils)::
+      "path[awk]"      string => "/usr/bin/awk";
+      "path[df]"       string => "/usr/bin/df";
+      "path[egrep]"    string => "/usr/bin/egrep";
+      "path[find]"     string => "/usr/bin/find";
+      "path[grep]"     string => "/usr/bin/grep";
+      "path[ls]"       string => "/usr/bin/ls";
+      "path[sed]"      string => "/usr/bin/sed";
+      "path[sort]"     string => "/usr/bin/sort";
+      "path[tr]"       string => "/usr/bin/tr";
 
     redhat::
 


### PR DESCRIPTION
CFE-2616

Changelog: Title
Signed-off-by: Kristian Amlie <kristian.amlie@cfengine.com>