### PR TITLE
ENT-4092 Prevent standalone self upgrade from triggering un-necessarily

### DIFF
--- a/standalone_self_upgrade.cf.in
+++ b/standalone_self_upgrade.cf.in
@@ -173,7 +173,7 @@ bundle edit_line cfengine_software_version_data
 "name": "$(cfengine_software.pkg_name)",
 "version": "$(cfengine_software.pkg_version)",
 "release": "$(cfengine_software.pkg_release)",
-"arch" "$(cfengine_software.pkg_arch)"
+"arch": "$(cfengine_software.pkg_arch)"
 }';
 }
 

--- a/standalone_self_upgrade.cf.in
+++ b/standalone_self_upgrade.cf.in
@@ -170,10 +170,10 @@ bundle edit_line cfengine_software_version_data
 {
       delete_lines: ".*";
       insert_lines: '{
-"name": "$(cfengine_version.pkg_name)",
-"version": "$(cfengine_version.pkg_version)",
-"release": "$(cfengine_version.pkg_release)",
-"arch" "$(cfengine_version.pkg_arch)"
+"name": "$(cfengine_software.pkg_name)",
+"version": "$(cfengine_software.pkg_version)",
+"release": "$(cfengine_software.pkg_release)",
+"arch" "$(cfengine_software.pkg_arch)"
 }';
 }
 


### PR DESCRIPTION
The variables used to record the desired version were referencing the incorrect bundle name.