### PR TITLE
CFE-2690: Prevent noise when a service that to be disabled is missing

### DIFF
--- a/lib/services.cf
+++ b/lib/services.cf
@@ -371,7 +371,7 @@ bundle agent standard_services(service,state)
     verbose_mode.fallback::
       "$(this.bundle): falling back to classic_services to $(state) $(service)";
 
-    systemd.service_notfound.(inform_mode|verbose_mode)::
+    systemd.service_notfound.(start|restart|reload).(inform_mode|verbose_mode)::
         "$(this.bundle): Could not find service: $(service)";
 }
 


### PR DESCRIPTION
As I commented on CFE-2690, the fact that it's missing
doesn't indicate a problem.  Actually, when the promise
is that the service should be stopped or disabled, the
fact that it's missing is (philosophically speaking) a
'KEPT' outcome of the promise.  When it's supposed to
be started or restarted then of course it has to be
present.

Especially in an environment where CFEngine is used for
security enforcement and there is a big list of obsolete
services (insecure) that should be disabled if found,
it's quite annoying to see the 'could not be found'
message every time you turn on inform mode.