### PR TITLE
CFE-2922 Avoid trying to read /proc/meminfo when it doesn't exist

### DIFF
--- a/cfe_internal/recommendations.cf
+++ b/cfe_internal/recommendations.cf
@@ -11,7 +11,9 @@ bundle agent postgresql_conf_reccomendations
     "pgsql_conf" string => "/var/cfengine/state/pg/data/postgresql.conf";
     "pgsql_conf" string => "/tmp/postgresql.conf";
     "mem_info_source" string => "/proc/meminfo";
-    "mem_info_data" data => data_readstringarray( $(mem_info_source), "", "(:|\s+)", inf, inf);
+      "mem_info_data"
+        data => data_readstringarray( $(mem_info_source), "", "(:|\s+)", inf, inf),
+        if => fileexists( $(mem_info_source) );
 
     "upper" string => "67108864"; # 64 * 1024 * 1024 in KB
     "lower" string => "3145728"; # 3 * 1024 * 1024 in KB


### PR DESCRIPTION
On hosts that this policy is not explicitly active on we see errors trying to
read the file because of pre-evaluation.

Changelog: Title
(cherry picked from commit df4d1ea59692834b28266b6d26035552fb7f5e7f)