### PR TITLE
ENT-3558: Include scheduled report assets in self maintenance

### DIFF
--- a/cfe_internal/enterprise/CFE_hub_specific.cf
+++ b/cfe_internal/enterprise/CFE_hub_specific.cf
@@ -456,4 +456,14 @@ bundle agent cfe_internal_purge_scheduled_reports_older_than_days(days)
       file_select => filetype_older_than("plain", $(days) ),
       comment => "Mission Portals scheduled reports are written here. They need
                   to be purged after some time so that they do not fill the disk.";
+
+      "$(cfe_internal_hub_vars.docroot)/api/static/." -> { "ENT-3558" }
+        handle => "cfe_internal_purge_scheduled_reports_files_docroot_api_static",
+        delete => tidy,
+        depth_search => recurse("inf"),
+        file_select => filetype_older_than("plain", $(days) ),
+        comment => "In some versions of Enterprise the async query api and
+                    scheduled reports assets are deposited in this directory.
+                    They need to be cleaned up as to not fill the disk.";
+
 }


### PR DESCRIPTION
In some versions of CFEngine Enterprise report assets from the asynchronous
query api and scheduled reports are deposited in api/static under the docroot
instead of tmp under the docroot.

This ensures cleanup of that directory.

Changelog: Title
(cherry picked from commit 2d8d226b6a19b375fd119ec7f4872c304b853eb9)
(cherry picked from commit ae13a81e8fcffc2a0ead238f9dff555438c619cc)