### PR TITLE
ENT-2797 Do not manage cf-consumer and redis-server after they have been removed

### DIFF
--- a/cfe_internal/update/update_policy.cf
+++ b/cfe_internal/update/update_policy.cf
@@ -136,9 +136,13 @@ bundle agent cfe_internal_update_policy_cpv
       comment => "File where Postgres database files will be logging -",
       handle => "cfe_internal_update_policy_postgresdb_log_file";
 
-      "redis_conf_file"  string => translatepath("$(sys.workdir)/config/redis.conf"),
-      comment => "Path to Redis configuration file",
-      handle => "cfe_internal_update_policy_redis_conf_file";
+    cfredis_in_enterprise::
+      # TODO Remove from MPF after 3.12 EOL
+
+      "redis_conf_file" -> { "ENT-2797" }
+        string => translatepath("$(sys.workdir)/config/redis.conf"),
+        comment => "Path to Redis configuration file",
+        handle => "cfe_internal_update_policy_redis_conf_file";
 
   classes:
 

--- a/cfe_internal/update/update_processes.cf
+++ b/cfe_internal/update/update_processes.cf
@@ -80,8 +80,16 @@ bundle agent cfe_internal_update_processes
       "agent[cf_postgres]" string => "cf-postgres";
       "agent[cf_runalerts]" string => "cf-runalerts";
       "agent[cf_apache]"   string => "cf-apache";
-      "agent[cf_redis_server]" string => "cf-redis-server";
-      "agent[cf_consumer]" string => "cf-consumer";
+
+    cfredis_in_enterprise::
+      # TODO Remove from MPF after 3.12 EOL
+      "agent[cf_redis_server]" -> { "ENT-2797" }
+        string => "cf-redis-server";
+
+    cfconsumer_in_enterprise::
+      # TODO Remove from MPF after 3.12 EOL
+      "agent[cf_consumer]" -> { "ENT-2797" }
+        string => "cf-consumer";
 
     any::
       # We get a consolidated list of all agents for the executing host.
@@ -226,14 +234,15 @@ bundle agent maintain_cfe_hub_process
       handle => "cfe_internal_maintain_cfe_hub_process_processes_check_vacuumdb",
       ifvarclass => "nova|enterprise";
 
-   am_policy_hub::
-      "$(cfe_internal_process_knowledge.bindir)/redis-server"
+   am_policy_hub.cfredis_in_enterprise::
+      "$(cfe_internal_process_knowledge.bindir)/redis-server" -> { "ENT-2797" }
       restart_class => "start_redis_server",
       comment => "Monitor redis-server process",
       handle => "cfe_internal_maintain_cfe_hub_process_processes_redis",
       ifvarclass => "nova|enterprise";
 
-      "$(cfe_internal_process_knowledge.bindir)/cf-consumer"
+    am_policy_hub.cfconsumer_in_enterprise::
+      "$(cfe_internal_process_knowledge.bindir)/cf-consumer" -> { "ENT-2797" }
       restart_class => "start_cf_consumer",
       comment => "Monitor cf-consumer process",
       handle => "cfe_internal_maintain_cfe_hub_process_processes_cf_consumer",
@@ -272,9 +281,10 @@ bundle agent maintain_cfe_hub_process
 
   commands:
 
-    !windows.am_policy_hub.start_redis_server::
+    !windows.am_policy_hub.start_redis_server.cfredis_in_enterprise::
+      # TODO Remove from MPF after 3.12 EOL
 
-     "$(cfe_internal_process_knowledge.bindir)/redis-server $(cfe_internal_update_policy.redis_conf_file)"
+     "$(cfe_internal_process_knowledge.bindir)/redis-server $(cfe_internal_update_policy.redis_conf_file)" -> { "ENT-2797" }
       contain => u_in_dir("/"),
       comment => "Start redis process",
       classes => u_kept_successful_command,
@@ -287,8 +297,10 @@ bundle agent maintain_cfe_hub_process
       classes => u_kept_successful_command,
       handle => "cfe_internal_maintain_cfe_hub_process_commands_start_postgres";
 
-    !windows.am_policy_hub.start_cf_consumer::
-     "$(cfe_internal_process_knowledge.bindir)/cf-consumer"
+    !windows.am_policy_hub.start_cf_consumer.cfconsumer_in_enterprise::
+      # TODO Remove from MPF after 3.12 EOL
+
+      "$(cfe_internal_process_knowledge.bindir)/cf-consumer"
       comment => "Start cf-consumer process",
       classes => u_kept_successful_command,
       handle => "cfe_internal_maintain_cfe_hub_process_commands_start_cf-consumer";

