### PR TITLE
make package name matching more accurate (3.12.x)

### DIFF
--- a/modules/packages/pkgsrc
+++ b/modules/packages/pkgsrc
@@ -102,7 +102,7 @@ get_package_data () {
         # or version, return nothing.
         # There's possibly a bug here because we're already emitting that the
         # PackageType is repo.
-        parse_pkg_data "$(pkgin -pP avail | grep "^${File}-" | grep "$Version;" | sort -n | tail -1)" | grep Name
+        parse_pkg_data "$(pkgin -pP avail | grep "^${File}-[0-9]" | grep "$Version;" | sort -n | tail -1)" | grep Name
     fi
 }
 


### PR DESCRIPTION
(cherry picked from commit c6d7ecc3daa70a7646ae4bf00a35d9150e18e550)
Signed-off-by: Craig Comstock <craig.comstock@northern.tech>