### PR TITLE
CFE-2897 Consider sles when considerign suse class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
         apt:
           sources:
             - sourceline: "deb https://cfengine-package-repos.s3.amazonaws.com/pub/apt/packages stable main"
-            - key_url: https://cfengine-package-repos.s3.amazonaws.com/pub/gpg.key
+              key_url: https://cfengine-package-repos.s3.amazonaws.com/pub/gpg.key
           packages:
             - cfengine-community
 
@@ -25,7 +25,7 @@ matrix:
         apt:
           sources:
             - sourceline: "deb https://cfengine-package-repos.s3.amazonaws.com/pub/apt/packages stable main"
-            - key_url: https://cfengine-package-repos.s3.amazonaws.com/pub/gpg.key
+              key_url: https://cfengine-package-repos.s3.amazonaws.com/pub/gpg.key
           packages:
             - cfengine-community=3.12.0-1
 
@@ -35,7 +35,7 @@ matrix:
         apt:
           sources:
             - sourceline: "deb https://cfengine-package-repos.s3.amazonaws.com/pub/apt/packages stable main"
-            - key_url: https://cfengine-package-repos.s3.amazonaws.com/pub/gpg.key
+              key_url: https://cfengine-package-repos.s3.amazonaws.com/pub/gpg.key
           packages:
             - cfengine-community=3.10.4-1
 
@@ -45,7 +45,7 @@ matrix:
         apt:
           sources:
             - sourceline: "deb https://cfengine-package-repos.s3.amazonaws.com/pub/apt/packages stable main"
-            - key_url: https://cfengine-package-repos.s3.amazonaws.com/pub/gpg.key
+              key_url: https://cfengine-package-repos.s3.amazonaws.com/pub/gpg.key
           packages:
             - cfengine-community=3.7.8-1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
             - sourceline: "deb https://cfengine-package-repos.s3.amazonaws.com/pub/apt/packages stable main"
               key_url: https://cfengine-package-repos.s3.amazonaws.com/pub/gpg.key
           packages:
-            - cfengine-community=3.12.0-1
+            - cfengine-community=3.12.*
 
     # JOB 3
     - env: CF_VERSION=3.10.x
@@ -37,7 +37,7 @@ matrix:
             - sourceline: "deb https://cfengine-package-repos.s3.amazonaws.com/pub/apt/packages stable main"
               key_url: https://cfengine-package-repos.s3.amazonaws.com/pub/gpg.key
           packages:
-            - cfengine-community=3.10.4-1
+            - cfengine-community=3.10.*
 
     # JOB 4
     - env: CF_VERSION=3.7.x
@@ -47,7 +47,7 @@ matrix:
             - sourceline: "deb https://cfengine-package-repos.s3.amazonaws.com/pub/apt/packages stable main"
               key_url: https://cfengine-package-repos.s3.amazonaws.com/pub/gpg.key
           packages:
-            - cfengine-community=3.7.8-1
+            - cfengine-community=3.7.*
 
 
 script:

