### PR TITLE
ENT-4365: Change cleanup consumer status SQL query

### DIFF
--- a/lib/cfe_internal_hub.cf
+++ b/lib/cfe_internal_hub.cf
@@ -216,15 +216,16 @@ bundle agent cfe_internal_database_cleanup_consumer_status (row_count)
       "status_table_name" -> { "ENT-4331" }
         string => "__status";
 
-      # This is the fallback query to use in case the cleanup_historical_data
-      # function is not present.
-      "remove_query" -> { "ENT-4365" }
-        string => "DELETE FROM $(status_table_name) WHERE ts IN (SELECT ts FROM $(status_table_name) ORDER BY ts DESC OFFSET 50000);";
-
     cfengine_3_7|cfengine_3_10|cfengine_3_12_0|cfengine_3_12_1::
 
       "status_table_name" -> { "ENT-4331" }
         string => "status";
+
+    any::
+      # This is the fallback query to use in case the cleanup_historical_data
+      # function is not present.
+      "remove_query" -> { "ENT-4365" }
+        string => "DELETE FROM $(status_table_name) WHERE ts IN (SELECT ts FROM $(status_table_name) ORDER BY ts DESC OFFSET 50000);";
 
     has_sql_function_cleanup_historical_data::
 

--- a/lib/cfe_internal_hub.cf
+++ b/lib/cfe_internal_hub.cf
@@ -149,7 +149,7 @@ bundle agent cfe_internal_hub_maintain
       action => if_elapsed_day;
 
       "Remove cf-consumer history"
-      usebundle => cfe_internal_database_cleanup_consumer_status("50000"),
+      usebundle => cfe_internal_database_cleanup_consumer_status("3"),
       action => if_elapsed_day;
 
       "Remove diagnostics history"
@@ -216,7 +216,7 @@ bundle agent cfe_internal_database_cleanup_consumer_status (row_count)
     any::
 
       "remove_query"
-        string => "DELETE FROM $(status_table_name) WHERE ts IN (SELECT ts FROM $(status_table_name) ORDER BY ts DESC OFFSET $(row_count));";
+        string => "SELECT * FROM cleanup_historical_data('$(status_table_name)', 'ts', $(row_count), 'host');";
 
   commands:
       "$(sys.bindir)/psql cfdb -c \"$(remove_query)\""

--- a/lib/cfe_internal_hub.cf
+++ b/lib/cfe_internal_hub.cf
@@ -201,6 +201,14 @@ bundle agent cfe_internal_database_cleanup_consumer_status (row_count)
 # of cf-consumer to be replaced with cf-hub-worker per Ole.
 {
 
+  classes:
+
+      # We probe the database to see if the function is defined
+
+      "has_sql_function_cleanup_historical_data"
+        expression => returnszero( "$(sys.bindir)/psql cfdb -c \"SELECT 'cleanup_historical_data'::regproc;", noshell ),
+        if => isexecutable( "$(sys.bindir)/psql" );
+
   vars:
 
     any::
@@ -208,12 +216,17 @@ bundle agent cfe_internal_database_cleanup_consumer_status (row_count)
       "status_table_name" -> { "ENT-4331" }
         string => "__status";
 
+      # This is the fallback query to use in case the cleanup_historical_data
+      # function is not present.
+      "remove_query" -> { "ENT-4365" }
+        string => "DELETE FROM $(status_table_name) WHERE ts IN (SELECT ts FROM $(status_table_name) ORDER BY ts DESC OFFSET 50000);";
+
     cfengine_3_7|cfengine_3_10|cfengine_3_12_0|cfengine_3_12_1::
 
       "status_table_name" -> { "ENT-4331" }
         string => "status";
 
-    any::
+    has_sql_function_cleanup_historical_data::
 
       "remove_query"
         string => "SELECT * FROM cleanup_historical_data('$(status_table_name)', 'ts', $(row_count), 'host');";
@@ -221,6 +234,7 @@ bundle agent cfe_internal_database_cleanup_consumer_status (row_count)
   commands:
       "$(sys.bindir)/psql cfdb -c \"$(remove_query)\""
       handle => "cf_database_maintain_consumer_status";
+
 }
 
 bundle agent cfe_internal_database_cleanup_diagnostics (settings)

--- a/lib/cfe_internal_hub.cf
+++ b/lib/cfe_internal_hub.cf
@@ -206,7 +206,7 @@ bundle agent cfe_internal_database_cleanup_consumer_status (row_count)
       # We probe the database to see if the function is defined
 
       "has_sql_function_cleanup_historical_data"
-        expression => returnszero( "$(sys.bindir)/psql cfdb -c \"SELECT 'cleanup_historical_data'::regproc;", noshell ),
+        expression => returnszero( "$(sys.bindir)/psql cfdb -c \"SELECT 'cleanup_historical_data'::regproc;\" > /dev/null 2>&1", useshell ),
         if => isexecutable( "$(sys.bindir)/psql" );
 
   vars:


### PR DESCRIPTION
Changelog: Title
Use a new cleanup_historical_data SQL function that keeps a specified number of items for a host