### PR TITLE
CFE-2773: Configure ignore_missing_inputs and ignore_missing_bundles via augments

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -129,6 +129,46 @@ Override this bundle by setting `def.mpf_update_policy_bundle` via augments:
 
 - Introduced in 3.12.0
 
+#### ignore_missing_bundles
+
+This option allows you to ignore errors when a bundle specified in body common control bundlesequence is not found.
+
+This example illustrates enabling the option via augments.
+
+```
+{
+  "vars": {
+    "control_common_ignore_missing_bundles": "true"
+  }
+}
+```
+
+**NOTE:** The same augments key is used for both `update.cf` and `promsies.cf` entries.
+
+**History:**
+
+- Introduced in 3.12.0
+
+#### ignore_missing_inputs
+
+This option allows you to ignore errors when a file specified in body common control inputs is not found.
+
+This example illustrates enabling the option via augments.
+
+```
+{
+  "vars": {
+    "control_common_ignore_missing_inputs": "true"
+  }
+}
+```
+
+**NOTE:** The same augments key is used for both `update.cf` and `promsies.cf` entries.
+
+**History:**
+
+- Introduced in 3.12.0
+
 ### Verify update transfers
 
 Enable additional verrification after file transfers during policy update by
@@ -329,6 +369,46 @@ The SMTP server that `cf-execd` should use to send emails.
 
 This is a list of of network ranges that the hub should allow download of policy
 files from.
+
+#### ignore_missing_bundles
+
+This option allows you to ignore errors when a bundle specified in body common control bundlesequence is not found.
+
+This example illustrates enabling the option via augments.
+
+```
+{
+  "vars": {
+    "control_common_ignore_missing_bundles": "true"
+  }
+}
+```
+
+**NOTE:** The same augments key is used for both `update.cf` and `promises.cf` entries.
+
+**History:**
+
+- Introduced in 3.12.0
+
+#### ignore_missing_inputs
+
+This option allows you to ignore errors when a file specified in body common control inputs is not found.
+
+This example illustrates enabling the option via augments.
+
+```
+{
+  "vars": {
+    "control_common_ignore_missing_inputs": "true"
+  }
+}
+```
+
+**NOTE:** The same augments key is used for both `update.cf` and `promises.cf` entries.
+
+**History:**
+
+- Introduced in 3.12.0
 
 #### trustkeysfrom
 

--- a/controls/def.cf
+++ b/controls/def.cf
@@ -194,6 +194,17 @@ bundle common def
 
       "bundlesequence_end" slist => {};
       "bundlesequence_end" slist => getvalues( tbse );
+
+      "control_common_ignore_missing_bundles" -> { "CFE-2773" }
+        string => ifelse( strcmp( $(control_common_ignore_missing_bundles), "true" ),
+                          "true",
+                          "false");
+
+      "control_common_ignore_missing_inputs" -> { "CFE-2773" }
+        string => ifelse( strcmp( $(control_common_ignore_missing_inputs), "true" ),
+                          "true",
+                          "false");
+
       # Agent controls
 
       "control_agent_files_single_copy"

--- a/controls/update_def.cf.in
+++ b/controls/update_def.cf.in
@@ -54,14 +54,13 @@ bundle common update_def
       "bundlesequence_end" slist => {};
       "bundlesequence_end" slist => getvalues( tbse );
 
+      "augments_inputs"
+        slist => {},
+        ifvarclass => not( isvariable( "def.update_inputs" ) );
 
       "augments_inputs"
         slist => { @(def.update_inputs) },
         ifvarclass => isvariable( "def.update_inputs" );
-
-      "augments_inputs"
-        slist => {},
-        ifvarclass => not( isvariable( "def.update_inputs" ) );
 
       # Begin change
 
@@ -138,6 +137,18 @@ bundle common update_def
 
     !enable_cfengine_enterprise_hub_ha::
       "policy_servers" slist => {"$(sys.policy_hub)"};
+
+    any::
+
+      "control_common_ignore_missing_bundles" -> { "CFE-2773" }
+        string => ifelse( strcmp( $(control_common_ignore_missing_bundles), "true" ),
+                          "true",
+                          "false");
+
+      "control_common_ignore_missing_inputs" -> { "CFE-2773" }
+        string => ifelse( strcmp( $(control_common_ignore_missing_inputs), "true" ),
+                          "true",
+                          "false");
 
   classes:
 

--- a/promises.cf.in
+++ b/promises.cf.in
@@ -73,6 +73,11 @@ body common control
     (debian|redhat|suse)::
           package_module => $(package_module_knowledge.platform_default);
 
+    any::
+        ignore_missing_bundles => "$(def.control_common_ignore_missing_bundles)";
+        ignore_missing_inputs => "$(def.control_common_ignore_missing_inputs)";
+
+
 }
 
 bundle common inventory

--- a/update.cf
+++ b/update.cf
@@ -30,6 +30,11 @@ body common control
                   "cfe_internal/update/update_processes.cf",
                   @(update_def.augments_inputs)
       };
+
+    any::
+        ignore_missing_bundles => "$(update_def.control_common_ignore_missing_bundles)";
+        ignore_missing_inputs => "$(update_def.control_common_ignore_missing_inputs)";
+
 }
 
 #############################################################################


### PR DESCRIPTION
This change allows configuring ignore_missing_inputs and ignore_missing_bundles
body common control options via augments. Note it affects both update.cf and
promises.cf entry points.

Example Augments:
```
{
  "vars": {
    "control_common_ignore_missing_inputs": "true",
    "control_common_ignore_missing_bundles": "true"
  }
}
```