### PR TITLE
ENT-4158 Inventory Setuid Files

### DIFF
--- a/cfe_internal/CFE_cfengine.cf
+++ b/cfe_internal/CFE_cfengine.cf
@@ -14,7 +14,7 @@
 #  - some agent bundles are in CFE_hub_specific.cf
 #
 ##################################################################
-bundle agent cfe_internal_management_file_control
+bundle common cfe_internal_management_file_control
 {
   vars:
 


### PR DESCRIPTION
When the agent observes a file that is setuid it is logged to
`$(sys.workdir)/cfagent.$(hostname -f).log`.

This change introduces inventory for these observed files. For each file in the
log that is setuid inventory of that file is tagged with `setuid Files`.
Additionally separate inventory is done for each root owned setuid file as `root
owned setuid Files`. This policy also handles clearing of files that were once
setuid but are no longer found or are no longer setuid from the log since there
is no pre-existing automatic processes to clear entries from the log.

Changelog: Title