### PR TITLE
make package name matching more accurate

### DIFF
--- a/modules/packages/pkgsrc
+++ b/modules/packages/pkgsrc
@@ -102,7 +102,7 @@ get_package_data () {
         # or version, return nothing.
         # There's possibly a bug here because we're already emitting that the
         # PackageType is repo.
-        parse_pkg_data "$(pkgin -pP avail | grep "^${File}-" | grep "$Version;" | sort -n | tail -1)" | grep Name
+        parse_pkg_data "$(pkgin -pP avail | grep "^${File}-[0-9]" | grep "$Version;" | sort -n | tail -1)" | grep Name
     fi
 }
 


### PR DESCRIPTION
The regex matching in `get_package_data()` is too loose. For instance, a promise to install the `gmp` package resulted in `gmp-api` being installed. Because:

```
$ pkgin -pP avail | grep ^gmp-                
gmp-6.1.2;Library for arbitrary precision arithmetic
gmp-api-38.0;Headers for developing Gecko Media Plugins
```

We now look for `Name-[0-9]` in the available package list. The regex can't be any tighter than that, as it seems pretty much any character is allowed in the version number. So `File-[0-9\.]*;` will miss packages like `gmpc-tagedit-11.8.16nb8`.

