### PR TITLE
ENT-3375: Allow configuration of allowlegacyconnects from augments

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -475,7 +475,7 @@ For example to allow client initiated reporting for hosts coming from
 ```
 {
   "vars": {
-    "mpf_access_rules_collect_calls_admit_ips": "24.124.0.0/16",
+    "mpf_access_rules_collect_calls_admit_ips": [ "24.124.0.0/16" ]
   }
 }
 ```

--- a/MPF.md
+++ b/MPF.md
@@ -364,6 +364,20 @@ Enterprise agent is detected.
 
 ## Main Policy (promises.cf)
 
+### Allow connections from the classic/legacy protocol
+
+By default since 3.9.0 `cf-serverd` disallows connections from the classic protocol by default. To allow clients using the legacy protocol (versions prior to 3.7.0 by default) define ```control_server_allowlegacyconnects``` as a list of networks.
+
+Example definition in augments file:
+
+```
+{
+  "vars": {
+    "control_server_allowlegacyconnects": [ "0.0.0.0/0" ]
+  }
+}
+```
+
 ### Adjust the maximum amount of client side report data to retain (CFEngine Enterprise)
 
 Enterprise agents cache detailed information about each agent run locally. The

--- a/controls/cf_serverd.cf
+++ b/controls/cf_serverd.cf
@@ -26,7 +26,7 @@ body server control
 
       ## List of the hosts not using the latest protocol that we'll accept connections from
       ## (absence of this option or empty list means allow none)
-      # allowlegacyconnects   => { };
+      allowlegacyconnects   => { @(def.control_server_allowlegacyconnects) };
 
       # Maximum number of concurrent connections.
       # Suggested value >= total number of hosts

--- a/controls/def.cf
+++ b/controls/def.cf
@@ -126,6 +126,13 @@ bundle common def
                           not(isvariable("trustkeysfrom"))),
         meta => { "defvar" };
 
+      ## List of the hosts not using the latest protocol that we'll accept connections from
+      ## (absence of this option or empty list means allow none)
+      "control_server_allowlegacyconnects"
+        slist => {},
+        ifvarclass => not( isvariable( "control_server_allowlegacyconnects" ) );
+
+
       # Agent Controls
 
       "control_agent_default_repository"


### PR DESCRIPTION
Supersedes https://github.com/cfengine/masterfiles/pull/960