### PR TITLE
Services do not detect state on FreeBSD

### DIFF
--- a/lib/services.cf
+++ b/lib/services.cf
@@ -170,12 +170,14 @@ bundle agent standard_services(service,state)
       "call_systemctl" string => "$(paths.systemctl) --no-ask-password --global --system";
       "systemd_properties" string => "-pLoadState,CanStop,UnitFileState,ActiveState,LoadState,CanStart,CanReload";
       "c_service" string => canonify("$(service)");
+
     freebsd::
       "init" string => ifelse(fileexists("/usr/local/etc/rc.d/$(service)"),
-			      "/usr/local/etc/rc.d/$(service)",
-			      "/etc/rc.d/$(service)");
+                              "/usr/local/etc/rc.d/$(service)",
+                              "/etc/rc.d/$(service)");
+
     !freebsd::
-      "init" string => "/etc/init.d/$(service)";      
+      "init" string => "/etc/init.d/$(service)";
 
     start|restart|reload::
       "chkconfig_mode" string => "on";

--- a/lib/services.cf
+++ b/lib/services.cf
@@ -169,8 +169,13 @@ bundle agent standard_services(service,state)
   vars:
       "call_systemctl" string => "$(paths.systemctl) --no-ask-password --global --system";
       "systemd_properties" string => "-pLoadState,CanStop,UnitFileState,ActiveState,LoadState,CanStart,CanReload";
-      "init" string => "/etc/init.d/$(service)";
       "c_service" string => canonify("$(service)");
+    freebsd::
+      "init" string => ifelse(fileexists("/usr/local/etc/rc.d/$(service)"),
+			      "/usr/local/etc/rc.d/$(service)",
+			      "/etc/rc.d/$(service)");
+    !freebsd::
+      "init" string => "/etc/init.d/$(service)";      
 
     start|restart|reload::
       "chkconfig_mode" string => "on";


### PR DESCRIPTION
Services do not detect state on FreeBSD due to wrong path to init scripts when using the default sysvservice facility. Replace /etc/rc.d/$(service) with /usr/local/etc/rc.d/$(service) or /etc/rc.d/$(service) if the first does not exist.