### PR TITLE
Remove call to undefined bundle

### DIFF
--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -72,11 +72,6 @@ bundle agent inventory_autorun
       "aws" usebundle => cfe_autorun_inventory_aws_ec2_metadata(),
         handle => "cfe_internal_autorun_inventory_ec2_metadata";
 
-    !disable_inventory_setuid::
-      "Inventory SetUID Files" -> { "ENT-4158" }
-        usebundle => cfe_autorun_inventory_setuid(),
-        handle => "cfe_internal_autorun_inventory_setuid";
-
     any::
       "listening ports" usebundle => cfe_autorun_inventory_listening_ports(),
       handle => "cfe_internal_autorun_listening_ports";


### PR DESCRIPTION
This inventory is not present in 3.12.x. It belongs to the Security
inventory category that is first introduced in Mission Portal in 3.13.0.

Changelog: None