### PR TITLE
Redirect output from 'geninstall' on AIX

### DIFF
--- a/standalone_self_upgrade.cf.in
+++ b/standalone_self_upgrade.cf.in
@@ -942,8 +942,8 @@ body package_method u_generic(repo)
         package_name_convention    => "$(name)-$(version).bff";
         package_delete_convention  => "$(name)";
 
-        package_add_command        => "/usr/bin/rm -f $(repo)/.toc && /usr/sbin/geninstall -IqacgXNY -d $(repo) cfengine.cfengine-nova$";
-        package_update_command     => "/usr/bin/rm -f $(repo)/.toc && /usr/sbin/geninstall -IqacgXNY -d $(repo) cfengine.cfengine-nova$";
+        package_add_command        => "/usr/bin/rm -f $(repo)/.toc && /usr/sbin/geninstall -IacgXNY -d $(repo) cfengine.cfengine-nova > /dev/null$";
+        package_update_command     => "/usr/bin/rm -f $(repo)/.toc && /usr/sbin/geninstall -IacgXNY -d $(repo) cfengine.cfengine-nova > /dev/null$";
 
       # package_add_command        => "/bin/sh -c /usr/sbin/inutoc $(repo) && /usr/sbin/installp -qacgXNYd $(repo) cfengine.cfengine-nova$";
       # package_update_command     => "/bin/sh -c /usr/sbin/inutoc $(repo) && /usr/sbin/installp -qacgXNYd $(repo) cfengine.cfengine-nova$";


### PR DESCRIPTION
Somehow dropping the '-q' option and redirecting the output seems
to fix the issues with self-upgrade not properly (re-)starting
services on AIX.

Ticket: ENT-3972