### PR TITLE
CFE-2860 Specify scope => "namespace" when using persistent classes

### DIFF
--- a/cfe_internal/update/update_processes.cf
+++ b/cfe_internal/update/update_processes.cf
@@ -503,4 +503,5 @@ body classes u_always_forever(theclass)
       repair_denied => { $(theclass) };
       repair_timeout => { $(theclass) };
       persist_time => 999999999;
+      scope => "namespace";
 }

--- a/lib/common.cf
+++ b/lib/common.cf
@@ -439,6 +439,7 @@ body classes state_repaired(x)
 {
       promise_repaired => { "$(x)" };
       persist_time => "10";
+      scope => "namespace";
 }
 
 ##
@@ -452,6 +453,7 @@ body classes enumerate(x)
       promise_repaired => { "mXC_$(x)" };
       promise_kept => { "mXC_$(x)" };
       persist_time => "15";
+      scope => "namespace";
 }
 
 ##


### PR DESCRIPTION
If scope is not set to namespace, then info messages are emitted and the class
is automatically scoped to namespace. This change prevents annoying messages and
retains the same behavior.