### PR TITLE
Better support non-standard location of mastefiles

### DIFF
--- a/controls/update_def.cf.in
+++ b/controls/update_def.cf.in
@@ -134,7 +134,7 @@ bundle common update_def
       # "masterfiles" shortcut.
 
       "mpf_update_policy_master_location" -> { "ENT-3692" }
-        string => ifelse( "am_policy_hub", "/var/cfengine/masterfiles",
+        string => ifelse( "am_policy_hub", "@prefix@/masterfiles",
                           "masterfiles");
 
       # Here we allow the masterfiles location to be overridden via augments. If


### PR DESCRIPTION
Using '--prefix' with './configure' allows masterfiles to be
installed to a different location than
/var/cfengine/masterfiles. This location should then be respected
in the installed MPF policy.