### PR TITLE
ENT-3368: Fix self upgrade for hosts older than 3.7.4

### DIFF
--- a/standalone_self_upgrade.cf.in
+++ b/standalone_self_upgrade.cf.in
@@ -78,7 +78,19 @@ bundle common cfengine_software
 #@ brief Variables to control the specifics in desired package selection
 {
   vars:
+
       # Default desired CFEngine software
+
+      "pkg_name" string => "cfengine-nova";
+      "pkg_version" string => "@VERSION@";
+      "pkg_release" string => "1";
+      "pkg_arch" string => "x86_64";
+      "package_dir" string => "$(sys.flavour)_$(sys.arch)";
+
+!(cfengine_3_7_1|cfengine_3.7.2|cfengine_3.7.3)::
+# After 3.7.4 a fix to ifelse and isvarinbel allows for actuating the function
+# even thought the promise references an unresolved variable.
+
       "pkg_name" string => ifelse( isvariable( "def.cfengine_software_pkg_name" ), $(def.cfengine_software_pkg_name), "cfengine-nova");
       "pkg_version" string => ifelse( isvariable( "def.cfengine_software_pkg_version" ), $(def.cfengine_software_pkg_version), "@VERSION@");
       "pkg_release" string => ifelse( isvariable( "def.cfengine_software_pkg_release" ), $(def.cfengine_software_pkg_release), "1");
@@ -216,16 +228,21 @@ bundle agent cfengine_software_version_packages2
   packages:
 
     (redhat|centos).!__supported::
-      "$(local_software_dir)/$(pkg_name)-$(pkg_version)-$(pkg_release).$(pkg_arch).rpm"
+      "$(local_software_dir)/$(cfengine_package_names.my_pkg)"
       policy => "present",
       package_module => yum,
       comment => "Ensure the latest package is installed";
 
     (debian|ubuntu).!__supported::
-      "$(local_software_dir)/$(pkg_name)_$(pkg_version)-$(pkg_release)_$(pkg_arch).deb"
+      "$(local_software_dir)/$(cfengine_package_names.my_pkg)"
       policy => "present",
       package_module => apt_get,
       comment => "Ensure the latest package is installed";
+
+  reports:
+
+    "DEBUG|DEBUG_$(this.bundle)"::
+      "Running $(this.bundle)";
 }
 
 bundle agent cfengine_software_version_packages1
@@ -349,6 +366,50 @@ bundle agent cfengine_software_version_packages1
         package_method => u_generic( $(cfengine_software.local_software_dir) ),
         classes => u_if_else("bin_update_success", "bin_update_fail");
 
+  reports:
+
+    "DEBUG|DEBUG_$(this.bundle)"::
+      "Running $(this.bundle)";
+}
+
+bundle common cfengine_package_names
+{
+  vars:
+      "pkg_name" string => "$(cfengine_software.pkg_name)";
+      "pkg_version" string => "$(cfengine_software.pkg_version)";
+      "pkg_release" string => "$(cfengine_software.pkg_release)";
+      "pkg_arch" string => "$(cfengine_software.pkg_arch)";
+
+      # Redhat/Centos 4, 5 use the same package
+
+      "pkg[redhat_5_x86_64]" string => "$(pkg_name)-$(pkg_version)-$(pkg_release).el4.x86_64.rpm";
+      "pkg[centos_5_x86_64]" string => "$(pkg[redhat_5_x86_64])";
+      "pkg[SuSE_11_x86_64]" string => "$(pkg[redhat_5_x86_64])";
+      "pkg[SuSE_10_x86_64]" string => "$(pkg[redhat_5_x86_64])";
+
+      # Redhat/Centos 6, 7 use the same package
+
+      "pkg[redhat_6_x86_64]" string => "$(pkg_name)-$(pkg_version)-$(pkg_release).el6.x86_64.rpm";
+      "pkg[centos_6_x86_64]" string => "$(pkg[redhat_6_x86_64])";
+      "pkg[redhat_7_x86_64]" string => "$(pkg[redhat_6_x86_64])";
+      "pkg[centos_7_x86_64]" string => "$(pkg[redhat_6_x86_64])";
+
+      # Debian 7, 8 and Ubuntu 14, 16 use the same package
+
+      "pkg[debian_7_x86_64]" string => "$(pkg_name)_$(pkg_version)-$(pkg_release)_amd64-debian7.deb";
+      "pkg[debian_8_x86_64]" string => "$(pkg[debian_7_x86_64])";
+      "pkg[ubuntu_14_x86_64]" string => "$(pkg[debian_7_x86_64])";
+      "pkg[ubuntu_16_x86_64]" string => "$(pkg[debian_7_x86_64])";
+
+      "my_pkg"
+        string => "$(pkg[$(sys.flavor)_$(sys.arch)])",
+        comment => "The package name for the currently executing platform.";
+
+  reports:
+
+    "DEBUG|DEBUG_$(this.bundle)"::
+
+      "My Package: $(my_pkg)";
 }
 
 bundle agent cfengine_master_software_content
