### PR TITLE
CFE-2722: Fix systemctl path detection

### DIFF
--- a/lib/paths.cf
+++ b/lib/paths.cf
@@ -104,7 +104,7 @@ bundle common paths
     _have_bin_systemctl::
       "path[systemctl]"      string => "/bin/systemctl";
     !_have_bin_systemctl::
-      "path[systemctl]"      string => "/bin/systemctl";
+      "path[systemctl]"      string => "/usr/bin/systemctl";
 
     linux::
       "path[lsattr]"        string => "/usr/bin/lsattr";


### PR DESCRIPTION
f704e39e broke systemctl path detection.

Changelog: Title