### PR TITLE
Check if port exists before attempting to uninstall it on FreeBSD

### DIFF
--- a/modules/packages/freebsd_ports
+++ b/modules/packages/freebsd_ports
@@ -75,8 +75,17 @@ Architecture=none/'
 
 remove() {
   name="${INPUT_Name?Name must be given to remove}"
-  BATCH=1
-  cd $(whereis -sq "$name")
+  export BATCH=1
+
+  PORT_PATH=$(whereis -sq "$name")
+
+  if [ -z "$PORT_PATH" ]
+  then
+    echo "ErrorMessage=Could not remove $name, port does not exist"
+    exit 0
+  fi
+
+  cd "$PORT_PATH"
   make deinstall >&2
 }
 


### PR DESCRIPTION
Something I had sitting around in my own version of this package, doing some spring cleaning :)

Provide a meaningful error message if the `whereis` check returns nothing (i.e. port not found) rather than a meaningless message from make.