### PR TITLE
CFE-2855 apt_get package module includes held packages when listing updates

### DIFF
--- a/modules/packages/apt_get
+++ b/modules/packages/apt_get
@@ -166,7 +166,7 @@ def list_updates(online):
         if result != 0:
             return result
 
-    process = subprocess_Popen([apt_get_cmd] + apt_get_options + ["-s", "upgrade"], stdout=subprocess.PIPE)
+    process = subprocess_Popen([apt_get_cmd] + apt_get_options + ["--simulate", "--ignore-hold", "upgrade"], stdout=subprocess.PIPE)
     for line in process.stdout:
         if PY3:
             line = line.decode("utf-8")

--- a/modules/packages/apt_get
+++ b/modules/packages/apt_get
@@ -166,6 +166,10 @@ def list_updates(online):
         if result != 0:
             return result
 
+   # We ignore held packages (--ignore-hold) so that all package updates
+   # available are listed. This makes package update listing compatible with
+   # debian 8 and highers `apt list --upgradeable`
+
     process = subprocess_Popen([apt_get_cmd] + apt_get_options + ["--simulate", "--ignore-hold", "upgrade"], stdout=subprocess.PIPE)
     for line in process.stdout:
         if PY3:


### PR DESCRIPTION
We ignore held packages (`--ignore-hold`) so that all package updates available
are listed. This makes package update listing compatible with debian 8 and
higher `apt list --upgradeable`.