### PR TITLE
CFE-2927 Override dmidecode inventory attributes via augments

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -388,6 +388,40 @@ hosts.
 The following settings are defined in `controls/def.cf` can be set from an
 [augments file][Augments].
 
+### dmidecode inventory
+
+When dmidecode is present, some key system attributes are inventoried. The
+inventoried attributes can be overridden by defining
+`def.cfe_autorun_inventory_demidecode[dmidefs]` via augments. dmidecode queries
+each key in dmidefs and tags the result with the value prefixed with
+`attribute_name=` Note, as the dmidefs are overridden, you must supply all
+desired inventory attributes.
+
+For example:
+
+```json
+{
+  "vars": {
+    "cfe_autorun_inventory_dmidecode": {
+      "dmidefs": {
+        "bios-vendor": "BIOS vendor",
+        "bios-version": "BIOS version",
+        "system-serial-number": "System serial number",
+        "system-manufacturer": "System manufacturer",
+        "system-version": "System version",
+        "system-product-name": "System product name",
+        "bios-release-date": "BIOS release date",
+        "chassis-serial-number": "Chassis serial number",
+        "chassis-asset-tag": "Chassis asset tag",
+        "baseboard-asset-tag": "Baseboard asset tag"
+      }
+    }
+  }
+}
+```
+
+**History:**
+- Introduced 3.13.0, 3.12.1, 3.10.5
 
 ### mailto
 

--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -549,6 +549,12 @@ bundle agent cfe_autorun_inventory_dmidecode
   "system-uuid": "System UUID",
 }');
 
+      # We override dmidefs from augments when we can.
+
+      "dmidefs" -> { "CFE-2927" }
+        data => mergedata( "def.cfe_autorun_inventory_dmidecode[dmidefs]" ),
+        if => isvariable( "def.cfe_autorun_inventory_dmidecode[dmidefs]");
+
       # other dmidecode variables you may want:
       # baseboard-asset-tag
       # baseboard-manufacturer


### PR DESCRIPTION
Want to inventory another dmidecode attribute?

Instead of modifying the vendored policy, define dmidefs in augments.

For example:

```
{
  "vars": {
    "cfe_autorun_inventory_dmidecode": {
      "dmidefs": {
        "bios-vendor": "BIOS vendor",
        "bios-version": "BIOS version",
        "system-serial-number": "System serial number",
        "system-manufacturer": "System manufacturer",
        "system-version": "System version",
        "system-product-name": "System product name",
        "system-uuid": "System UUID",
        "bios-release-date": "Bios release date",
        "chassis-serial-number": "Chassis serial number",
        "chassis-asset-tag": "Chassis asset tag",
        "baseboard-asset-tag": "Baseboard asset tag"
      }
    }
  }
}
```

DEBUG run output:

```
[root@hub masterfiles]# cf-agent -KID DEBUG_cfe_autorun_inventory_dmidecode
R: DEBUG cfe_autorun_inventory_dmidecode: Obtained BIOS vendor = 'innotek GmbH'
R: DEBUG cfe_autorun_inventory_dmidecode: Obtained BIOS version = 'VirtualBox'
R: DEBUG cfe_autorun_inventory_dmidecode: Obtained System serial number = '0'
R: DEBUG cfe_autorun_inventory_dmidecode: Obtained System manufacturer = 'innotek GmbH'
R: DEBUG cfe_autorun_inventory_dmidecode: Obtained System version = '1.2'
R: DEBUG cfe_autorun_inventory_dmidecode: Obtained System product name = 'VirtualBox'
R: DEBUG cfe_autorun_inventory_dmidecode: Obtained System UUID = '5CA32EC5-7D53-49AA-AAEF-2B4502D34844'
R: DEBUG cfe_autorun_inventory_dmidecode: Obtained Bios release date = '12/01/2006'
R: DEBUG cfe_autorun_inventory_dmidecode: Obtained Chassis serial number = 'Not Specified'
R: DEBUG cfe_autorun_inventory_dmidecode: Obtained Chassis asset tag = 'Not Specified'
R: DEBUG cfe_autorun_inventory_dmidecode: Obtained Baseboard asset tag = 'Not Specified'
```