### PR TITLE
Fix permissions of directories in the ready-to-install tarball.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -23,6 +23,7 @@ dist-hook:
 tar-package:
 	pkgdir=`mktemp -d`  &&  export pkgdir  &&  \
 	origdir=`pwd`       &&  export origdir &&  \
+	umask 0022          &&  chmod 755 $$pkgdir && \
 	$(MAKE) prefix=$$pkgdir install  &&  \
 	(   cd $$pkgdir  &&  \
             find . -name '*.cf*' | xargs -n1 chmod go-w  &&  \


### PR DESCRIPTION
By default "make install" uses the user's umask for directories, so run
"umask 022" in the beginning of the "tar-package" make target.

Additionally in the same "tar-package" target, `mktemp -d` is setting
the root folder's permissions to 700, so change it manually to 755.

Fixes ENT-3295, ENT-3299.