### PR TITLE
ENT-3390: Fix to frequent logging of enterprise license utilization

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -590,7 +590,7 @@ Example enabling the class from an [augments file][Augments]:
 ```
 {
   "classes": {
-    "enable_log_cfengine_enterprise_license_utilization": ["policy_server"]
+    "enable_log_cfengine_enterprise_license_utilization": [ "enterprise_edition" ]
   }
 }
 ```

--- a/cfe_internal/enterprise/CFE_hub_specific.cf
+++ b/cfe_internal/enterprise/CFE_hub_specific.cf
@@ -445,7 +445,8 @@ bundle agent log_cfengine_enterprise_license_utilization
 
       "$(sys.date), hosts_reporting=$(count_reporting), hosts_seen=$(count_seen)"
         report_to_file => "$(sys.workdir)/log/license_utilization.log",
-        action => if_elapsed( $(log_frequency) );
+        if => not("cfe_internal_logged_utilization"),
+        classes => cfe_internal_log_utilization($(log_frequency));
 
     policy_server.enterprise_edition.!enable_log_cfengine_enterprise_license_utilization::
 
@@ -453,13 +454,22 @@ bundle agent log_cfengine_enterprise_license_utilization
 }
 
 bundle agent cfe_internal_refresh_inventory_view
-#@brief Refresh materialized view every 5 minutes
-
+# @brief Refresh materialized view every 5 minutes
 {
   commands:
     any::
       "$(sys.workdir)/httpd/php/bin/php $(cfe_internal_hub_vars.docroot)/index.php cli_tasks inventory_refresh"
-      comment => "Refresh materialized view every 5 minutes",
-      classes => kept_successful_command,
-      handle  => "cfe_internal_inventory_refresh_mp";
+        comment => "Refresh materialized view every 5 minutes",
+        classes => kept_successful_command,
+        handle  => "cfe_internal_inventory_refresh_mp";
+}
+
+body classes cfe_internal_log_utilization(time)
+# @brief Define persistent class for period of time to control log volume
+{
+        promise_repaired => { "cfe_internal_logged_utilization" };
+        promise_kept => { "cfe_internal_logged_utilization" };
+
+        scope => "namespace";
+        persist_time => "$(time)";
 }


### PR DESCRIPTION
This change prevents logging of Enterprise license utilization more frequently
than desired. It was being logged on each agent run instead of waiting for the
expected period of time to pass before logging triggered again. The promiser
contains $(sys.date) which is different for each agent run making the promise
unique on each run and the lock useless. Locking was traded out for a persistent
class which is defined and communicates that logging has happened. When the
class expires the promise will actuate again and the resulting class will
persist guarding it until the class expires.

Changelog: Title