### PR TITLE
CFE-2690: Be less noisy when a promised service is not found

### DIFF
--- a/lib/services.cf
+++ b/lib/services.cf
@@ -371,7 +371,7 @@ bundle agent standard_services(service,state)
     verbose_mode.fallback::
       "$(this.bundle): falling back to classic_services to $(state) $(service)";
 
-    systemd.service_notfound::
+    systemd.service_notfound.(inform_mode|verbose_mode)::
         "$(this.bundle): Could not find service: $(service)";
 }
 


### PR DESCRIPTION
The failed promise messages are likely to make it clear enough what is going on
without this extra report. It is nice to have in inform_mode and verbose_mode.