### PR TITLE
ENT-4331 Fix status table name

### DIFF
--- a/lib/cfe_internal_hub.cf
+++ b/lib/cfe_internal_hub.cf
@@ -204,8 +204,8 @@ bundle agent cfe_internal_database_cleanup_consumer_status (row_count)
   vars:
 
       "status_table_name" -> { "ENT-4331" }
-        string => ifelse( eval( "$(sys.cf_version) < 3.12.1", class, infix ), "__status",
-                          "status"),
+        string => ifelse( eval( "$(sys.cf_version) < 3.12.2", class, infix ), "status",
+                          "__status"),
         comment => "This is important for handling the current name of the status table for proper cleanup.";
 
       "remove_query"


### PR DESCRIPTION
The status table name was reversed for the version of policy

Changelog: None