### PR TITLE
CFE-2624: Configure networks allowed to initiate report collection (client initiated reporting) via augments

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -405,6 +405,23 @@ For example:
   }
 }
 ```
+### Configure networks allowed to make collect_calls (client initiated reporting)
+
+By default the hub allows collect calls (client initiated reporting) from the
+networks defined in `def.acl` To configure which networks are allowed to
+initiate report collection define
+`def.mpf_access_rules_collect_calls_admit_ips`.
+
+For example to allow client initiated reporting for hosts coming from
+`24.124.0.0/16`:
+
+```
+{
+  "vars": {
+    "mpf_access_rules_collect_calls_admit_ips": "24.124.0.0/16",
+  }
+}
+```
 
 ### Configure Enterprise Measurement/Monitoring Collection
 

--- a/MPF.md
+++ b/MPF.md
@@ -405,6 +405,7 @@ For example:
   }
 }
 ```
+
 ### Configure networks allowed to make collect_calls (client initiated reporting)
 
 By default the hub allows collect calls (client initiated reporting) from the

--- a/controls/cf_serverd.cf
+++ b/controls/cf_serverd.cf
@@ -99,6 +99,11 @@ bundle server access_rules()
       comment => "Grant access to templates directory",
       admit => { @(def.acl) };
 
+      enterprise_edition.policy_server::
+        "collect_calls"
+          resource_type => "query",
+          admit_ips => { @(def.mpf_access_rules_collect_calls_admit_ips) };
+
     !windows::
       "$(def.cf_runagent_shell)"
       handle => "server_access_grant_access_shell_cmd",

--- a/controls/def.cf
+++ b/controls/def.cf
@@ -300,6 +300,10 @@ bundle common def
         slist => {},
         unless => isvariable(control_hub_exclude_hosts);
 
+      "mpf_access_rules_collect_calls_admit_ips"
+        slist => { @(def.acl) },
+        unless => isvariable(mpf_access_rules_collect_calls_admit_ips);
+
     enterprise_edition.enable_client_initiated_reporting::
       "control_server_call_collect_interval"
         string => "5",


### PR DESCRIPTION
Changelog: Title