### PR TITLE
ENT-4235 Make runalerts quiet during normal operation 3.10.x

### DIFF
--- a/cfe_internal/enterprise/templates/runalerts.php.mustache
+++ b/cfe_internal/enterprise/templates/runalerts.php.mustache
@@ -9,15 +9,24 @@ if(PHP_SAPI != 'cli')
 
 while(1 == 1)
 {
-  print("Checking for sql alerts");
+  $sqlstatus=0;
   touch ('{{{vars.cfe_internal_php_runalerts.runalerts_stampfiles_dir}}}/runalerts_sql');
-  passthru('{{{vars.sys.workdir}}}/httpd/php/bin/php {{{vars.sys.workdir}}}/httpd/htdocs/index.php cli_tasks runalerts {{{vars.cfe_internal_php_runalerts.sql[limit]}}} {{{vars.cfe_internal_php_runalerts.sql[running]}}} sql');
+  passthru('{{{vars.sys.workdir}}}/httpd/php/bin/php {{{vars.sys.workdir}}}/httpd/htdocs/index.php cli_tasks runalerts {{{vars.cfe_internal_php_runalerts.sql[limit]}}} {{{vars.cfe_internal_php_runalerts.sql[running]}}} sql', $sqlstatus);
 
-  print("Checking for sketch alerts");
+  if ($sqlstatus != 0){
+    print("Error executing cli_task runalerts sql");
+    print("Sleeping for {{{vars.cfe_internal_php_runalerts.sleep_time}}} seconds");
+  }
+
+  $sketchstatus=0;
   touch('{{{vars.cfe_internal_php_runalerts.runalerts_stampfiles_dir}}}/runalerts_sketch');
-  passthru('{{{vars.sys.workdir}}}/httpd/php/bin/php {{{vars.sys.workdir}}}/httpd/htdocs/index.php cli_tasks runalerts {{{vars.cfe_internal_php_runalerts.sketch[limit]}}} {{{vars.cfe_internal_php_runalerts.sketch[running]}}} sketch');
+  passthru('{{{vars.sys.workdir}}}/httpd/php/bin/php {{{vars.sys.workdir}}}/httpd/htdocs/index.php cli_tasks runalerts {{{vars.cfe_internal_php_runalerts.sketch[limit]}}} {{{vars.cfe_internal_php_runalerts.sketch[running]}}} sketch', $sketchstatus);
 
-  print("Sleeping for {{{vars.cfe_internal_php_runalerts.sleep_time}}} seconds");
+  if ($sketchstatus != 0){
+    print("Error executing cli_task runalerts sketch");
+    print("Sleeping for {{{vars.cfe_internal_php_runalerts.sleep_time}}} seconds");
+  }
+
   sleep({{{vars.cfe_internal_php_runalerts.sleep_time}}});
 }
 ?>


### PR DESCRIPTION
These frequent log messages add up in large environments, we only want to log
information when there is a problem.
