### PR TITLE
ENT-3161: Include previous_state and untracked reports when client clear a buildup of unreported data

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -364,6 +364,23 @@ Enterprise agent is detected.
 
 ## Main Policy (promises.cf)
 
+### Adjust the maximum amount of client side report data to retain (CFEngine Enterprise)
+
+Enterprise agents cache detailed information about each agent run locally. The
+data is purged when the data is reported to a hub. If the volume of data exceeds
+`def.max_client_history_size` then the client will purge the local data in order
+to keep report collection from timing out.
+
+The default 50M threshold can be configured using an augments file, for example:
+
+```
+{
+  "vars": {
+    "max_client_history_size": "5M"
+  }
+}
+```
+
 ### Exclude hosts from hub initiated report collection
 
 You may want to exclude some hosts like community agents, hosts behind NAT, and

--- a/controls/def.cf
+++ b/controls/def.cf
@@ -257,6 +257,7 @@ bundle common def
 
       "max_client_history_size" -> { "cf-hub", "CFEngine Enterprise" }
         int => "50M",
+        unless => isvariable(max_client_history_size),
         comment => "The threshold of report diffs which will trigger purging of
                     diff files.";
 

--- a/lib/cfe_internal.cf
+++ b/lib/cfe_internal.cf
@@ -74,7 +74,19 @@ bundle agent cfe_internal_cleanup_agent_reports
         slist => findfiles("$(sys.workdir)/state/promise_log/*.csv"),
         unless => isvariable( $(this.promiser) );
 
-      "files" slist => { @(diff_files), @(promise_log_files) };
+      "previous_state_files"
+        slist => findfiles("$(sys.workdir)/state/previous_state/*.cache"),
+        unless => isvariable( $(this.promiser) );
+
+      "untracked_files"
+        slist => findfiles("$(sys.workdir)/state/untracked/*.idx"),
+        unless => isvariable( $(this.promiser) );
+
+      "files"
+        slist => { @(diff_files),
+                   @(promise_log_files),
+                   @(previous_state_files),
+                   @(untracked_files) };
 
       "reports_size[$(files)]"
         int => filesize("$(files)"),


### PR DESCRIPTION
Changelog: Title