### PR TITLE
ENT-4177: Updated yum package module to take arbitrary options

### DIFF
--- a/modules/packages/yum
+++ b/modules/packages/yum
@@ -103,13 +103,15 @@ def list_installed():
 
 
 def list_updates(online):
+    global yum_options
     for line in sys.stdin:
         line = line.strip()
         if line.startswith("options="):
             option = line[len("options="):]
-            if option.startswith("enablerepo=") or option.startswith("disablerepo="):
-                global yum_options
-                yum_options += ["--" + option]
+            if option.startswith("-"):
+                yum_options.append(option)
+            elif option.startswith("enablerepo=") or option.startswith("disablerepo="):
+                yum_options.append("--" + option)
 
     online_flag = []
     if not online:
@@ -215,9 +217,10 @@ def package_arguments_builder(is_yum_install):
         line = line.strip()
         if line.startswith("options="):
             option = line[len("options="):]
-            if option.startswith("enablerepo=") or option.startswith("disablerepo="):
-                global yum_options
-                yum_options += ["--" + option]
+            if option.startswith("-"):
+                yum_options.append(option)
+            elif option.startswith("enablerepo=") or option.startswith("disablerepo="):
+                yum_options.append("--" + option)
         if line.startswith("Name="):
             if name:
                 # Each new "Name=" triggers a new entry.


### PR DESCRIPTION
Example:
```
[root@hub vagrant]# nano
bash: /bin/nano: No such file or directory
[root@hub vagrant]# cat test.cf
body file control {
  inputs => {"/var/cfengine/inputs/lib/stdlib.cf"};
}

bundle agent main {
  packages:
    "nano"
      policy => "present",
      package_module => yum,
      architecture => "x86_64",
      options => { "--setopt=tsflags=nodocs" };
}
[root@hub vagrant]# cf-agent -f ./test.cf -IC -K
    info: Successfully installed package 'nano'
[root@hub vagrant]# man nano
No manual entry for nano
[root@hub vagrant]# 
```