### PR TITLE
ENT-3692 The path to source policy updates is tunable via augments

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -76,6 +76,29 @@ As is typical for CFEngine, the policy and the configuration are mixed. In
 to `controls/update_def.cf` as you read this. We are skipping the nonessential
 ones.
 
+### Configure upstream masterfiles location for policy update
+
+Want to get your policy from a place other than `/var/cfengine/masterfiles` on
+`sys.policy_hub`?
+
+With an augments like this:
+
+```
+{
+  "vars": {
+            "house": "Gryffindor",
+            "mpf_update_policy_master_location": "/srv/cfengine/$(sys.flavor)/$(def.house)"
+          }
+}
+```
+
+A CentOS 7 host would copy policy from `/srv/cfengine/centos_6/Gryffindor` to
+`$(sys.inputdir)` (commonly `/var/cfengine/inputs**).
+
+**History:**
+
+- Introduced in 3.12.0.
+
 ### Append to inputs used by update policy
 
 You can append to the inputs used by the update policy via augments by defining

--- a/cfe_internal/update/update_policy.cf
+++ b/cfe_internal/update/update_policy.cf
@@ -90,12 +90,12 @@ bundle agent cfe_internal_update_policy_cpv
       comment => "Directory containing CFEngine policies",
       handle => "cfe_internal_update_policy_vars_inputs_dir";
 
+      "master_location" -> { "ENT-3692" }
+        string => "$(update_def.master_location)",
+        comment => "The path to request updates from the policy server.",
+        handle => "cfe_internal_update_policy_vars_master_location";
 
     windows::
-
-      "master_location"    string => "/var/cfengine/masterfiles",  # NB! NOT $(sys.workdir) on Windows !
-      comment => "The master CFEngine policy directory on the policy host",
-      handle => "cfe_internal_update_policy_vars_master_location_windows";
 
       "modules_dir"        string => "/var/cfengine/modules",      # NB! NOT $(sys.workdir) on Windows !
       comment => "Directory containing CFEngine modules",
@@ -106,9 +106,6 @@ bundle agent cfe_internal_update_policy_cpv
       handle => "cfe_internal_update_policy_vars_plugins_dir_windows";
 
     !windows::
-      "master_location"    string => "$(sys.masterdir)",
-      comment => "The master CFEngine policy directory on the policy host",
-      handle => "cfe_internal_update_policy_vars_master_location";
 
       "modules_dir"        string => translatepath("$(sys.workdir)/modules"),
       comment => "Directory containing CFEngine modules",

--- a/controls/update_def.cf.in
+++ b/controls/update_def.cf.in
@@ -128,6 +128,12 @@ bundle common update_def
       comment => "Group that CFEngine Enterprise webserver runs as",
       handle => "common_def_vars_cf_cfapache_group";
 
+      "mpf_update_policy_master_location" -> { "ENT-3692" }
+        comment => "Directory where clients should get policy from.",
+        string => ifelse( isvariable( $(def.mpf_update_policy_master_location) ),
+                                      $(def.mpf_update_policy_master_location),
+                          "masterfiles");
+
     # enable_cfengine_enterprise_hub_ha is defined below
     # Disabled by default
 


### PR DESCRIPTION
This change makes it to override the path where policy updates bound for
`$(sys.inputdir)` come from by setting a variable via an augments file.

With an augments like this:

```
{ 
  "vars": { 
            "house": "Gryffindor",
            "mpf_update_policy_master_location": "/srv/cfengine/$(sys.flavor)/$(def.house)"
          }
}
```

A CentOS 7 host would copy policy from `/srv/cfengine/centos_6/Gryffindor` to
`$(sys.inputdir)` (commonly `/var/cfengine/inputs`).