### PR TITLE
ENT-3907 Fix policy compatibility for 3.7.x

### DIFF
--- a/cfe_internal/enterprise/CFE_hub_specific.cf
+++ b/cfe_internal/enterprise/CFE_hub_specific.cf
@@ -494,8 +494,11 @@ bundle agent cfe_internal_enterprise_maintenance
 
     enterprise_edition::
 
+      "enterprise_maintenance_bundles_unsorted"
+        slist => bundlesmatching(".*", "enterprise_maintenance");
+
       "enterprise_maintenance_bundles"
-        slist => sort( bundlesmatching(".*", "enterprise_maintenance"),
+        slist => sort( @(enterprise_maintenance_bundles_unsorted),
                        lex);
 
   methods:


### PR DESCRIPTION
3.7.x does not support nested function calls as well as newer versions.
In order for the policy to be backwards compatible this needs to be
separated into multiple promises.