--- a/MPF.md
+++ b/MPF.md
@@ -592,6 +592,27 @@ Example definition in augments file:
 }
 ```
 
+### Configure users allowed to initate execution via cf-runagent
+
+cf-serverd only allows specified users to request unscheduled execution remotely via cf-runagent.
+
+By default the MPF allows `root` to request unscheduled execution of non policy servers and does not allow any users to request unscheduled execution from policy servers.
+
+To configure the list of users allowed to request unscheduled execution from non policy servers define `vars.control_server_allowusers_non_policy_server`. This example allows the users `hubmanager` and  `cfoperator` to request unscheduled execution from policy servers and no users are allowed to request unscheduled runs from non policy servers.
+
+```
+{
+  "vars": {
+    "control_server_allowusers_non_policy_server": [ ],
+    "control_server_allowusers_policy_server": [ "hubmanager", "cfoperator" ]
+  }
+}
+```
+
+**History:**
+
+- Added in 3.13.0, 3.12.1
+
 ### Configure retention for files in log directories
 
 By default the MPF rotates managed log files when they reach 1M in size. To configure this limit via augments define `vars.mpf_log_file_max_size`.

--- a/cfe_internal/CFE_cfengine.cf
+++ b/cfe_internal/CFE_cfengine.cf
@@ -14,11 +14,24 @@
 #  - some agent bundles are in CFE_hub_specific.cf
 #
 ##################################################################
+bundle agent cfe_internal_management_file_control
+{
+  vars:
+
+      "inputs" slist => { };
+
+    cfengine_recommendations_enabled::
+      "input[cfengine_recommendations]"
+        string => "$(this.promise_dirname)/recommendations.cf";
+
+    any::
+      "inputs" slist => getvalues( input );
+}
 
 body file control
 {
     cfengine_recommendations_enabled::
-      inputs => { "recommendations.cf" };
+      inputs => { @(cfe_internal_management_file_control.inputs) };
 }
 
 bundle agent cfe_internal_management

--- a/cfe_internal/update/update_bins.cf
+++ b/cfe_internal/update/update_bins.cf
@@ -357,7 +357,7 @@ bundle edit_line u_install_script
 {
   insert_lines:
 
-    redhat|suse::
+    redhat|suse|sles::
 
       "#!/bin/sh
 
@@ -455,7 +455,7 @@ body package_method u_generic(repo)
     debian::
       package_update_command     => "$(sys.workdir)/bin/cf-upgrade -b $(cfe_internal_update_bins.backup_script) -s $(cfe_internal_update_bins.backup_file) -i $(cfe_internal_update_bins.install_script)";
 
-    redhat|SuSE|suse::
+    redhat|SuSE|suse|sles::
 
       package_changes => "individual";
 
@@ -481,14 +481,14 @@ body package_method u_generic(repo)
       package_version_less_command => "$(sys.bindir)/rpmvercmp '$(v1)' lt '$(v2)'";
       package_version_equal_command => "$(sys.bindir)/rpmvercmp '$(v1)' eq '$(v2)'";
 
-    (redhat|SuSE|suse)::
+    (redhat|SuSE|suse|sles)::
       package_update_command     => "$(sys.workdir)/bin/cf-upgrade -b $(cfe_internal_update_bins.backup_script) -s $(cfe_internal_update_bins.backup_file) -i $(cfe_internal_update_bins.install_script)";
 
     redhat.!redhat_4::
       package_list_update_command => "/usr/bin/yum --quiet check-update";
     redhat_4::
       package_list_update_command => "/usr/bin/yum check-update";
-    SuSE|suse::
+    SuSE|suse|sles::
       package_list_update_command => "/usr/bin/zypper list-updates";
 
     windows::

--- a/controls/cf_serverd.cf
+++ b/controls/cf_serverd.cf
@@ -38,8 +38,13 @@ body server control
     enterprise_edition.client_initiated_reporting_enabled::
       call_collect_interval => "$(def.control_server_call_collect_interval)";
 
+    # The MPF provides different variables for configuring which users are
+    # allowed to initiate execution via cf-runagent.
     !policy_server::
-      allowusers            => { "root" };
+      allowusers => { @(def.control_server_allowusers_non_policy_server) };
+
+    policy_server::
+        allowusers => { @(def.control_server_allowusers_policy_server) };
 
     windows::
       cfruncommand => "$(sys.cf_agent) -I -D cf_runagent_initiated -f \"$(sys.update_policy_path)\"  &

--- a/controls/def.cf
+++ b/controls/def.cf
@@ -133,6 +133,15 @@ bundle common def
         ifvarclass => not( isvariable( "control_server_allowlegacyconnects" ) );
 
 
+      # Users authorized to request executions via cf-runagent
+      "control_server_allowusers_non_policy_server"
+        slist => { "root" },
+        ifvarclass => not( isvariable( "control_server_allowusers_non_policy_server" ) );
+
+      "control_server_allowusers_policy_server"
+        slist => {},
+        ifvarclass => not( isvariable( "control_server_allowusers_non_policy_server" ) );
+
       # Executor Controls
 
       ## Default splaytime to 4 unless it's already defined (via augments)

--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -589,7 +589,7 @@ bundle agent cfe_autorun_inventory_packages
     # exists. As package modules become available the package_methods should be
     # removed.
 
-    suse::
+    suse|sles::
       "cfe_internal_non_existing_package"
       package_policy => "add",
       package_method => inventory_zypper($(refresh)),
@@ -607,7 +607,7 @@ bundle agent cfe_autorun_inventory_packages
       package_method => emerge,
       action => if_elapsed_day;
 
-    !redhat.!debian.!gentoo.!suse.!aix::
+    !redhat.!debian.!gentoo.!(suse|sles).!aix::
       "cfe_internal_non_existing_package"
       package_policy => "add",
       package_method => generic,

--- a/lib/bundles.cf
+++ b/lib/bundles.cf
@@ -84,13 +84,13 @@ bundle agent cronjob(commands,user,hours,mins)
 # ```
 {
   vars:
-    suse::
+    suse|sles::
       "crontab" string => "/var/spool/cron/tabs";
     redhat|fedora::
       "crontab" string => "/var/spool/cron";
     freebsd::
       "crontab" string => "/var/cron/tabs";
-    !(suse|redhat|fedora|freebsd)::
+    !(suse|sles|redhat|fedora|freebsd)::
       "crontab" string => "/var/spool/cron/crontabs";
 
     any::

--- a/lib/packages.cf
+++ b/lib/packages.cf
@@ -63,7 +63,7 @@ bundle common package_module_knowledge
     redhat|amazon_linux::
       "platform_default" string => "yum";
 
-    suse::
+    suse|sles::
       "platform_default" string => "zypper";
 
     aix::
@@ -1802,7 +1802,7 @@ body package_method generic
 #     "mypackage" package_method => generic, package_policy => "add";
 # ```
 {
-    suse::
+    suse|sles::
       package_changes => "bulk";
       package_list_command => "$(rpm_knowledge.call_rpm) -qa --queryformat \"$(rpm_knowledge.rpm_output_format)\"";
       # set it to "0" to avoid caching of list during upgrade
@@ -1977,12 +1977,12 @@ bundle agent package_absent(package)
       package_policy => "delete",
       package_method => yum_rpm_permissive;
 
-    suse::
+    suse|sles::
       "$(package)"
       package_policy => "delete",
       package_method => zypper;
 
-    !debian.!redhat.!suse::
+    !debian.!redhat.!(suse|sles)::
       "$(package)"
       package_policy => "delete",
       package_method => generic;
@@ -2014,12 +2014,12 @@ bundle agent package_present(package)
       package_policy => "add",
       package_method => yum_rpm_permissive;
 
-    suse::
+    suse|sles::
       "$(package)"
       package_policy => "add",
       package_method => zypper;
 
-    !debian.!redhat.!suse::
+    !debian.!redhat.!(suse|sles)::
       "$(package)"
       package_policy => "add",
       package_method => generic;
@@ -2053,13 +2053,13 @@ bundle agent package_latest(package)
       package_version => "999999999",
       package_method => yum_rpm_permissive;
 
-    suse::
+    suse|sles::
       "$(package)"
       package_policy => "addupdate",
       package_version => "999999999",
       package_method => zypper;
 
-    !debian.!redhat.!suse::
+    !debian.!redhat.!(suse|sles)::
       "$(package)"
       package_policy => "addupdate",
       package_method => generic;
@@ -2228,7 +2228,7 @@ bundle agent package_specific(package_name, desired, package_version, package_ar
       package_architectures => { $(package_arch) },
       package_method => yum_rpm;
 
-    suse::
+    suse|sles::
 
       "$(package_name)"
       package_policy => $(desired),
@@ -2254,13 +2254,13 @@ bundle agent package_specific(package_name, desired, package_version, package_ar
       package_version => $(package_version),
       package_method => solaris_install($(solaris_admin_file));
 
-    !filebased.!debian.!redhat.!suse::
+    !filebased.!debian.!redhat.!(suse|sles)::
 
       "$(package_name)"
       package_policy => $(desired),
       package_method => generic;
 
   reports:
-    "(DEBUG|DEBUG_$(this.bundle)).filebased.!suse.!debian.!redhat.!aix.!solaris_pkgadd"::
+    "(DEBUG|DEBUG_$(this.bundle)).filebased.!(suse|sles).!debian.!redhat.!aix.!solaris_pkgadd"::
       "DEBUG $(this.bundle): sorry, can't do file-based installs on $(sys.os)";
 }

--- a/lib/paths.cf
+++ b/lib/paths.cf
@@ -473,10 +473,10 @@ bundle common paths
 
       "path[sysctl]"        string => "/sbin/sysctl";
 
-    !suse::
+    !(suse|sles)::
       "path[logger]"        string => "/usr/bin/logger";
 
-    suse::
+    suse|sles::
 
       "path[awk]"           string => "/usr/bin/awk";
       "path[bc]"            string => "/usr/bin/bc";

--- a/lib/services.cf
+++ b/lib/services.cf
@@ -582,7 +582,7 @@ bundle agent classic_services(service,state)
       "pattern[varnish]"          string => ".*varnish.*";
       "pattern[wpa_supplicant]"   string => ".*wpa_supplicant.*";
 
-    suse::
+    suse|sles::
 
       "baseinit[mysql]"           string => "mysqld";
       "pattern[mysql]"            string => ".*mysqld.*";

--- a/promises.cf.in
+++ b/promises.cf.in
@@ -67,10 +67,10 @@ body common control
 
       # We only define pacakge_invetory on redhat like systems that have a
       # python version that works with the package module.
-    (redhat|centos|suse|amazon_linux).cfe_yum_package_module_supported.!disable_inventory_package_refresh::
+    (redhat|centos|suse|sles|amazon_linux).cfe_yum_package_module_supported.!disable_inventory_package_refresh::
         package_inventory => { $(package_module_knowledge.platform_default) };
 
-    (debian|redhat|suse|amazon_linux)::
+    (debian|redhat|suse|sles|amazon_linux)::
           package_module => $(package_module_knowledge.platform_default);
 
     any::
@@ -92,7 +92,7 @@ bundle common inventory
 {
   classes:
       "other_unix_os" expression => "!windows.!macos.!linux.!freebsd";
-      "specific_linux_os" expression => "redhat|debian|suse";
+      "specific_linux_os" expression => "redhat|debian|suse|sles";
 
   vars:
       # This list is intended to grow as needed
@@ -102,7 +102,7 @@ bundle common inventory
     redhat::
       "inputs" slist => { "inventory/any.cf", "inventory/linux.cf", "inventory/lsb.cf", "inventory/redhat.cf", "inventory/os.cf" };
       "bundles" slist => { "inventory_control", "inventory_any", "inventory_autorun", "inventory_linux", "inventory_lsb", "inventory_redhat", "inventory_os" };
-    suse::
+    suse|sles::
       "inputs" slist => { "inventory/any.cf", "inventory/linux.cf", "inventory/lsb.cf", "inventory/suse.cf", "inventory/os.cf" };
       "bundles" slist => { "inventory_control", "inventory_any", "inventory_autorun", "inventory_linux", "inventory_lsb", "inventory_suse", "inventory_os" };
     windows::

--- a/standalone_self_upgrade.cf.in
+++ b/standalone_self_upgrade.cf.in
@@ -122,7 +122,7 @@ bundle agent cfengine_software
         comment => "On debian hosts it's the standard to use 'amd64' instead of
                    'x86_64' in package architectures.";
 
-    (redhat|centos|suse).32_bit::
+    (redhat|centos|suse|sles).32_bit::
       "pkg_arch"
         string => "i386",
         comment => "i686 is the detected architecture, but the package is
@@ -295,7 +295,7 @@ bundle agent cfengine_software_version_packages1
 {
   classes:
 
-      "cf_upgrade" expression => "(redhat|suse|debian|solaris|solarisx86).!(am_policy_hub|policy_server)";
+      "cf_upgrade" expression => "(redhat|suse|sles|debian|solaris|solarisx86).!(am_policy_hub|policy_server)";
 
   vars:
 
@@ -629,7 +629,7 @@ bundle edit_line u_install_script
 {
   insert_lines:
 
-    redhat|suse::
+    redhat|suse|sles::
 
       "#!/bin/sh
 
@@ -806,7 +806,7 @@ body package_method u_generic(repo)
     debian::
         package_update_command     => "$(sys.workdir)/bin/cf-upgrade -b $(cfe_internal_update_bins.backup_script) -s $(cfe_internal_update_bins.backup_file) -i $(cfe_internal_update_bins.install_script)";
 
-    redhat|SuSE|suse::
+    redhat|SuSE|suse|sles::
 
         package_changes => "individual";
 
@@ -832,14 +832,14 @@ body package_method u_generic(repo)
         package_version_less_command => "$(sys.bindir)/rpmvercmp '$(v1)' lt '$(v2)'";
         package_version_equal_command => "$(sys.bindir)/rpmvercmp '$(v1)' eq '$(v2)'";
 
-    (redhat|SuSE|suse)::
+    (redhat|SuSE|suse|sles)::
         package_update_command     => "$(sys.workdir)/bin/cf-upgrade -b $(cfe_internal_update_bins.backup_script) -s $(cfe_internal_update_bins.backup_file) -i $(cfe_internal_update_bins.install_script)";
 
     redhat.!redhat_4::
         package_list_update_command => "/usr/bin/yum --quiet check-update";
     redhat_4::
         package_list_update_command => "/usr/bin/yum check-update";
-    SuSE|suse::
+    SuSE|suse|sles::
         package_list_update_command => "/usr/bin/zypper list-updates";
 
     windows::

--- a/tests/acceptance/17_packages/01_init/unsafe/timed/001-prepare-repositories.cf
+++ b/tests/acceptance/17_packages/01_init/unsafe/timed/001-prepare-repositories.cf
@@ -45,7 +45,7 @@ body contain useshell
 bundle agent repositories
 {
   vars:
-    suse::
+    suse|sles::
       "repo_file" string => "/etc/zypp/repos.d/test-repository.repo";
       "repos" slist => { "rpm_repo" };
     redhat::
@@ -81,7 +81,7 @@ bundle agent repositories
         depth_search => recurse("inf"),
         file_select => not_test_source;
 
-    suse::
+    suse|sles::
       "/etc/zypp/repos.d"
         delete => tidy,
         depth_search => recurse("inf"),
@@ -97,7 +97,7 @@ body file_select not_test_source
 bundle edit_line repository
 {
   insert_lines:
-    redhat|suse::
+    redhat|suse|sles::
       "[test-repository]";
       "name=Test repository";
       "baseurl=file:///test-repos/rpm_repo";
@@ -178,7 +178,7 @@ bundle agent dpkg_multiarch
 bundle agent update
 {
   commands:
-    suse::
+    suse|sles::
       "zypper ref"
         contain => useshell,
         classes => if_successful("update_ok");

--- a/tests/acceptance/17_packages/11_old/unsafe/named_multi_pkg_absent.cf
+++ b/tests/acceptance/17_packages/11_old/unsafe/named_multi_pkg_absent.cf
@@ -45,7 +45,7 @@ bundle agent init
             package_architectures => { "$(p.arch)" },
             package_method => apt_get;
 
-        redhat|suse::
+        redhat|suse|sles::
 
             "$(package_name)"
             package_policy => "add",
@@ -69,7 +69,7 @@ bundle agent test
             package_policy => "delete",
             classes => test_set_class("pass_$(package_name)","fail_$(package_name)");
 
-        redhat|suse::
+        redhat|suse|sles::
 
             "$(package_name)"
             package_policy => "delete",
@@ -97,7 +97,7 @@ bundle agent check
 
             "not_has_pkg_$(test.package_name)" not => returnszero("dpkg -l | grep ' $(test.package_name) ' > /dev/null", "useshell");
 
-        redhat|suse::
+        redhat|suse|sles::
 
             "not_has_pkg_$(test.package_name)" not => returnszero("/bin/rpm -q $(test.package_name) > /dev/null", "useshell");
 

--- a/tests/acceptance/17_packages/11_old/unsafe/named_multi_pkg_present.cf
+++ b/tests/acceptance/17_packages/11_old/unsafe/named_multi_pkg_present.cf
@@ -57,7 +57,7 @@ bundle agent test
             package_policy => "add",
             classes => test_set_class("pass_$(package_name)","fail_$(package_name)");
 
-        suse::
+        suse|sles::
 
             "$(package_name)"
             package_policy => "add",
@@ -83,7 +83,7 @@ bundle agent check
 
             "has_pkg_$(test.package_name)" expression => returnszero("dpkg -l | egrep ' $(test.package_name)(:amd64)? '", "useshell");
 
-        redhat|suse::
+        redhat|suse|sles::
 
             "has_pkg_$(test.package_name)" expression => returnszero("/bin/rpm -qa | grep -qw $(test.package_name)", "useshell");
 

--- a/tests/acceptance/17_packages/11_old/unsafe/named_multi_pkg_upgrade.cf
+++ b/tests/acceptance/17_packages/11_old/unsafe/named_multi_pkg_upgrade.cf
@@ -61,7 +61,7 @@ bundle agent test
             package_method => yum_rpm,
             classes => test_set_class("pass_$(package_name)","fail_$(package_name)");
 
-        suse::
+        suse|sles::
 
             "$(package_name)"
             package_policy => "update",
@@ -90,7 +90,7 @@ bundle agent check
 
             "has_pkg_$(test.package_name)" expression => returnszero("dpkg -l | egrep ' $(test.package_name)(:amd64)? '", "useshell");
 
-        redhat|suse::
+        redhat|suse|sles::
 
             "has_pkg_$(test.package_name)" expression => returnszero("/bin/rpm -qa | grep -qw $(test.package_name)", "useshell");
 

--- a/tests/acceptance/17_packages/11_old/unsafe/named_pkg_absent.cf
+++ b/tests/acceptance/17_packages/11_old/unsafe/named_pkg_absent.cf
@@ -45,7 +45,7 @@ bundle agent init
             package_policy => "add",
             package_method => apt_get;
 
-        redhat|suse::
+        redhat|suse|sles::
 
             "$(package_name)"
             package_policy => "add",
@@ -66,7 +66,7 @@ bundle agent test
             package_policy => "delete",
             classes => test_set_class("pass","fail");
 
-    redhat|suse::
+    redhat|suse|sles::
         "$(package_name)"
         package_policy => "delete",
         classes => test_set_class("pass","fail");
@@ -89,7 +89,7 @@ bundle agent check
     classes:
         debian::
             "not_has_pkg" not => returnszero("dpkg -l | grep ' $(test.package_name) ' > /dev/null", "useshell");
-        redhat|suse::
+        redhat|suse|sles::
             "not_has_pkg" not => returnszero("/bin/rpm -q $(test.package_name) > /dev/null", "useshell");
 
         any::

--- a/tests/acceptance/17_packages/11_old/unsafe/named_pkg_file_present.cf
+++ b/tests/acceptance/17_packages/11_old/unsafe/named_pkg_file_present.cf
@@ -54,7 +54,7 @@ bundle agent test
             package_architectures => { "$(p.arch)" },
             package_method => dpkg_version("$(p.resources)/file_repo");
 
-        redhat|suse::
+        redhat|suse|sles::
 
             "$(package_name)"
             classes => test_set_class("pass","fail"),
@@ -87,7 +87,7 @@ bundle agent check
         debian::
             "has_pkg" expression => returnszero("dpkg -l | egrep ' $(test.package_name)(:amd64)? ' > /dev/null", "useshell");
 
-        redhat|suse::
+        redhat|suse|sles::
             "has_pkg" expression => returnszero("/bin/rpm -q $(test.package_name) > /dev/null", "useshell");
 
         any::

--- a/tests/acceptance/17_packages/11_old/unsafe/named_pkg_file_upgrade.cf
+++ b/tests/acceptance/17_packages/11_old/unsafe/named_pkg_file_upgrade.cf
@@ -54,7 +54,7 @@ bundle agent test
             package_method => dpkg_version("$(p.resources)/file_repo"),
             classes => test_set_class("pass", "fail");
 
-        redhat|suse::
+        redhat|suse|sles::
 
             "$(package_name)"
             package_policy => "addupdate",
@@ -83,7 +83,7 @@ bundle agent check
         debian::
             "has_pkg" expression => returnszero("dpkg -l | egrep ' $(test.package_name)(:amd64)? ' > /dev/null", "useshell");
 
-        redhat|suse::
+        redhat|suse|sles::
             "has_pkg" expression => returnszero("/bin/rpm -q $(test.package_name) > /dev/null", "useshell");
 
         any::

--- a/tests/acceptance/17_packages/11_old/unsafe/named_pkg_present.cf
+++ b/tests/acceptance/17_packages/11_old/unsafe/named_pkg_present.cf
@@ -59,7 +59,7 @@ bundle agent test
             package_policy => "add",
             classes => test_set_class("pass","fail");
 
-        suse::
+        suse|sles::
 
             "$(package_name)"
             package_policy => "add",
@@ -82,7 +82,7 @@ bundle agent check
 
     classes:
 
-        redhat|suse::
+        redhat|suse|sles::
             "has_pkg" expression => returnszero("/bin/rpm -q $(test.package_name) > /dev/null", "useshell");
 
         debian::

--- a/tests/acceptance/17_packages/11_old/unsafe/named_pkg_upgrade.cf
+++ b/tests/acceptance/17_packages/11_old/unsafe/named_pkg_upgrade.cf
@@ -61,7 +61,7 @@ bundle agent test
             package_method => yum_rpm,
             classes => test_set_class("pass","fail");
 
-        suse::
+        suse|sles::
 
             "$(package_name)"
             package_policy => "addupdate",
@@ -87,7 +87,7 @@ bundle agent check
 
     classes:
 
-        redhat|suse::
+        redhat|suse|sles::
             "has_pkg" expression => returnszero("/bin/rpm -q $(test.package_name) > /dev/null", "useshell");
 
         debian::

--- a/tests/acceptance/17_packages/11_old/unsafe/named_versioned_pkg_present.cf
+++ b/tests/acceptance/17_packages/11_old/unsafe/named_versioned_pkg_present.cf
@@ -62,7 +62,7 @@ bundle agent test
             package_method => yum_rpm,
             classes => test_set_class("pass","fail");
 
-        suse::
+        suse|sles::
             "$(package_name)"
             package_policy => "add",
             package_select => "==",
@@ -91,7 +91,7 @@ bundle agent check
         debian::
             "has_pkg" expression => returnszero("dpkg -l | egrep ' $(test.package_name)(:amd64)? ' > /dev/null", "useshell");
 
-        redhat|suse::
+        redhat|suse|sles::
             "has_pkg" expression => returnszero("/bin/rpm -q $(test.package_name) > /dev/null", "useshell");
 
         any::

--- a/tests/acceptance/17_packages/11_old/unsafe/named_versioned_pkg_upgrade.cf
+++ b/tests/acceptance/17_packages/11_old/unsafe/named_versioned_pkg_upgrade.cf
@@ -65,7 +65,7 @@ bundle agent test
             package_method => yum_rpm,
             classes => test_set_class("pass","fail");
 
-        suse::
+        suse|sles::
             "$(package_name)"
             package_policy => "addupdate",
             package_select => "==",
@@ -94,7 +94,7 @@ bundle agent check
         debian::
             "has_pkg" expression => returnszero("dpkg -l | egrep ' $(test.package_name)(:amd64)? ' > /dev/null", "useshell");
 
-        redhat|suse::
+        redhat|suse|sles::
             "has_pkg" expression => returnszero("/bin/rpm -q $(test.package_name) > /dev/null", "useshell");
 
         any::

--- a/tests/acceptance/17_packages/packages-info.cf.sub
+++ b/tests/acceptance/17_packages/packages-info.cf.sub
@@ -16,14 +16,14 @@ bundle common p
     "name[2]" string => "test-package-$(distinct_name[2])";
     "name[3]" string => "test-package-$(distinct_name[3])";
 
-    redhat|suse::
+    redhat|suse|sles::
       "ext" string => "rpm";
       "delim" string => "-";
     debian::
       "ext" string => "deb";
       "delim" string => "_";
 
-    redhat|suse::
+    redhat|suse|sles::
       "64_bit" string => "x86_64";
     debian::
       "64_bit" string => "amd64";
@@ -39,7 +39,7 @@ bundle common p
       "version[1]" string => "1.0-1";
       "version[2]" string => "1.0-2";
 
-    redhat|suse::
+    redhat|suse|sles::
       "package[$(packages)][$(versions)][$(archs)]"
         string => "$(p.resources)/rpm_repo/$(name[$(packages)])-$(version[$(versions)]).$($(archs)).rpm";
     debian::
@@ -77,11 +77,11 @@ bundle agent clear_packages(key)
       "output_sink" string => "> $(G.dev_null) 2>&1";
 
   commands:
-    redhat|suse::
+    redhat|suse|sles::
       "$(paths.path[rpm]) -e --allmatches $(p.name[$(p.packages)]) $(output_sink)"
         contain => in_shell,
         comment => $(key);
-    debian::
+    debian|sles::
       "$(paths.path[dpkg]) --purge $(p.name[$(p.packages)]):$(p.$(p.archs)) $(output_sink)"
         contain => in_shell,
         comment => $(key);
@@ -100,7 +100,7 @@ bundle agent install_package(package_name, package_version, package_arch, key)
       "output_sink" string => "> $(G.dev_null) 2>&1";
 
   commands:
-    redhat|suse::
+    redhat|suse|sles::
       "$(paths.path[rpm]) -U --force $(p.resources)/rpm_repo/$(package_name)-$(package_version).$(package_arch).rpm $(output_sink)"
         contain => in_shell,
         comment => $(key);


### PR DESCRIPTION
Added sles hardclass This is done because parsing the /etc/os-release results in the harclasses sles and sles_<version>. The suse and suse_<version> are only available on SLES 12 SP 3 or lower because they still have the /etc/SuSE-release. This has been removed in SLES 15.