### PR TITLE
CFE-2953 - fix isvariable syntax error in update_def.cf

### DIFF
--- a/controls/update_def.cf.in
+++ b/controls/update_def.cf.in
@@ -141,7 +141,7 @@ bundle common update_def
       "mpf_update_policy_master_location" -> { "ENT-3692" }
         comment => "Directory where clients should get policy from.",
         string => "$(def.mpf_update_policy_master_location)",
-        if => isvariable( $(def.mpf_update_policy_master_location) );
+        if => isvariable( "def.mpf_update_policy_master_location" );
 
     # enable_cfengine_enterprise_hub_ha is defined below
     # Disabled by default


### PR DESCRIPTION
This error prevents pulling policy updates from from def.mpf_update_policy_master_location:

if => isvariable( $(def.mpf_update_policy_master_location) );

should be:

if => isvariable( "def.mpf_update_policy_master_location" );

(cherry picked from commit ca8222ed9067b681a624ede58dcea03458e407df)