### PR TITLE
CFE-2932 Detect systemd service enablement for non native services 3.10.x

### DIFF
--- a/lib/services.cf
+++ b/lib/services.cf
@@ -229,6 +229,8 @@ bundle agent standard_services(service,state)
 #
     systemd::
       "service_enabled" expression => reglist(@(systemd_service_info), "UnitFileState=enabled");
+      "service_enabled" -> { "CFE-2923" }
+        expression => returnszero( "$(call_systemctl) is-enabled $(service) > /dev/null 2>&1", useshell);
       "service_active"  expression => reglist(@(systemd_service_info), "ActiveState=active");
       "service_loaded"  expression => reglist(@(systemd_service_info), "LoadState=loaded");
       "service_notfound" expression => reglist(@(systemd_service_info), "LoadState=not-found");


### PR DESCRIPTION
Because non-native services have UnitFileState=bad we need an alternate way to
detect if the service is enabled or not. Since systemctl is-enabled
logs the fact that the service is not native to stderr, the probe must
be run in a shell and the output must be redirected to /dev/null or the
agent will output the information.

Changelog: Title
(cherry picked from commit a3b4260b81dae8a48b3dee55589616d6d47a82d9)