### PR TITLE
ENT-3923 Sync cf-runalerts override unit template with package

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -402,7 +402,7 @@ The SMTP server that `cf-execd` should use to send emails.
 
 #### acl
 
-`def.acl` is a list of of network ranges that should be allowed to connect to cf-serverd. It is also used in the default access promises to allow hosts access to policy and modules that should be distributed. 
+`def.acl` is a list of of network ranges that should be allowed to connect to cf-serverd. It is also used in the default access promises to allow hosts access to policy and modules that should be distributed.
 
 Here is an example setting the acl from augments:
 

--- a/templates/cf-runalerts.service.mustache
+++ b/templates/cf-runalerts.service.mustache
@@ -1,7 +1,7 @@
 [Unit]
 Description=CFEngine Enterprise SQL Alerts
 After=syslog.target
-ConditionFileIsExecutable={{{vars.sys.bindir}}}/runalerts.php
+ConditionPathExists={{{vars.sys.bindir}}}/runalerts.php
 ConditionFileIsExecutable={{{vars.sys.workdir}}}/httpd/php/bin/php
 
 PartOf=cfengine3.service
@@ -13,7 +13,7 @@ Requires=cf-postgres.service
 Type=simple
 # The cfapache user doesn't have the rights to write to {{{vars.sys.workdir}}}/httpd/php/runalerts_*
 User={{{vars.def.cf_apache_user}}}
-ExecStart={{{vars.sys.bindir}}}/runalerts.php
+ExecStart={{{vars.sys.workdir}}}/httpd/php/bin/php {{{vars.sys.bindir}}}/runalerts.php
 Restart=always
 RestartSec=10
 


### PR DESCRIPTION
This change simply synchronizes the override template provided for convenience with the unit provided by the package.