### PR TITLE
Ent 4190 hub license usage logging performance

### DIFF
--- a/cfe_internal/enterprise/CFE_hub_specific.cf
+++ b/cfe_internal/enterprise/CFE_hub_specific.cf
@@ -374,7 +374,7 @@ bundle agent log_cfengine_enterprise_license_utilization
 # @brief Log the number of hosts seen within the last 24 hours and the number of
 # hosts reported to have the "cfengine" class. Note any hosts that has been
 # successfully collected from is expected to have the "cfengine" class. This
-# policy will not do anything unless the class
+# bundle will not be called unless the class
 # `enable_log_cfengine_enterprise_license_utilization` is defined.
 {
   reports:
@@ -387,7 +387,7 @@ bundle agent log_cfengine_enterprise_license_utilization
 
       "log_frequency" int => "720";
 
-    policy_server.enterprise_edition.enable_log_cfengine_enterprise_license_utilization::
+    policy_server.enterprise_edition::
 
       "log_dir" string => "$(sys.workdir)/log";
 
@@ -405,23 +405,20 @@ bundle agent log_cfengine_enterprise_license_utilization
 
   files:
 
-    policy_server.enterprise_edition.enable_log_cfengine_enterprise_license_utilization::
+    policy_server.enterprise_edition::
       "$(log_dir)/."
         create => "true",
         comment => "The log dir must exist in order to write to a file.";
 
   reports:
 
-    policy_server.enterprise_edition.enable_log_cfengine_enterprise_license_utilization::
+    policy_server.enterprise_edition::
 
       "$(sys.date), hosts_reporting=$(count_reporting), hosts_seen=$(count_seen)"
         report_to_file => "$(sys.workdir)/log/license_utilization.log",
         if => not("cfe_internal_logged_utilization"),
         classes => cfe_internal_log_utilization($(log_frequency));
 
-    policy_server.enterprise_edition.!enable_log_cfengine_enterprise_license_utilization::
-
-      "WARNING $(this.bundle) is actuated but not enabled. enable_$(this.bundle) is not defined.";
 }
 
 bundle agent cfe_internal_enterprise_maintenance

--- a/cfe_internal/enterprise/CFE_hub_specific.cf
+++ b/cfe_internal/enterprise/CFE_hub_specific.cf
@@ -379,7 +379,7 @@ bundle agent log_cfengine_enterprise_license_utilization
 {
   reports:
 
-    policy_server.enterprise_edition.(DEBUG|DEBUG_log_cfengine_enterprise_license_utilization|inform_mode)::
+    policy_server.enterprise_edition.DEBUG_log_cfengine_enterprise_license_utilization::
 
       "Hosts reported: $(count_reporting)";
 
@@ -389,7 +389,7 @@ bundle agent log_cfengine_enterprise_license_utilization
 
       "log_dir" string => "$(sys.workdir)/log";
 
-    policy_server.enterprise_edition.(DEBUG|DEBUG_log_cfengine_enterprise_license_utilization|inform_mode|!cfe_internal_logged_utilization)::
+    policy_server.enterprise_edition.(DEBUG_log_cfengine_enterprise_license_utilization|!cfe_internal_logged_utilization)::
 
       "log_frequency" int => "720";
 

--- a/cfe_internal/enterprise/CFE_hub_specific.cf
+++ b/cfe_internal/enterprise/CFE_hub_specific.cf
@@ -385,11 +385,13 @@ bundle agent log_cfengine_enterprise_license_utilization
 
   vars:
 
-      "log_frequency" int => "720";
-
     policy_server.enterprise_edition::
 
       "log_dir" string => "$(sys.workdir)/log";
+
+    policy_server.enterprise_edition.(DEBUG|DEBUG_log_cfengine_enterprise_license_utilization|inform_mode|!cfe_internal_logged_utilization)::
+
+      "log_frequency" int => "720";
 
       # Using address for reporting hosts because hostseen() will incur
       # undesirable reverse dns lookups if name is used
@@ -412,11 +414,10 @@ bundle agent log_cfengine_enterprise_license_utilization
 
   reports:
 
-    policy_server.enterprise_edition::
+    policy_server.enterprise_edition.!cfe_internal_logged_utilization::
 
       "$(sys.date), hosts_reporting=$(count_reporting), hosts_seen=$(count_seen)"
         report_to_file => "$(sys.workdir)/log/license_utilization.log",
-        if => not("cfe_internal_logged_utilization"),
         classes => cfe_internal_log_utilization($(log_frequency));
 
 }

--- a/cfe_internal/enterprise/main.cf
+++ b/cfe_internal/enterprise/main.cf
@@ -38,6 +38,7 @@ bundle agent cfe_internal_enterprise_main
 
       "hub" -> { "ENT-3186" }
         usebundle => log_cfengine_enterprise_license_utilization,
+        unless => "cfe_internal_logged_utilization",
         handle => "log_cfengine_enterprise_license_utilization",
         comment => "Log license utilization information";
 

--- a/cfe_internal/enterprise/main.cf
+++ b/cfe_internal/enterprise/main.cf
@@ -38,7 +38,6 @@ bundle agent cfe_internal_enterprise_main
 
       "hub" -> { "ENT-3186" }
         usebundle => log_cfengine_enterprise_license_utilization,
-        unless => "cfe_internal_logged_utilization",
         handle => "log_cfengine_enterprise_license_utilization",
         comment => "Log license utilization information";
 


### PR DESCRIPTION
This is exactly the same as PR #1235 but with the branch renamed and the changelog line added to the last commit message as per Nick Anderson's request.