@@ -372,11 +433,6 @@ bundle agent cfengine_master_software_content
       "dir[SuSE_11_x86_64]" string => "$(dir[redhat_5_x86_64])";
       "dir[SuSE_10_x86_64]" string => "$(dir[redhat_5_x86_64])";
 
-      "pkg[redhat_5_x86_64]" string => "$(pkg_name)-$(pkg_version)-$(pkg_release).x86_64.rpm";
-      "pkg[centos_5_x86_64]" string => "$(pkg[redhat_5_x86_64])";
-      "pkg[SuSE_11_x86_64]" string => "$(pkg[redhat_5_x86_64])";
-      "pkg[SuSE_10_x86_64]" string => "$(pkg[redhat_5_x86_64])";
-
       # Redhat/Centos 6, 7 use the same package
 
       "dir[redhat_6_x86_64]" string => "agent_rhel6_x86_64";
@@ -384,22 +440,11 @@ bundle agent cfengine_master_software_content
       "dir[redhat_7_x86_64]" string => "$(dir[redhat_6_x86_64])";
       "dir[centos_7_x86_64]" string => "$(dir[redhat_6_x86_64])";
 
-      "pkg[redhat_6_x86_64]" string => "$(pkg_name)-$(pkg_version)-$(pkg_release).x86_64.rpm";
-      "pkg[centos_6_x86_64]" string => "$(pkg[redhat_6_x86_64])";
-      "pkg[redhat_7_x86_64]" string => "$(pkg[redhat_6_x86_64])";
-      "pkg[centos_7_x86_64]" string => "$(pkg[redhat_6_x86_64])";
-
-
       # Debian 7, 8 and Ubuntu 14, 16 use the same package
       "dir[debian_7_x86_64]" string => "agent_debian7_x86_64";
       "dir[debian_8_x86_64]" string => "$(dir[debian_7_x86_64])";
       "dir[ubuntu_14_x86_64]" string => "$(dir[debian_7_x86_64])";
       "dir[ubuntu_16_x86_64]" string => "$(dir[debian_7_x86_64])";
-
-      "pkg[debian_7_x86_64]" string => "$(pkg_name)_$(pkg_version)-$(pkg_release)_amd64.deb";
-      "pkg[debian_8_x86_64]" string => "$(pkg[debian_7_x86_64])";
-      "pkg[ubuntu_14_x86_64]" string => "$(pkg[debian_7_x86_64])";
-      "pkg[ubuntu_16_x86_64]" string => "$(pkg[debian_7_x86_64])";
 
       "platform_dir" slist => getindices( dir );
 
@@ -411,12 +456,12 @@ bundle agent cfengine_master_software_content
   commands:
       # Fetch each package that we don't already have
        "/usr/bin/curl"
-        args => "-s $(base_url)/$(dir[$(platform_dir)])/$(pkg[$(platform_dir)]) --output /var/cfengine/master_software_updates/$(platform_dir)/$(pkg[$(platform_dir)])",
-        if => not( fileexists( "/var/cfengine/master_software_updates/$(platform_dir)/$(pkg[$(platform_dir)])" ) );
+        args => "-s $(base_url)/$(dir[$(platform_dir)])/$(cfengine_package_names.pkg[$(platform_dir)]) --output /var/cfengine/master_software_updates/$(platform_dir)/$(cfengine_package_names.pkg[$(platform_dir)])",
+        if => not( fileexists( "/var/cfengine/master_software_updates/$(platform_dir)/$(cfengine_package_names.pkg[$(platform_dir)])" ) );
 
   reports:
     DEBUG|DEBUG_cfengine_master_software_content::
-      "curl -s $(base_url)/$(dir[$(i)])/$(pkg[$(i)]) --output /var/cfengine/master_software_updates/$(i)/$(pkg[$(i)])";
+      "curl -s $(base_url)/$(dir[$(i)])/$(cfengine_package_names.pkg[$(i)]) --output /var/cfengine/master_software_updates/$(i)/$(cfengine_pacakge_names.pkg[$(i)])";
 }
 
 bundle edit_line u_backup_script


### PR DESCRIPTION
This patch avoids the use of the ifelse function on hosts running
versions older than 3.7.4 so that the correct variables are defined.
Additionally this patch updates the url patterns for enterprise packages
so that enterprise hubs can automatically download the packages and
clients reference the newer naming convention.

Changelog: Title