### PR TITLE
ENT-3438: make apt_get package module work with repositories containing spaces in the label

### DIFF
--- a/modules/packages/apt_get
+++ b/modules/packages/apt_get
@@ -193,7 +193,7 @@ def list_updates(online):
         #                repository(ies)      arch (might be optional)
         #                       |               |
         #                    /--+-\   /---------+---------\
-                         "\s+[^[)]*(\s\[(?P<arch>[^]\s]+)\])?\).*", line)
+                         "(?:\s+\S+)*?(\s+\[(?P<arch>[^]\s]+)\])?\).*", line)
 
         if match is not None:
             sys.stdout.write("Name=" + match.group("name") + "\n")


### PR DESCRIPTION
Changelog: Title