### PR TITLE
Remove trailing whitespace (git doesn't like it!)

### DIFF
--- a/inventory/aix.cf
+++ b/inventory/aix.cf
@@ -76,4 +76,3 @@ bundle agent inventory_aix_oslevel
      "Highest Service Pack: $(oslevel_s)";
      "Highest Technology Level: $(oslevel_r)";
 }
-


### PR DESCRIPTION
Remove trailing whitespace from inventory/aix.cf as git complains about
it.

In Git core.whitespace configuration settings, `blank-at-eof` treats
blank lines added at the end of file as an error (enabled by default).

I ran into this when using git to update our MPF. I had to override
it with `git apply --whitespace=warn` to get git to actually apply
the patch to inventory/aix.cf