### PR TITLE
CFE-2776 Fix cf-runagent during 3.7.x -> 3.10.x migration

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -32,6 +32,11 @@ request to expose the tunable into the ```def``` bundle.
 **Note:** `controls/def.cf` contains the defaults and settings for `promises.cf`
 and `controls/update_def.cf` contains the defaults and settings for `update.cf`.
 
+Since 3.7.8, 3.10.4, and 3.12.0 The class `cf_runagent_initated` is defined by
+default in the MPF for agent executions initiated by `cf-runagent` through
+`cf-serverd`. Previously the class `cfruncommand` was defined. See `body server
+control cfruncommand` in `controls/cf_serverd.cf`.
+
 ## Update Policy (update.cf)
 
 Synchronizing clients with the policy server happens here, in

--- a/controls/cf_serverd.cf
+++ b/controls/cf_serverd.cf
@@ -45,12 +45,28 @@ body server control
       cfruncommand => "$(sys.cf_agent) -I -D cfruncommand -f \"$(sys.update_policy_path)\"  &
                        $(sys.cf_agent) -I -D cfruncommand";
 
-    !windows::
-      # last single quote in cfruncommand is left open, so that
-      # arguments (like -K and --remote-bundles) are properly appended.
-      cfruncommand => "$(def.cf_runagent_shell) -c \'
+    !windows.!cfengine_3_7::
+
+      # In 3.10 the quotation is properly closed when EOF is reached. It is left
+      # open so that arguments (like -K and --remote-bundles) can be appended.
+      # 3.10.x does not automatically append -I -Dcfruncommand
+
+        cfruncommand => "$(def.cf_runagent_shell) -c \'
                            $(sys.cf_agent) -I -D cfruncommand -f $(sys.update_policy_path)  ;
                            $(sys.cf_agent) -I -D cfruncommand";
+
+    !windows.cfengine_3_7::
+
+      # 3.7.x does not properly close open quotes when EOF is reached preventing
+      # policy execution, so we must provide a trailing quote for cfruncommand.
+
+      # 3.7.x Automatically appends -I -Dcfruncommand to the cfruncommand. This
+      # results in a benign error about not being allowed to specify inputs for
+      # remote execution.
+
+        cfruncommand => "$(def.cf_runagent_shell) -c \'
+                           $(sys.cf_agent) -I -D cfruncommand -f $(sys.update_policy_path)  ;
+                           $(sys.cf_agent) -I -D cfruncommand\'";
 
       # Bind to all interfaces including ipv6
       # Adding this on windows will force ipv6 only

--- a/controls/cf_serverd.cf
+++ b/controls/cf_serverd.cf
@@ -42,8 +42,8 @@ body server control
       allowusers            => { "root" };
 
     windows::
-      cfruncommand => "$(sys.cf_agent) -I -D cfruncommand -f \"$(sys.update_policy_path)\"  &
-                       $(sys.cf_agent) -I -D cfruncommand";
+      cfruncommand => "$(sys.cf_agent) -I -D cf_runagent_initiated -f \"$(sys.update_policy_path)\"  &
+                       $(sys.cf_agent) -I -D cf_runagent_initiated";
 
     !windows.!cfengine_3_7::
 
@@ -52,8 +52,8 @@ body server control
       # 3.10.x does not automatically append -I -Dcfruncommand
 
         cfruncommand => "$(def.cf_runagent_shell) -c \'
-                           $(sys.cf_agent) -I -D cfruncommand -f $(sys.update_policy_path)  ;
-                           $(sys.cf_agent) -I -D cfruncommand";
+                           $(sys.cf_agent) -I -D cf_runagent_initiated -f $(sys.update_policy_path)  ;
+                           $(sys.cf_agent) -I -D cf_runagent_initiated";
 
     !windows.cfengine_3_7::
 
@@ -61,12 +61,14 @@ body server control
       # policy execution, so we must provide a trailing quote for cfruncommand.
 
       # 3.7.x Automatically appends -I -Dcfruncommand to the cfruncommand. This
-      # results in a benign error about not being allowed to specify inputs for
-      # remote execution.
+      # results in an error about not being allowed to specify inputs for remote
+      # execution from the update policy. In order to preserve the ability for
+      # policy to know its execution provenance we define a different class
+      # `cf_runagent_initiated` that does not elicit the error.
 
         cfruncommand => "$(def.cf_runagent_shell) -c \'
-                           $(sys.cf_agent) -I -D cfruncommand -f $(sys.update_policy_path)  ;
-                           $(sys.cf_agent) -I -D cfruncommand\'";
+                           $(sys.cf_agent) -I -D cf_runagent_initiated -f $(sys.update_policy_path)  ;
+                           $(sys.cf_agent) -I -D cf_runagent_initiated\'";
 
       # Bind to all interfaces including ipv6
       # Adding this on windows will force ipv6 only


### PR DESCRIPTION
This fixes an issue introduce by the addition of the ability to specify the bundlesequence cf-agent should use during a request made by cf-runagent.

3.10.x and greater needs an open cfruncommand specification so that it can append the arguments like no locks and remote bundles.