### PR TITLE
Explanation why stdout redirect fixes package operations on AIX

### DIFF
--- a/standalone_self_upgrade.cf.in
+++ b/standalone_self_upgrade.cf.in
@@ -942,6 +942,9 @@ body package_method u_generic(repo)
         package_name_convention    => "$(name)-$(version).bff";
         package_delete_convention  => "$(name)";
 
+      # Redirecting the output to '/dev/null' below makes sure 'geninstall' has
+      # its stdout open even if the 'cf-agent' process that started it
+      # terminates (e.g. gets killed).
         package_add_command        => "/usr/bin/rm -f $(repo)/.toc && /usr/sbin/geninstall -IacgXNY -d $(repo) cfengine.cfengine-nova > /dev/null$";
         package_update_command     => "/usr/bin/rm -f $(repo)/.toc && /usr/sbin/geninstall -IacgXNY -d $(repo) cfengine.cfengine-nova > /dev/null$";
         package_delete_command     => "/usr/sbin/installp -ug cfengine.cfengine-nova$";


### PR DESCRIPTION
This is quite a tricky thing to figure out so let's note it down
before we forget about it.

Ticket: ENT-3972