### PR TITLE
ENT-3537: Add enterprise maintenance bundles to host info report

### DIFF
--- a/templates/host_info_report.mustache
+++ b/templates/host_info_report.mustache
@@ -47,3 +47,12 @@ Free Swap: {{{vars.mon.value_mem_freeswap}}} MB
 [{{method}}] {{name}}: version {{version}}, arch {{arch}}
 {{/vars.host_info_report_software.packages}}
 {{/classes.show_software}}
+
+{{#classes.enterprise_edition}}
+## Policy
+
+### Enterprise maintanance bundles available
+{{#vars.cfe_internal_enterprise_maintenance.enterprise_maintenance_bundles}}
+    {{{.}}}
+{{/vars.cfe_internal_enterprise_maintenance.enterprise_maintenance_bundles}}
+{{/classes.enterprise_edition}}


### PR DESCRIPTION
This adds a list of the enterprise maintenance bundles that are available
in the policy to the host info report.

For example a host info report (`cf-agent -KIb host_info_report`) from a
policy hub would include this:

```
 ## Policy

 ### Enterprise maintanance bundles available
    default:cfe_internal_refresh_events_table
    default:cfe_internal_refresh_inventory_view
```