### PR TITLE
ENT-3191: Ensure postgresql.log is rotated

### DIFF
--- a/controls/3.7/def.cf
+++ b/controls/3.7/def.cf
@@ -197,6 +197,7 @@ bundle common def
         "$(sys.workdir)/cf_repair.log",
         "$(sys.workdir)/state/cf_value.log",
         "$(sys.workdir)/outputs/dc-scripts.log",
+        "/var/log/postgresql.log",
       };
 
       "hub_log_files" slist =>


### PR DESCRIPTION
Changelog: Title