### PR TITLE
Do not use bindtointerface on windows (CFE-2662)

### DIFF
--- a/controls/cf_serverd.cf
+++ b/controls/cf_serverd.cf
@@ -32,9 +32,6 @@ body server control
       # Suggested value >= total number of hosts
       maxconnections        => "$(def.control_server_maxconnections)";
 
-      # Bind to all interfaces including ipv6
-      bindtointerface => "::";
-
       # Allow connections from nodes which are out-of-sync
       denybadclocks         => "false";
 
@@ -54,6 +51,10 @@ body server control
       cfruncommand => "$(def.cf_runagent_shell) -c \'
                            $(sys.cf_agent) -I -D cfruncommand -f $(sys.update_policy_path)  ;
                            $(sys.cf_agent) -I -D cfruncommand";
+
+      # Bind to all interfaces including ipv6
+      # Adding this on windows will force ipv6 only
+      bindtointerface => "::";
 
 }
 


### PR DESCRIPTION
Note that this does not fix the issue, it's just a workaround on windows.