### PR TITLE
Fix an example of setting control_hub_hub_schedule to be a valid JSON

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -677,7 +677,7 @@ Here we set the schedule to initiate pull collection once every 30 minutes via a
 ```
 {
   "vars": {
-    "control_hub_hub_schedule": { "Min00", "Min30" }
+    "control_hub_hub_schedule": [ "Min00", "Min30" ]
   }
 }
 ```


### PR DESCRIPTION
Otherwise it fails to parse.