### PR TITLE
Improve efficiency and error handling of user specified policy update bundle

### DIFF
--- a/cfe_internal/update/update_policy.cf
+++ b/cfe_internal/update/update_policy.cf
@@ -30,7 +30,12 @@ bundle agent cfe_internal_update_policy
       # (otherwise we may get an error about undefined bundle)
 
       "have_found_user_specified_update_bundle"
-        expression  => isgreaterthan( 0, length( "found_matching_user_specified_bundle" ) );
+        expression  => some(".*", "found_matching_user_specified_bundle");
+
+      "missing_user_specified_update_bundle"
+       not  => some(".*", "found_matching_user_specified_bundle");
+
+
 
   vars:
       "default_policy_update_bundle" string => "cfe_internal_update_policy_cpv";
@@ -69,7 +74,9 @@ bundle agent cfe_internal_update_policy
 
       "User specified update bundle MISSING! Falling back to $(default_policy_update_bundle)."
         if => and( "have_user_specified_update_bundle",
-                   not( "have_found_user_specified_update_bundle" ));
+                   "missing_user_specified_update_bundle"
+                  );
+
 
 }
 


### PR DESCRIPTION
Changelog: Title

Fix MPF reporting both "found" and "missing" regarding the user-defined
update policy bundle.

First, note that
https://docs.cfengine.com/docs/3.10/reference-functions-some.html says:

> It's convenient to set a class to not => some(".*", mylist) in order to
> check if mylist is empty. Since some() returns as soon as possible, that
> is better than using length() or every() or none() which must traverse
> the entire list.

So I switched to some().

Second, let's stop relying on negative knowledge (absense of "found"
class) and instead rely on positive knowledge only ("found" class
for if found; and "missing" class for if missing).

(cherry picked from commit 26eb50bd827e88041fac2c90b026f781e79d9055)