### PR TITLE
ENT-3910 Fix policy backward compatibility

### DIFF
--- a/cfe_internal/enterprise/CFE_hub_specific.cf
+++ b/cfe_internal/enterprise/CFE_hub_specific.cf
@@ -498,13 +498,27 @@ bundle agent cfe_internal_enterprise_maintenance
         slist => bundlesmatching(".*", "enterprise_maintenance");
 
       "enterprise_maintenance_bundles"
-        slist => sort( @(enterprise_maintenance_bundles_unsorted),
+        slist => sort( enterprise_maintenance_bundles_unsorted,
                        lex);
+
+      "enterprise_maintenance_bundle_count"
+        int => length( enterprise_maintenance_bundles );
 
   methods:
 
-    "Enterprise Maintenance"
-      usebundle => $(enterprise_maintenance_bundles);
+      "Enterprise Maintenance"
+        usebundle => $(enterprise_maintenance_bundles),
+        ifvarclass => isgreaterthan( $(enterprise_maintenance_bundle_count), 0 );
+
+  reports:
+
+    "DEBUG|DEBUG_$(this.bundle)"::
+
+      "DEBUG $(this.bundle): $(enterprise_maintenance_bundle_count) CFEngine Enterprise Maintenance Bundles"
+        ifvarclass => isgreaterthan( $(enterprise_maintenance_bundle_count), 0 );
+
+      "DEBUG $(this.bundle): $(enterprise_maintenance_bundles) CFEngine Enterprise Maintenance Bundles"
+        ifvarclass => isgreaterthan( $(enterprise_maintenance_bundle_count), 0 );
 }
 
 bundle agent cfe_internal_refresh_inventory_view


### PR DESCRIPTION
In newer versions of cfengine the promise to run the bundles would have been
skipped if there were no bundles to run. This makes that behavior explicit, and
compatible with 3.7.0 to avoid an error about trying to actuate a bundle
that does not exist.

(cherry picked from commit bf94ae0e90e7964db7b370eb5642b2ad8fb38a80)