### PR TITLE
Store the epoch of packages in cache db with zypper

### DIFF
--- a/modules/packages/zypper
+++ b/modules/packages/zypper
@@ -33,7 +33,7 @@ import re
 
 rpm_cmd = os.environ.get('CFENGINE_TEST_RPM_CMD', "/bin/rpm")
 rpm_quiet_option = ["--quiet"]
-rpm_output_format = "Name=%{name}\nVersion=%{version}-%{release}\nArchitecture=%{arch}\n"
+rpm_output_format = "Name=%{name}\nVersion=%|EPOCH?{%{epoch}:}:{}|%{version}-%{release}\nArchitecture=%{arch}\n"
 
 zypper_cmd = os.environ.get('CFENGINE_TEST_ZYPPER_CMD', "/usr/bin/zypper")
 zypper_options = ["--quiet", "-n"]


### PR DESCRIPTION
When a package has an epoch, in order to install the precise version
with zypper, it is required to write the complete version `epoch:version`
and `version` alone is not understood.

But currently the installed package cache does not store the
epoch, and a package with an epoch in the version will never be considered
as present.

This commits adds the `${epoch}:` before the version of the package
in the installed package database, allowing to install and
properly detect the package.