### PR TITLE
CFE-2927 Allow dmidefs inventory to be overridden via augments

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -388,6 +388,40 @@ hosts.
 The following settings are defined in `controls/def.cf` can be set from an
 [augments file][Augments].
 
+### dmidecode inventory
+
+When dmidecode is present, some key system attributes are inventoried. The
+inventoried attributes can be overridden by defining
+`def.cfe_autorun_inventory_demidecode[dmidefs]` via augments. dmidecode queries
+each key in dmidefs and tags the result with the value prefixed with
+`attribute_name=` Note, as the dmidefs are overridden, you must supply all
+desired inventory attributes.
+
+For example:
+
+```json
+{
+  "vars": {
+    "cfe_autorun_inventory_dmidecode": {
+      "dmidefs": {
+        "bios-vendor": "BIOS vendor",
+        "bios-version": "BIOS version",
+        "system-serial-number": "System serial number",
+        "system-manufacturer": "System manufacturer",
+        "system-version": "System version",
+        "system-product-name": "System product name",
+        "bios-release-date": "BIOS release date",
+        "chassis-serial-number": "Chassis serial number",
+        "chassis-asset-tag": "Chassis asset tag",
+        "baseboard-asset-tag": "Baseboard asset tag"
+      }
+    }
+  }
+}
+```
+
+**History:**
+- Introduced 3.13.0, 3.12.1, 3.10.5
 
 ### mailto
 

--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -480,6 +480,12 @@ bundle agent cfe_autorun_inventory_dmidecode
   "system-uuid": "System UUID",
 }');
 
+      # We override dmidefs from augments when we can.
+
+      "dmidefs" -> { "CFE-2927" }
+        data => mergedata( "def.cfe_autorun_inventory_dmidecode[dmidefs]" ),
+        if => isvariable( "def.cfe_autorun_inventory_dmidecode[dmidefs]");
+
       # other dmidecode variables you may want:
       # baseboard-asset-tag
       # baseboard-manufacturer


### PR DESCRIPTION
This change allows uses to override the default dmidecode attributes that are
inventoried via augments. Being able to extend the inventoried attributes allows
for more flexibility without having to maintain modifications to the vendored
policy.
