### PR TITLE
CFE-2932 Update policy can now skip local copy optimization on policy servers

### DIFF
--- a/cfe_internal/update/update_policy.cf
+++ b/cfe_internal/update/update_policy.cf
@@ -296,10 +296,11 @@ body copy_from u_rcp(from,server)
       trustkey    => "false";
 
 
-    !am_policy_hub::
+      # CFE-2932 For testing, we want to be able to avoid this local copy optimiztion
+    !am_policy_hub|mpf_skip_local_copy_optimizaton::
       servers => { "$(server)" };
 
-    !am_policy_hub.sys_policy_hub_port_exists::
+    !am_policy_hub.(sys_policy_hub_port_exists|mpf_skip_local_copy_optimization)::
       portnumber => "$(sys.policy_hub_port)";
 
     cfengine_internal_encrypt_transfers::


### PR DESCRIPTION
Changelog: Title

Policy servers avoid making a local connection to cf-serverd during policy
updates. cf-serverd is not always running, so this allows policy updates for the
hub itself, even when cf-serverd is not available (like during bootstrap). For
testing it is desirable to be able to excercise network access over the local
network. With this change if the mpf_skip_local_copy_optimization class is
defined, then policy update will happen over the local network.