--- a/controls/def.cf
+++ b/controls/def.cf
@@ -489,6 +489,12 @@ bundle common def
       # Enable paths to POSIX tools instead of native tools when possible.
       "mpf_stdlib_use_posix_utils" expression => "any";
 
+      # TODO Remove from MPF after 3.12 EOL
+      "cfredis_in_enterprise" -> { "ENT-2797" }
+        or => { "cfengine_3_7", "cfengine_3_8", "cfengine_3_9", "cfengine_3_10", "cfengine_3_11" };
+      "cfconsumer_in_enterprise"  -> { "ENT-2797" }
+        expression => "cfredis_in_enterprise";
+
   reports:
     DEBUG|DEBUG_def::
       "DEBUG: $(this.bundle)";

--- a/controls/update_def.cf.in
+++ b/controls/update_def.cf.in
@@ -216,6 +216,13 @@ bundle common update_def
       # Enable failover to node which is outside cluster
       #"failover_to_replication_node_enabled" expression => "enterprise_edition";
 
+    any::
+      # TODO Remove from MPF after 3.12 EOL
+      "cfredis_in_enterprise" -> { "ENT-2797" }
+        or => { "cfengine_3_7", "cfengine_3_8", "cfengine_3_9", "cfengine_3_10", "cfengine_3_11" };
+      "cfconsumer_in_enterprise"  -> { "ENT-2797" }
+        expression => "cfredis_in_enterprise";
+
   reports:
     DEBUG|DEBUG_update_def::
       "DEBUG: $(this.bundle)";

--- a/lib/cfe_internal_hub.cf
+++ b/lib/cfe_internal_hub.cf
@@ -187,6 +187,8 @@ bundle agent cfe_internal_database_cleanup_reports (settings)
 bundle agent cfe_internal_database_cleanup_consumer_status (row_count)
 # @ignore
 # @brief keep up to row_count entries in the database
+# @note ENT-2797 After cf-consumer removal, this will still be necessary, functionality
+# of cf-consumer to be replaced with cf-hub-worker per Ole.
 {
 
   vars:
@@ -255,15 +257,21 @@ bundle agent cfe_internal_postgresql_maintenance
       comment => "Vacuum Full PostgreSQL (database: cfdb)",
       handle => "cfe_internal_postgresql_maintenance_vacuum_full";
 
-    policy_server.enterprise::
-      "cf_consumer_pid"
+    policy_server.enterprise.cfconsumer_in_enterprise::
+      # TODO Remove after 3.12 EOL
+
+      "cf_consumer_pid" -> { "ENT-2797" }
         string => readfile("$(sys.workdir)/cf-consumer.pid", 0),
         ifvarclass => fileexists( "$(sys.workdir)/cf-consumer.pid" ),
         comment => "Read cf-consumer.pid for the main cf-consumer PID";
 
   classes:
-      "cf_consumer_pid_correct" expression => isvariable("cf_consumer_pid"),
-      comment => "Check if cf-consumer pid is correctly defined";
+
+    cfconsumer_in_enterprise::
+      # TODO Remove after 3.12 EOL
+      "cf_consumer_pid_correct" -> { "ENT-2972" }
+        expression => isvariable("cf_consumer_pid"),
+        comment => "Check if cf-consumer pid is correctly defined";
 
   processes:
 
@@ -273,11 +281,14 @@ bundle agent cfe_internal_postgresql_maintenance
       comment => "Terminate cf-hub while doing PostgreSQL maintenance",
       handle => "cfe_internal_postgresql_maintenance_processes_term_cf_hub";
 
-    cf_consumer_pid_correct::
-      "cf-consumer" signals => { "kill" },
-      process_select => by_pid("$(cf_consumer_pid)"),
-      comment => "Kill cf-consumer while doing PostgreSQL maintenance",
-      handle => "cfe_internal_postgresql_maintenance_processes_kill_cf_consumer";
+    cf_consumer_pid_correct.cfconsumer_in_enterprise::
+      # TODO Remove from MPF after 3.12 EOL
+
+      "cf-consumer" -> { "ENT-2797" }
+        signals => { "kill" },
+        process_select => by_pid("$(cf_consumer_pid)"),
+        comment => "Kill cf-consumer while doing PostgreSQL maintenance",
+        handle => "cfe_internal_postgresql_maintenance_processes_kill_cf_consumer";
 
   commands:
 


### PR DESCRIPTION
This change avoids managing cf-consumer and redis-server after they have been removed.

Knowledge of removal based on cfengine_MAJOR_MINOR hard classes defined for
cfredis_in_enterprise and cfconsumer_in_enterprise in def.cf and update_def.cf