### PR TITLE
ENT-3368 and ENT-3377: Fixs to standalone self upgrade

### DIFF
--- a/standalone_self_upgrade.cf.in
+++ b/standalone_self_upgrade.cf.in
@@ -98,7 +98,7 @@ bundle common cfengine_software
       "package_dir" string => "$(sys.flavour)_$(sys.arch)";
 
 !(cfengine_3_7_1|cfengine_3.7.2|cfengine_3.7.3)::
-# After 3.7.4 a fix to ifelse and isvarinbel allows for actuating the function
+# After 3.7.4 a fix to ifelse and isvarible allows for actuating the function
 # even thought the promise references an unresolved variable.
 
       "pkg_name" string => ifelse( isvariable( "def.cfengine_software_pkg_name" ), $(def.cfengine_software_pkg_name), "cfengine-nova");

--- a/standalone_self_upgrade.cf.in
+++ b/standalone_self_upgrade.cf.in
@@ -394,6 +394,7 @@ bundle common cfengine_package_names
 
       "pkg[redhat_5_x86_64]" string => "$(pkg_name)-$(pkg_version)-$(pkg_release).el4.x86_64.rpm";
       "pkg[centos_5_x86_64]" string => "$(pkg[redhat_5_x86_64])";
+      "pkg[oracle_5_x86_64]" string => "$(pkg[redhat_5_x86_64])";
       "pkg[SuSE_11_x86_64]" string => "$(pkg[redhat_5_x86_64])";
       "pkg[SuSE_10_x86_64]" string => "$(pkg[redhat_5_x86_64])";
 
@@ -418,8 +419,10 @@ bundle common cfengine_package_names
 
       "pkg[redhat_6_x86_64]" string => "$(pkg_name)-$(pkg_version)-$(pkg_release).el6.x86_64.rpm";
       "pkg[centos_6_x86_64]" string => "$(pkg[redhat_6_x86_64])";
+      "pkg[oracle_6_x86_64]" string => "$(pkg[redhat_6_x86_64])";
       "pkg[redhat_7_x86_64]" string => "$(pkg[redhat_6_x86_64])";
       "pkg[centos_7_x86_64]" string => "$(pkg[redhat_6_x86_64])";
+      "pkg[oracle_7_x86_64]" string => "$(pkg[redhat_6_x86_64])";
 
       # Debian 7, 8 and Ubuntu 14, 16 use the same package
 
@@ -486,6 +489,7 @@ bundle agent cfengine_master_software_content
       # Redhat/Centos 4, 5 and SuSE 10, 11 all use the same package
       "dir[redhat_5_x86_64]" string => "agent_rpm_x86_64";
       "dir[centos_5_x86_64]" string => "$(dir[redhat_5_x86_64])";
+      "dir[oracle_5_x86_64]" string => "$(dir[redhat_5_x86_64])";
       "dir[SuSE_11_x86_64]" string => "$(dir[redhat_5_x86_64])";
       "dir[SuSE_10_x86_64]" string => "$(dir[redhat_5_x86_64])";
 
@@ -510,8 +514,10 @@ bundle agent cfengine_master_software_content
 
       "dir[redhat_6_x86_64]" string => "agent_rhel6_x86_64";
       "dir[centos_6_x86_64]" string => "$(dir[redhat_6_x86_64])";
+      "dir[oracle_6_x86_64]" string => "$(dir[redhat_6_x86_64])";
       "dir[redhat_7_x86_64]" string => "$(dir[redhat_6_x86_64])";
       "dir[centos_7_x86_64]" string => "$(dir[redhat_6_x86_64])";
+      "dir[oracle_7_x86_64]" string => "$(dir[redhat_6_x86_64])";
 
       # Debian 7, 8 and Ubuntu 14, 16 use the same package
       "dir[debian_7_x86_64]" string => "agent_debian7_x86_64";

