### PR TITLE
add server control allowlegacyconnects to def.json

### DIFF
--- a/controls/cf_serverd.cf
+++ b/controls/cf_serverd.cf
@@ -26,7 +26,7 @@ body server control
 
       ## List of the hosts not using the latest protocol that we'll accept connections from
       ## (absence of this option or empty list means allow none)
-      # allowlegacyconnects   => { };
+      allowlegacyconnects   => { @(def.control_server_allowlegacyconnects) };
 
       # Maximum number of concurrent connections.
       # Suggested value >= total number of hosts

--- a/controls/def.cf
+++ b/controls/def.cf
@@ -126,6 +126,13 @@ bundle common def
                           not(isvariable("trustkeysfrom"))),
         meta => { "defvar" };
 
+      ## List of the hosts not using the latest protocol that we'll accept connections from
+      ## (absence of this option or empty list means allow none)
+      "control_server_allowlegacyconnects"
+        slist => {},
+        ifvarclass => not( isvariable( "control_server_allowlegacyconnects" ) );
+
+
       # Agent Controls
 
       "control_agent_default_repository"


### PR DESCRIPTION
Not too experience with this, so would appreciate your review @nickanderson 
We should backport to 3.10 if ok.

Ref https://cfengine.zendesk.com/agent/tickets/3589