### PR TITLE
ENT-4054 Users allowed to request execution via cf-runagent can be configured via augments

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -592,6 +592,27 @@ Example definition in augments file:
 }
 ```
 
+### Configure users allowed to initate execution via cf-runagent
+
+cf-serverd only allows specified users to request unscheduled execution remotely via cf-runagent.
+
+By default the MPF allows `root` to request unscheduled execution of non policy servers and does not allow any users to request unscheduled execution from policy servers.
+
+To configure the list of users allowed to request unscheduled execution from non policy servers define `vars.control_server_allowusers_non_policy_server`. This example allows the users `hubmanager` and  `cfoperator` to request unscheduled execution from policy servers and no users are allowed to request unscheduled runs from non policy servers.
+
+```
+{
+  "vars": {
+    "control_server_allowusers_non_policy_server": [ ],
+    "control_server_allowusers_policy_server": [ "hubmanager", "cfoperator" ]
+  }
+}
+```
+
+**History:**
+
+- Added in 3.13.0, 3.12.1
+
 ### Configure retention for files in log directories
 
 By default the MPF rotates managed log files when they reach 1M in size. To configure this limit via augments define `vars.mpf_log_file_max_size`.

--- a/cfe_internal/CFE_cfengine.cf
+++ b/cfe_internal/CFE_cfengine.cf
@@ -14,11 +14,24 @@
 #  - some agent bundles are in CFE_hub_specific.cf
 #
 ##################################################################
+bundle agent cfe_internal_management_file_control
+{
+  vars:
+
+      "inputs" slist => { };
+
+    cfengine_recommendations_enabled::
+      "input[cfengine_recommendations]"
+        string => "$(this.promise_dirname)/recommendations.cf";
+
+    any::
+      "inputs" slist => getvalues( input );
+}
 
 body file control
 {
     cfengine_recommendations_enabled::
-      inputs => { "recommendations.cf" };
+      inputs => { @(cfe_internal_management_file_control.inputs) };
 }
 
 bundle agent cfe_internal_management

--- a/controls/cf_serverd.cf
+++ b/controls/cf_serverd.cf
@@ -38,8 +38,13 @@ body server control
     enterprise_edition.client_initiated_reporting_enabled::
       call_collect_interval => "$(def.control_server_call_collect_interval)";
 
+    # The MPF provides different variables for configuring which users are
+    # allowed to initiate execution via cf-runagent.
     !policy_server::
-      allowusers            => { "root" };
+      allowusers => { @(def.control_server_allowusers_non_policy_server) };
+
+    policy_server::
+        allowusers => { @(def.control_server_allowusers_policy_server) };
 
     windows::
       cfruncommand => "$(sys.cf_agent) -I -D cf_runagent_initiated -f \"$(sys.update_policy_path)\"  &

--- a/controls/def.cf
+++ b/controls/def.cf
@@ -133,6 +133,15 @@ bundle common def
         ifvarclass => not( isvariable( "control_server_allowlegacyconnects" ) );
 
 
+      # Users authorized to request executions via cf-runagent
+      "control_server_allowusers_non_policy_server"
+        slist => { "root" },
+        ifvarclass => not( isvariable( "control_server_allowusers_non_policy_server" ) );
+
+      "control_server_allowusers_policy_server"
+        slist => {},
+        ifvarclass => not( isvariable( "control_server_allowusers_non_policy_server" ) );
+
       # Executor Controls
 
       ## Default splaytime to 4 unless it's already defined (via augments)


### PR DESCRIPTION
This change allows different lists of users to be authorized for cf-runagent for policy servers and non policy servers.