### PR TITLE
Allow multiple sections in insert_ini_section

### DIFF
--- a/lib/files.cf
+++ b/lib/files.cf
@@ -504,9 +504,10 @@ bundle edit_line insert_ini_section(name, config)
   insert_lines:
       "[$(name)]"
       location => start,
-      comment => "Prepend a line to the file if it doesn't already exist";
+      comment => "Insert an ini section with values if not present";
 
-      "$(k)=$($(config)[$(k)])";
+      "$(k)=$($(config)[$(k)])"
+      location => after("[$(name)]");
 }
 
 


### PR DESCRIPTION
When insert_ini_section is used on a file which contains other sections, or isoperating on a new file with no sections and is given an slist of multiple sections and values to add, the values were not associated with the correct file sections, but intermingled with others. The [section] for multiple sections is placed at the top of the file, but then the values are placed anywhere else.

Example:

```
bundle agent ini_edit
{
  vars:
    "options[test][option_one]" string => "content_one";
    "options[fake][fake_option]" string => "example";
    "sections" slist => getindices("options");

  files:
    "/tmp/foo.ini"
    create => "true",
    edit_line => insert_ini_section("$(sections)", "ini_edit.options[$(sections)]");
}
```

Result in foo.ini:

> [fake]
> [test]
> option_one=option_one_content
> option_one=fake_one
> option_two=option_two_content

By tying the location of the config values to the section header, insert_ini_section is now able to be iterated.