--- a/standalone_self_upgrade.cf.in
+++ b/standalone_self_upgrade.cf.in
@@ -9,6 +9,16 @@ bundle agent main
 # software to remote clients, and managing the version of cfengine installed on
 # non hubs.
 {
+  classes:
+
+      "policy_server_dat_unstable"
+        expression => isnewerthan( "$(sys.workdir)/policy_server.dat", "$(sys.workdir)/outputs" ),
+        comment => "If $(sys.workdir)/policy_server.dat is newer than the
+                    outputs directory, it can indicate that the current agent
+                    execution is a result of bootstrap. For stability we want to
+                    skip upgrades during bootstrap. The outputs directory should
+                    be newer than the policy_server.dat on the next agent run
+                    and allow upgrade then.";
 
   reports:
       "Running $(this.promise_filename)";
@@ -22,7 +32,7 @@ bundle agent main
       "Master Software Repository Data"
         usebundle => cfengine_master_software_content;
 
-    !(am_policy_hub|policy_server)::
+    !(am_policy_hub|policy_server|policy_server_dat_unstable)::
 
       "Local Software Cache"
         usebundle => cfengine_software_cached_locally;

--- a/standalone_self_upgrade.cf.in
+++ b/standalone_self_upgrade.cf.in
@@ -387,6 +387,23 @@ bundle common cfengine_package_names
       "pkg[SuSE_11_x86_64]" string => "$(pkg[redhat_5_x86_64])";
       "pkg[SuSE_10_x86_64]" string => "$(pkg[redhat_5_x86_64])";
 
+      # 32bit RPMs
+      "pkg[redhat_5_i386]" string => "$(pkg_name)-$(pkg_version)-$(pkg_release).el4.i386.rpm";
+      "pkg[redhat_5_i586]" string => "$(pkg[redhat_5_i386])";
+      "pkg[redhat_5_i686]" string => "$(pkg[redhat_5_i386])";
+      "pkg[centos_5_i386]" string => "$(pkg[redhat_5_i386])";
+      "pkg[centos_5_i586]" string => "$(pkg[redhat_5_i386])";
+      "pkg[centos_5_i686]" string => "$(pkg[redhat_5_i386])";
+      "pkg[centos_6_i386]" string => "$(pkg[redhat_5_i386])";
+      "pkg[redhat_6_i386]" string => "$(pkg[redhat_5_i386])";
+      "pkg[redhat_6_i586]" string => "$(pkg[redhat_5_i386])";
+      "pkg[redhat_6_i686]" string => "$(pkg[redhat_5_i386])";
+      "pkg[centos_7_i386]" string => "$(pkg[redhat_5_i386])";
+      "pkg[centos_7_i586]" string => "$(pkg[redhat_5_i386])";
+      "pkg[centos_7_i686]" string => "$(pkg[redhat_5_i386])";
+      "pkg[SuSE_11_i386]" string => "$(pkg[redhat_5_i386])";
+      "pkg[SuSE_10_i386]" string => "$(pkg[redhat_5_i386])";
+
       # Redhat/Centos 6, 7 use the same package
 
       "pkg[redhat_6_x86_64]" string => "$(pkg_name)-$(pkg_version)-$(pkg_release).el6.x86_64.rpm";
@@ -400,6 +417,35 @@ bundle common cfengine_package_names
       "pkg[debian_8_x86_64]" string => "$(pkg[debian_7_x86_64])";
       "pkg[ubuntu_14_x86_64]" string => "$(pkg[debian_7_x86_64])";
       "pkg[ubuntu_16_x86_64]" string => "$(pkg[debian_7_x86_64])";
+
+      # 32bit DEBs
+      "pkg[debian_4_i386]" string => "$(pkg_name)_$(pkg_version)-$(pkg_release)_i386-debian4.deb";
+      "pkg[debian_4_i586]" string => "$(pkg[debian_4_i386])";
+      "pkg[debian_4_i686]" string => "$(pkg[debian_4_i386])";
+      "pkg[debian_5_i386]" string => "$(pkg[debian_4_i386])";
+      "pkg[debian_5_i586]" string => "$(pkg[debian_4_i386])";
+      "pkg[debian_5_i686]" string => "$(pkg[debian_4_i386])";
+      "pkg[debian_6_i386]" string => "$(pkg[debian_4_i386])";
+      "pkg[debian_6_i586]" string => "$(pkg[debian_4_i386])";
+      "pkg[debian_6_i686]" string => "$(pkg[debian_4_i386])";
+      "pkg[debian_7_i386]" string => "$(pkg[debian_4_i386])";
+      "pkg[debian_7_i586]" string => "$(pkg[debian_4_i386])";
+      "pkg[debian_7_i686]" string => "$(pkg[debian_4_i386])";
+      "pkg[debian_8_i386]" string => "$(pkg[debian_4_i386])";
+      "pkg[debian_8_i586]" string => "$(pkg[debian_4_i386])";
+      "pkg[debian_8_i686]" string => "$(pkg[debian_4_i386])";
+      "pkg[debian_9_i386]" string => "$(pkg[debian_4_i386])";
+      "pkg[debian_9_i586]" string => "$(pkg[debian_4_i386])";
+      "pkg[debian_9_i686]" string => "$(pkg[debian_4_i386])";
+      "pkg[ubuntu_12_i386]" string => "$(pkg[debian_4_i386])";
+      "pkg[ubuntu_12_i586]" string => "$(pkg[debian_4_i386])";
+      "pkg[ubuntu_12_i686]" string => "$(pkg[debian_4_i386])";
+      "pkg[ubuntu_14_i386]" string => "$(pkg[debian_4_i386])";
+      "pkg[ubuntu_14_i586]" string => "$(pkg[debian_4_i386])";
+      "pkg[ubuntu_14_i686]" string => "$(pkg[debian_4_i386])";
+      "pkg[ubuntu_16_i386]" string => "$(pkg[debian_4_i386])";
+      "pkg[ubuntu_16_i586]" string => "$(pkg[debian_4_i386])";
+      "pkg[ubuntu_16_i686]" string => "$(pkg[debian_4_i386])";
 
       "my_pkg"
         string => "$(pkg[$(sys.flavor)_$(sys.arch)])",
@@ -433,6 +479,23 @@ bundle agent cfengine_master_software_content
       "dir[SuSE_11_x86_64]" string => "$(dir[redhat_5_x86_64])";
       "dir[SuSE_10_x86_64]" string => "$(dir[redhat_5_x86_64])";
 
+      # All 32bit rpms use the same package
+      "dir[redhat_5_i386]" string => "agent_rpm_i386";
+      "dir[centos_5_i386]" string => "$(dir[redhat_5_i386])";
+      "dir[centos_5_i586]" string => "$(dir[redhat_5_i386])";
+      "dir[centos_5_i686]" string => "$(dir[redhat_5_i386])";
+      "dir[centos_6_i386]" string => "$(dir[redhat_5_i386])";
+      "dir[centos_6_i586]" string => "$(dir[redhat_5_i386])";
+      "dir[centos_6_i686]" string => "$(dir[redhat_5_i386])";
+      "dir[redhat_6_i386]" string => "$(dir[redhat_5_i386])";
+      "dir[redhat_6_i586]" string => "$(dir[redhat_5_i386])";
+      "dir[redhat_6_i686]" string => "$(dir[redhat_5_i386])";
+      "dir[centos_7_i386]" string => "$(dir[redhat_5_i386])";
+      "dir[centos_7_i586]" string => "$(dir[redhat_5_i386])";
+      "dir[centos_7_i686]" string => "$(dir[redhat_5_i386])";
+      "dir[SuSE_11_i386]" string => "$(dir[redhat_5_i386])";
+      "dir[SuSE_10_i386]" string => "$(dir[redhat_5_i386])";
+
       # Redhat/Centos 6, 7 use the same package
 
       "dir[redhat_6_x86_64]" string => "agent_rhel6_x86_64";
@@ -445,6 +508,32 @@ bundle agent cfengine_master_software_content
       "dir[debian_8_x86_64]" string => "$(dir[debian_7_x86_64])";
       "dir[ubuntu_14_x86_64]" string => "$(dir[debian_7_x86_64])";
       "dir[ubuntu_16_x86_64]" string => "$(dir[debian_7_x86_64])";
+
+      # All 32bit debs use the same package
+      "dir[debian_4_i386]" string => "agent_deb_i386";
+      "dir[debian_4_i586]" string => "$(dir[debian_4_i386])";
+      "dir[debian_4_i686]" string => "$(dir[debian_4_i386])";
+      "dir[debian_5_i386]" string => "$(dir[debian_4_i386])";
+      "dir[debian_5_i586]" string => "$(dir[debian_4_i386])";
+      "dir[debian_5_i686]" string => "$(dir[debian_4_i386])";
+      "dir[debian_6_i386]" string => "$(dir[debian_4_i386])";
+      "dir[debian_6_i586]" string => "$(dir[debian_4_i386])";
+      "dir[debian_6_i686]" string => "$(dir[debian_4_i386])";
+      "dir[debian_7_i386]" string => "$(dir[debian_4_i386])";
+      "dir[debian_7_i586]" string => "$(dir[debian_4_i386])";
+      "dir[debian_7_i686]" string => "$(dir[debian_4_i386])";
+      "dir[debian_8_i386]" string => "$(dir[debian_4_i386])";
+      "dir[debian_8_i586]" string => "$(dir[debian_4_i386])";
+      "dir[debian_8_i686]" string => "$(dir[debian_4_i386])";
+      "dir[debian_9_i386]" string => "$(dir[debian_4_i386])";
+      "dir[debian_9_i586]" string => "$(dir[debian_4_i386])";
+      "dir[debian_9_i686]" string => "$(dir[debian_4_i386])";
+      "dir[ubuntu_14_i386]" string => "$(dir[debian_4_i386])";
+      "dir[ubuntu_14_i586]" string => "$(dir[debian_4_i386])";
+      "dir[ubuntu_14_i686]" string => "$(dir[debian_4_i386])";
+      "dir[ubuntu_16_i386]" string => "$(dir[debian_4_i386])";
+      "dir[ubuntu_16_i586]" string => "$(dir[debian_4_i386])";
+      "dir[ubuntu_16_i686]" string => "$(dir[debian_4_i386])";
 
       "platform_dir" slist => getindices( dir );
 

--- a/standalone_self_upgrade.cf.in
+++ b/standalone_self_upgrade.cf.in
@@ -78,7 +78,19 @@ bundle common cfengine_software
 #@ brief Variables to control the specifics in desired package selection
 {
   vars:
+
       # Default desired CFEngine software
+
+      "pkg_name" string => "cfengine-nova";
+      "pkg_version" string => "@VERSION@";
+      "pkg_release" string => "1";
+      "pkg_arch" string => "x86_64";
+      "package_dir" string => "$(sys.flavour)_$(sys.arch)";
+
+!(cfengine_3_7_1|cfengine_3.7.2|cfengine_3.7.3)::
+# After 3.7.4 a fix to ifelse and isvarinbel allows for actuating the function
+# even thought the promise references an unresolved variable.
+
       "pkg_name" string => ifelse( isvariable( "def.cfengine_software_pkg_name" ), $(def.cfengine_software_pkg_name), "cfengine-nova");
       "pkg_version" string => ifelse( isvariable( "def.cfengine_software_pkg_version" ), $(def.cfengine_software_pkg_version), "@VERSION@");
       "pkg_release" string => ifelse( isvariable( "def.cfengine_software_pkg_release" ), $(def.cfengine_software_pkg_release), "1");
@@ -216,16 +228,21 @@ bundle agent cfengine_software_version_packages2
   packages:
 
     (redhat|centos).!__supported::
-      "$(local_software_dir)/$(pkg_name)-$(pkg_version)-$(pkg_release).$(pkg_arch).rpm"
+      "$(local_software_dir)/$(cfengine_package_names.my_pkg)"
       policy => "present",
       package_module => yum,
       comment => "Ensure the latest package is installed";
 
     (debian|ubuntu).!__supported::
-      "$(local_software_dir)/$(pkg_name)_$(pkg_version)-$(pkg_release)_$(pkg_arch).deb"
+      "$(local_software_dir)/$(cfengine_package_names.my_pkg)"
       policy => "present",
       package_module => apt_get,
       comment => "Ensure the latest package is installed";
+
+  reports:
+
+    "DEBUG|DEBUG_$(this.bundle)"::
+      "Running $(this.bundle)";
 }
 
 bundle agent cfengine_software_version_packages1
@@ -349,6 +366,50 @@ bundle agent cfengine_software_version_packages1
         package_method => u_generic( $(cfengine_software.local_software_dir) ),
         classes => u_if_else("bin_update_success", "bin_update_fail");
 
+  reports:
+
+    "DEBUG|DEBUG_$(this.bundle)"::
+      "Running $(this.bundle)";
+}
+
+bundle common cfengine_package_names
+{
+  vars:
+      "pkg_name" string => "$(cfengine_software.pkg_name)";
+      "pkg_version" string => "$(cfengine_software.pkg_version)";
+      "pkg_release" string => "$(cfengine_software.pkg_release)";
+      "pkg_arch" string => "$(cfengine_software.pkg_arch)";
+
+      # Redhat/Centos 4, 5 use the same package
+
+      "pkg[redhat_5_x86_64]" string => "$(pkg_name)-$(pkg_version)-$(pkg_release).el4.x86_64.rpm";
+      "pkg[centos_5_x86_64]" string => "$(pkg[redhat_5_x86_64])";
+      "pkg[SuSE_11_x86_64]" string => "$(pkg[redhat_5_x86_64])";
+      "pkg[SuSE_10_x86_64]" string => "$(pkg[redhat_5_x86_64])";
+
+      # Redhat/Centos 6, 7 use the same package
+
+      "pkg[redhat_6_x86_64]" string => "$(pkg_name)-$(pkg_version)-$(pkg_release).el6.x86_64.rpm";
+      "pkg[centos_6_x86_64]" string => "$(pkg[redhat_6_x86_64])";
+      "pkg[redhat_7_x86_64]" string => "$(pkg[redhat_6_x86_64])";
+      "pkg[centos_7_x86_64]" string => "$(pkg[redhat_6_x86_64])";
+
+      # Debian 7, 8 and Ubuntu 14, 16 use the same package
+
+      "pkg[debian_7_x86_64]" string => "$(pkg_name)_$(pkg_version)-$(pkg_release)_amd64-debian7.deb";
+      "pkg[debian_8_x86_64]" string => "$(pkg[debian_7_x86_64])";
+      "pkg[ubuntu_14_x86_64]" string => "$(pkg[debian_7_x86_64])";
+      "pkg[ubuntu_16_x86_64]" string => "$(pkg[debian_7_x86_64])";
+
+      "my_pkg"
+        string => "$(pkg[$(sys.flavor)_$(sys.arch)])",
+        comment => "The package name for the currently executing platform.";
+
+  reports:
+
+    "DEBUG|DEBUG_$(this.bundle)"::
+
+      "My Package: $(my_pkg)";
 }
 
 bundle agent cfengine_master_software_content
