### PR TITLE
ENT-3624: Improve context notifying user of missing policy update bundle

### DIFF
--- a/cfe_internal/update/update_policy.cf
+++ b/cfe_internal/update/update_policy.cf
@@ -68,7 +68,9 @@ bundle agent cfe_internal_update_policy
         if => "have_user_specified_update_bundle";
 
       "User specified update bundle MISSING! Falling back to $(default_policy_update_bundle)."
-        if => not( "have_user_specified_update_bundle" );
+        if => and( "have_user_specified_update_bundle",
+                   not( "have_found_user_specified_update_bundle" ));
+
 }
 
 bundle agent cfe_internal_update_policy_cpv


### PR DESCRIPTION
This change tightens the context for informing users when the user specified bundle for policy update is missing. This change restricts the report to when a custom policy update bundle is defined, and when it is unable to be found.