### PR TITLE
Add inventory of AWS EC2 linux instances

### DIFF
--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -546,6 +546,7 @@ bundle agent cfe_autorun_inventory_dmidecode
   "system-manufacturer": "System manufacturer",
   "system-version": "System version",
   "system-product-name": "System product name",
+  "system-uuid": "System UUID",
 }');
 
       # other dmidecode variables you may want:

--- a/inventory/aws.cf
+++ b/inventory/aws.cf
@@ -1,0 +1,21 @@
+bundle common inventory_aws
+# @brief inventory AWS EC2 instances
+#
+# Provides:
+#  ec2_instance class based on Amazon markers in dmidecode's system-uuid, bios-version or bios-vendor
+{
+  classes:
+    any::
+      "ec2_instance"
+        comment => "See http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/identify_ec2_instances.html",
+        or => {
+          regcmp("^[eE][cC]2.*", "$(cfe_autorun_inventory_dmidecode.dmi[system-uuid])"),
+          regcmp(".*[aA]mazon.*", "$(cfe_autorun_inventory_dmidecode.dmi[bios-version])"),
+          regcmp(".*[aA]mazon.*", "$(cfe_autorun_inventory_dmidecode.dmi[bios-vendor])")
+        };
+
+  reports:
+    (DEBUG|DEBUG_inventory_aws).ec2_instance
+      "DEBUG $(this.bundle)";
+      "$(const.t)+ec2_instance";
+}

--- a/promises.cf.in
+++ b/promises.cf.in
@@ -108,8 +108,8 @@ bundle common inventory
       "inputs" slist => { "inventory/any.cf", "inventory/freebsd.cf", "inventory/os.cf" };
       "bundles" slist => { "inventory_control", "inventory_any", "inventory_autorun", "inventory_freebsd", "inventory_os" };
     linux.!specific_linux_os::
-      "inputs" slist => { "inventory/any.cf", "inventory/linux.cf", "inventory/lsb.cf", "inventory/os.cf"};
-      "bundles" slist => { "inventory_control", "inventory_any", "inventory_autorun", "inventory_linux", "inventory_lsb", "inventory_os" };
+      "inputs" slist => { "inventory/any.cf", "inventory/linux.cf", "inventory/lsb.cf", "inventory/os.cf", "inventory/aws.cf" };
+      "bundles" slist => { "inventory_control", "inventory_any", "inventory_autorun", "inventory_linux", "inventory_lsb", "inventory_os", "inventory_aws" };
     aix::
       "inputs" slist => { "inventory/any.cf", "inventory/generic.cf", "inventory/aix.cf", "inventory/os.cf" };
       "bundles" slist => { "inventory_control", "inventory_any", "inventory_autorun", "inventory_generic", "inventory_aix", "inventory_os" };


### PR DESCRIPTION
(Windows EC2 instances can be recognized another way -- this
commit deals with Linux EC2 instances only.)

This code was implemented by @mikeweilgart 

