### PR TITLE
CFE-3011: guard vars promises in CFE Internal Mission Portal Apache

### DIFF
--- a/cfe_internal/enterprise/mission_portal.cf
+++ b/cfe_internal/enterprise/mission_portal.cf
@@ -39,6 +39,7 @@ bundle agent cfe_internal_enterprise_mission_portal_apache
 {
   vars:
 
+    policy_server.enterprise_edition::
     "template"
       string => "$(this.promise_dirname)/templates/httpd.conf.mustache",
       comment => "The template used to render the apache config file.";


### PR DESCRIPTION
Constrain vars promises in cfe_internal_enterprise_mission_portal_apache
to policy_server.enterprise_edition::, otherwise "cf-promises --show-vars"
includes a dump of the entire datastate from the "data" variable in
cfe_internal_enterprise_mission_portal_apache (line over 100K long).

Changelog: Commit