@@ -372,11 +433,6 @@ bundle agent cfengine_master_software_content
       "dir[SuSE_11_x86_64]" string => "$(dir[redhat_5_x86_64])";
       "dir[SuSE_10_x86_64]" string => "$(dir[redhat_5_x86_64])";
 
-      "pkg[redhat_5_x86_64]" string => "$(pkg_name)-$(pkg_version)-$(pkg_release).x86_64.rpm";
-      "pkg[centos_5_x86_64]" string => "$(pkg[redhat_5_x86_64])";
-      "pkg[SuSE_11_x86_64]" string => "$(pkg[redhat_5_x86_64])";
-      "pkg[SuSE_10_x86_64]" string => "$(pkg[redhat_5_x86_64])";
-
       # Redhat/Centos 6, 7 use the same package
 
       "dir[redhat_6_x86_64]" string => "agent_rhel6_x86_64";
@@ -384,22 +440,11 @@ bundle agent cfengine_master_software_content
       "dir[redhat_7_x86_64]" string => "$(dir[redhat_6_x86_64])";
       "dir[centos_7_x86_64]" string => "$(dir[redhat_6_x86_64])";
 
-      "pkg[redhat_6_x86_64]" string => "$(pkg_name)-$(pkg_version)-$(pkg_release).x86_64.rpm";
-      "pkg[centos_6_x86_64]" string => "$(pkg[redhat_6_x86_64])";
-      "pkg[redhat_7_x86_64]" string => "$(pkg[redhat_6_x86_64])";
-      "pkg[centos_7_x86_64]" string => "$(pkg[redhat_6_x86_64])";
-
-
       # Debian 7, 8 and Ubuntu 14, 16 use the same package
       "dir[debian_7_x86_64]" string => "agent_debian7_x86_64";
       "dir[debian_8_x86_64]" string => "$(dir[debian_7_x86_64])";
       "dir[ubuntu_14_x86_64]" string => "$(dir[debian_7_x86_64])";
       "dir[ubuntu_16_x86_64]" string => "$(dir[debian_7_x86_64])";
