### PR TITLE
CFE-2925 Add 'system-uuid' to default dmidecode inventory

### DIFF
--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -477,6 +477,7 @@ bundle agent cfe_autorun_inventory_dmidecode
   "system-manufacturer": "System manufacturer",
   "system-version": "System version",
   "system-product-name": "System product name",
+  "system-uuid": "System UUID",
 }');
 
       # other dmidecode variables you may want:


### PR DESCRIPTION
This inventory attribtue can be useful in identification of AWS EC2
systems, as well as providing an additional way for detecting duplicate host identity.

ChangeLog: Title
(cherry picked from commit 6935a10e2f5292929a45263e6ab6a1ec75d39796)