### PR TITLE
Sort indicies for insert_ini_section()

### DIFF
--- a/lib/files.cf
+++ b/lib/files.cf
@@ -515,7 +515,9 @@ bundle edit_line insert_ini_section(name, config)
 # @param config The fully-qualified name of an associative array containing `v[LHS]="rhs"`
 {
   vars:
-      "k" slist => getindices($(config));
+      # TODO: refactor once 3.7.x is EOL
+      "indeces" slist => getindices($(config));
+      "k" slist => sort("indeces", lex);
 
   insert_lines:
       "[$(name)]"

--- a/tests/acceptance/lib/files/insert_ini_section.cf
+++ b/tests/acceptance/lib/files/insert_ini_section.cf
@@ -40,7 +40,11 @@ bundle agent test
   vars:
       "options[test][test_option_one]" string => "test_option_one_value";
       "options[fake][fake_option_one]" string => "fake_option_one_value";
-      "sections" slist => getindices( options );
+
+      # TODO: refactor after 3.7.x is EOL
+      "sections_indices" slist => getindices(options);
+      "sections_sorted" slist => sort("sections_indices", lex);
+      "sections" slist => reverse("sections_sorted");
 
   files:
       "$(G.testfile).actual"


### PR DESCRIPTION
The first commit makes the tests more deterministic, the second commit makes the produced INI files potentially better readable.