### PR TITLE
ENT-3184: Use sparse in tar backup during CFE upgrades as lmdb uses spare files

### DIFF
--- a/cfe_internal/update/update_bins.cf
+++ b/cfe_internal/update/update_bins.cf
@@ -408,7 +408,7 @@ bundle edit_line u_backup_script
       "#!/bin/sh
 
 if [ $(const.dollar)1 = \"BACKUP\" ]; then
- tar cfz $(const.dollar)2 $(sys.workdir) > /dev/null
+ tar cfzS $(const.dollar)2 $(sys.workdir) > /dev/null
 fi
 if [ $(const.dollar)1 = \"RESTORE\" ]; then
  tar xfz $(const.dollar)2


### PR DESCRIPTION
Proven to improve performance, at least in one case (large lmdb files).
https://cfengine.zendesk.com/agent/tickets/3409