### PR TITLE
Add /var/log/postgresql.log to list of enterprise_log_files

### DIFF
--- a/controls/def.cf
+++ b/controls/def.cf
@@ -247,6 +247,7 @@ bundle common def
         "$(sys.workdir)/outputs/dc-scripts.log",
         "$(sys.workdir)/state/promise_log.jsonl",
         "$(sys.workdir)/state/classes.jsonl",
+        "/var/log/postgresql.log",
       };
 
       "hub_log_files" slist =>


### PR DESCRIPTION
As reported in https://cfengine.zendesk.com/hc/en-us/requests/3436,
CFEngine does not rotate the Postgres log file which will eventually
cause the disk to go 100% full and then stuff breaks (e.g., can't
download CSV reports anymore).

Nick Anderson suggested adding postgresql.log to enterprise_log_files,
which this commit does.  I've already implemented this change and tested it
on one of our hubs as documented in support ticket 3436.