### PR TITLE
ENT-4333 Prevent performance overhead on hubs that don't enable license utilization logging

### DIFF
--- a/cfe_internal/enterprise/CFE_hub_specific.cf
+++ b/cfe_internal/enterprise/CFE_hub_specific.cf
@@ -392,7 +392,7 @@ bundle agent log_cfengine_enterprise_license_utilization
 
       "log_dir" string => "$(sys.workdir)/log";
 
-    policy_server.enterprise_edition.(DEBUG_log_cfengine_enterprise_license_utilization|!cfe_internal_logged_utilization)::
+    policy_server.enterprise_edition.enable_log_cfengine_enterprise_license_utilization.(DEBUG_log_cfengine_enterprise_license_utilization|!cfe_internal_logged_utilization)::
 
       "log_frequency" int => "720";
 


### PR DESCRIPTION
…ense utilization logging

This is a fixup of pull request #1248 which was already merged to master.

Prior to #1248, any CFEngine Hub which had license utilization logging
enabled would call the expensive "hostswithclass()" and "hostsseen()"
functions during every agent run, even though the results are only
needed once every 12 hours.

In #1248, I fixed things up so that a 12 hour persistent class would be
set to indicate that the logging had been done, so that the hub would
not make these expensive function calls.

However in reviewing this code in light of a recently observed
performance problem, I found that I made a mistake in #1248 such that
any enterprise hub where the license utilization logging was NOT
enabled, would, during every run, make the function calls to
"hostswithclass()" and "hostsseen()".  This is a bug.

The function calls take time roughly proportional to how many host
records are present in the enterprise database, so the difference (the
performance impact) would not be noticed on a small hub.  Only with
thousands and thousands of hosts will the difference be noted - and then
only if license utilization logging is *not* enabled (since the
performance hit will only occur every 12 hours if the logging *is*
enabled, and this hit is unavoidable).

Fixing this is a simple matter of guarding those function calls with the
'enabled' class for license utilization logging (but still leaving in
place the part of the guard that's the negation of the persistent class
already added in #1248).  This commit does just that so that any hubs
where the license utilization is not enabled, won't ever run these
unnecessary function calls.