### PR TITLE
Fix systemctl path detection

### DIFF
--- a/lib/3.7/paths.cf
+++ b/lib/3.7/paths.cf
@@ -103,7 +103,7 @@ bundle common paths
     _have_bin_systemctl::
       "path[systemctl]"      string => "/bin/systemctl";
     !_have_bin_systemctl::
-      "path[systemctl]"      string => "/bin/systemctl";
+      "path[systemctl]"      string => "/usr/bin/systemctl";
 
     linux::
       "path[lsattr]"        string => "/usr/bin/lsattr";


### PR DESCRIPTION
f704e39 broke systemctl path detection, reverting to previous behavior.

Changelog: Title
(cherry picked from commit f15d39d813b98ba9647dba67d49f12d5e8dd9972)