### PR TITLE
CFE-1743 Fix package_latest detecting larger version in some cases

### DIFF
--- a/lib/packages.cf
+++ b/lib/packages.cf
@@ -2044,7 +2044,7 @@ bundle agent package_latest(package)
     debian::
       "$(package)"
       package_policy => "addupdate",
-      package_version => "999999999",
+      package_version => "999999999:9999999999",
       package_method => apt_get_permissive;
 
     redhat::


### PR DESCRIPTION
According to Debian versioning
policy (https://www.debian.org/doc/debian-policy/ch-controlfields.html,
omitted. This way version '9999999999' is actually '0:9999999999' which is lower
than '1:0.0.1'. Please see attached patch which should correct this problem by
replacing '9999999999' with '999999999:9999999999'.

Changelog: Title

Thanks Egor.

(cherry picked from commit 5c927a73fd0b1cb48c94d096c7802faed0ae6e29)