-
-      "pkg[debian_7_x86_64]" string => "$(pkg_name)_$(pkg_version)-$(pkg_release)_amd64.deb";
-      "pkg[debian_8_x86_64]" string => "$(pkg[debian_7_x86_64])";
-      "pkg[ubuntu_14_x86_64]" string => "$(pkg[debian_7_x86_64])";
-      "pkg[ubuntu_16_x86_64]" string => "$(pkg[debian_7_x86_64])";
 
       "platform_dir" slist => getindices( dir );
 
@@ -411,12 +456,12 @@ bundle agent cfengine_master_software_content
   commands:
       # Fetch each package that we don't already have
        "/usr/bin/curl"
-        args => "-s $(base_url)/$(dir[$(platform_dir)])/$(pkg[$(platform_dir)]) --output /var/cfengine/master_software_updates/$(platform_dir)/$(pkg[$(platform_dir)])",
-        if => not( fileexists( "/var/cfengine/master_software_updates/$(platform_dir)/$(pkg[$(platform_dir)])" ) );
+        args => "-s $(base_url)/$(dir[$(platform_dir)])/$(cfengine_package_names.pkg[$(platform_dir)]) --output /var/cfengine/master_software_updates/$(platform_dir)/$(cfengine_package_names.pkg[$(platform_dir)])",
+        if => not( fileexists( "/var/cfengine/master_software_updates/$(platform_dir)/$(cfengine_package_names.pkg[$(platform_dir)])" ) );
 
   reports:
     DEBUG|DEBUG_cfengine_master_software_content::
-      "curl -s $(base_url)/$(dir[$(i)])/$(pkg[$(i)]) --output /var/cfengine/master_software_updates/$(i)/$(pkg[$(i)])";
+      "curl -s $(base_url)/$(dir[$(i)])/$(cfengine_package_names.pkg[$(i)]) --output /var/cfengine/master_software_updates/$(i)/$(cfengine_pacakge_names.pkg[$(i)])";
 }
 
 bundle edit_line u_backup_script


### PR DESCRIPTION
This PR brings fixes for standalone self upgrade on agents older than 3.7.4 and addes support for 32bit deb and rpm platforms.