### PR TITLE
CFE-2905 An improved autorun methodology

### DIFF
--- a/lib/autorun.cf
+++ b/lib/autorun.cf
@@ -7,15 +7,56 @@ bundle agent autorun
 {
   vars:
     services_autorun::
-      "bundles" slist => bundlesmatching(".*", "autorun");
+@if minimum_version(3.11)
+      "services_prefixed_classes"
+        slist => classesmatching( "services_.*" );
+      # For backwards compatibility during upgrades, this must be guarded
+      # because the with attribute is used.
 
-      "sorted_bundles"
-        slist => sort("bundles", "lex"),
+      "services_autorun_input[$(with)]" -> { "CFE-2905" }
+        string => "$(sys.workdir)/inputs/services/$(with)/$(sys.policy_entry_basename)",
+        with => nth(string_split( "$(services_prefixed_classes)", "_", 2), 1),
+        if => fileexists( "$(sys.workdir)/inputs/services/$(with)/$(sys.policy_entry_basename)" );
+
+      # Both yaml and json formatted control files are supported.
+
+      "data_$(bundles)"
+        data => readyaml( "$(sys.workdir)/inputs/services/$(bundles)/control.yaml"),
+        if => fileexists( "$(sys.workdir)/inputs/services/$(bundles)/control.yaml" );
+
+      "data_$(bundles)"
+        data => readjson( "$(sys.workdir)/inputs/services/$(bundles)/control.json"),
+        if => fileexists( "$(sys.workdir)/inputs/services/$(bundles)/control.json");
+
+      # This is each directory inside services that has a matching policy entry
+      # e.g. services/example/promises.cf then the list would have an element
+      # matching example.
+      "services_autorun_policies"
+        slist => getindices( services_autorun_input );
+@endif
+
+      "bundles_tagged_autorun"
+        slist => bundlesmatching(".*", "autorun");
+
+      "sorted_autorun_bundles"
+        slist => sort("bundles_tagged_autorun", "lex"),
         comment => "Lexicographically sorted bundles for predictable order";
+
+      "sorted_services_autorun_policies"
+        slist => sort("services_autorun_bundles", "lex"),
+        comment => "Lexicographically sorted bundles for predictable order";
+
 
   methods:
     services_autorun::
       "autorun" usebundle => $(sorted_bundles);
+
+@if minimum_version(3.11)
+      # This is guarded because the variables it depends on are also guarded above
+    "services_$(sorted_bundles)"::
+      "Run $(sorted_bundles)" -> { "CFE-2905" }
+        usebundle => "$(_services_loader.data_$(sorted_bundles)[$(sys.policy_entry_basename)][namespace]):$(_services_loader.data_$(sorted_bundles)[$(sys.policy_entry_basename)][bundle])";
+@endif
 
   reports:
     DEBUG|DEBUG_autorun|DEBUG_services_autorun::

--- a/lib/autorun.cf
+++ b/lib/autorun.cf
@@ -20,13 +20,13 @@ bundle agent autorun
 
       # Both yaml and json formatted control files are supported.
 
-      "data_$(bundles)"
-        data => readyaml( "$(sys.workdir)/inputs/services/$(bundles)/control.yaml"),
-        if => fileexists( "$(sys.workdir)/inputs/services/$(bundles)/control.yaml" );
+      "data_$(services_prefixed_classes)"
+        data => readyaml( "$(sys.workdir)/inputs/services/$(services_prefixed_classes)/control.yaml"),
+        if => fileexists( "$(sys.workdir)/inputs/services/$(services_prefixed_classes)/control.yaml" );
 
-      "data_$(bundles)"
-        data => readjson( "$(sys.workdir)/inputs/services/$(bundles)/control.json"),
-        if => fileexists( "$(sys.workdir)/inputs/services/$(bundles)/control.json");
+      "data_$(services_prefixed_classes)"
+        data => readjson( "$(sys.workdir)/inputs/services/$(services_prefixed_classes)/control.json"),
+        if => fileexists( "$(sys.workdir)/inputs/services/$(services_prefixed_classes)/control.json");
 
       # This is each directory inside services that has a matching policy entry
       # e.g. services/example/promises.cf then the list would have an element
@@ -49,13 +49,13 @@ bundle agent autorun
 
   methods:
     services_autorun::
-      "autorun" usebundle => $(sorted_bundles);
+      "autorun" usebundle => $(sorted_autorun_bundles);
 
 @if minimum_version(3.11)
       # This is guarded because the variables it depends on are also guarded above
-    "services_$(sorted_bundles)"::
-      "Run $(sorted_bundles)" -> { "CFE-2905" }
-        usebundle => "$(_services_loader.data_$(sorted_bundles)[$(sys.policy_entry_basename)][namespace]):$(_services_loader.data_$(sorted_bundles)[$(sys.policy_entry_basename)][bundle])";
+    "services_$(sorted_services_autorun_policies)"::
+      "Run $(sorted_services_autorun_policies)" -> { "CFE-2905" }
+        usebundle => "$(_services_loader.data_$(sorted_services_autorun_policies)[$(sys.policy_entry_basename)][namespace]):$(_services_loader.data_$(sorted_services_autorun_policies)[$(sys.policy_entry_basename)][bundle])";
 @endif
 
   reports:


### PR DESCRIPTION
Until now, when the class `services_autorun` was defined, files in `services/autorun` ending in `.cf` were added to inputs, and any bundles found tagged with `autorun` were executed in lexical order.

This change brings a new methodology that better allows for polices needing more than a single asset.

Now, when `services_autorun` is defined, the services directory will be searched one level deep for directories named `policy` that contains a policy file matching the current entries name. Those matching files will be added to inputs. Bundle execution is controlled by a control.yaml or control.json file in the root of the subdirectory which contains keys matching the expected entries name, and subkeys for the namespace and bundle name to execute. These bundles are executed in lexical order of the directories name.

For example, given the following files:

- `services/beta/control.json`
- `services/beta/policy/example.cf`
- `services/alpha/control.json`
- `services/alpha/policy/promises.cf`

When the default policy is executed (`/var/cfengine/inputs/promises.cf`) with `services_autorun` defined, `services/alpha/policy/promises.cf` will be added to inputs.

Given the following `services/alpha/control.json`:

```
{ 
  "promises.cf": { 
    "namespace": "default",
    "bundle": "alpha_main"
  }
}
```

The bundle `alpha_main` in the `default` namespace will be automatically executed.

Changelog: Title