### PR TITLE
ENT-3730 Fix variable used for redis conf file

### DIFF
--- a/cfe_internal/update/update_processes.cf
+++ b/cfe_internal/update/update_processes.cf
@@ -279,7 +279,7 @@ bundle agent maintain_cfe_hub_process
 
     !windows.am_policy_hub.start_redis_server::
 
-     "$(cfe_internal_process_knowledge.bindir)/redis-server $(cfe_internal_update_policy.redis_conf_file)"
+     "$(cfe_internal_process_knowledge.bindir)/redis-server $(cfe_internal_update_policy_cpv.redis_conf_file)"
       contain => u_in_dir("/"),
       comment => "Start redis process",
       classes => u_kept_successful_command,


### PR DESCRIPTION
This conf file variable was moved into another bundle as part of some
refactoring to enable a more plugable policy update model for users to override with their own.