### PR TITLE
ENT-4362 Purge collection status records from the future

### DIFF
--- a/lib/cfe_internal_hub.cf
+++ b/lib/cfe_internal_hub.cf
@@ -229,6 +229,10 @@ bundle agent cfe_internal_database_cleanup_consumer_status (row_count)
       "remove_query" -> { "ENT-4365" }
         string => "DELETE FROM $(status_table_name) WHERE ts IN (SELECT ts FROM $(status_table_name) ORDER BY ts DESC OFFSET 50000);";
 
+
+      "delete_future_ts_query" -> { "ENT-4362" }
+        string => "DELETE FROM status WHERE  to_timestamp(ts::bigint) > (now() + interval '2 days')::timestamp;";
+
     has_sql_function_cleanup_historical_data::
 
       "remove_query"
@@ -237,6 +241,9 @@ bundle agent cfe_internal_database_cleanup_consumer_status (row_count)
   commands:
       "$(sys.bindir)/psql cfdb -c \"$(remove_query)\""
       handle => "cf_database_maintain_consumer_status";
+
+      "$(sys.bindir)/psql cfdb -c \"$(delete_future_ts_query)\"" -> { "ENT-4362" }
+        handle => "cf_database_maintain_consumer_status_no_future_timestamps";
 
 }
 


### PR DESCRIPTION
Changelog: Title

An issue with clocks, or client side database corruption can cause the
timestamps in the status table to become huge. This creates a problem patching
reports as the timestamps no longer reflect real ranges. This change ensures
that any timestamps for report collection status records that are in the future
will be purged, thus maintaining the ability to properly calculate deltas
between time ranges.