### PR TITLE
ENT-4365: Change cleanup consumer status SQL query

### DIFF
--- a/lib/cfe_internal_hub.cf
+++ b/lib/cfe_internal_hub.cf
@@ -149,7 +149,7 @@ bundle agent cfe_internal_hub_maintain
       action => if_elapsed_day;
 
       "Remove cf-consumer history"
-      usebundle => cfe_internal_database_cleanup_consumer_status("50000"),
+      usebundle => cfe_internal_database_cleanup_consumer_status("3"),
       action => if_elapsed_day;
 
       "Remove diagnostics history"
@@ -203,7 +203,7 @@ bundle agent cfe_internal_database_cleanup_consumer_status (row_count)
 
   vars:
       "remove_query"
-      string => "DELETE FROM status WHERE ts IN (SELECT ts FROM status ORDER BY ts DESC OFFSET $(row_count));";
+      string => "SELECT * FROM cleanup_historical_data('__status', 'ts', $(row_count), 'host');";
 
   commands:
       "$(sys.bindir)/psql cfdb -c \"$(remove_query)\""


### PR DESCRIPTION
Changelog: Title
Use a new cleanup_historical_data SQL function that keeps a specified number of items for a host