### PR TITLE
ENT-4100 Make runalerts quiet during normal operation

### DIFF
--- a/cfe_internal/enterprise/templates/runalerts.php.mustache
+++ b/cfe_internal/enterprise/templates/runalerts.php.mustache
@@ -9,11 +9,15 @@ if(PHP_SAPI != 'cli')
 
 while(1 == 1)
 {
-  print("Checking for sql alerts");
+  status=0;
   touch ('{{{vars.cfe_internal_php_runalerts.runalerts_stampfiles_dir}}}/runalerts_sql');
-  passthru('{{{vars.sys.workdir}}}/httpd/php/bin/php {{{vars.sys.workdir}}}/httpd/htdocs/index.php cli_tasks runalerts {{{vars.cfe_internal_php_runalerts.sql[limit]}}} {{{vars.cfe_internal_php_runalerts.sql[running]}}} sql');
+  passthru('{{{vars.sys.workdir}}}/httpd/php/bin/php {{{vars.sys.workdir}}}/httpd/htdocs/index.php cli_tasks runalerts {{{vars.cfe_internal_php_runalerts.sql[limit]}}} {{{vars.cfe_internal_php_runalerts.sql[running]}}} sql', $status);
 
-  print("Sleeping for {{{vars.cfe_internal_php_runalerts.sleep_time}}} seconds");
+  if ($status != 0){
+    print("Error executing cli_task runalerts sql");
+    print("Sleeping for {{{vars.cfe_internal_php_runalerts.sleep_time}}} seconds");
+  }
+
   sleep({{{vars.cfe_internal_php_runalerts.sleep_time}}});
 }
 ?>


### PR DESCRIPTION
These frequent log messages add up in large environments, we only want to log information when there is a problem.

Changelog: None