### PR TITLE
[3.12.x] Fix an example of setting control_hub_hub_schedule to be a valid JSON

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -726,7 +726,7 @@ Here we set the schedule to initiate pull collection once every 30 minutes via a
 ```
 {
   "vars": {
-    "control_hub_hub_schedule": { "Min00", "Min30" }
+    "control_hub_hub_schedule": [ "Min00", "Min30" ]
   }
 }
 ```


### PR DESCRIPTION
Otherwise it fails to parse.

(cherry picked from commit f60fb1535af53ebc26d5b219c139ca8cd2419002)