### PR TITLE
CFE-3022: Fedora no longer defines redhat_pure

### DIFF
--- a/inventory/redhat.cf
+++ b/inventory/redhat.cf
@@ -4,7 +4,7 @@ bundle common inventory_redhat
 # This common bundle is for Red Hat Linux inventory work.
 {
   classes:
-      "redhat_pure" expression => "redhat.!centos.!oracle",
+      "redhat_pure" expression => "redhat.!(centos|oracle|fedora)",
       comment => "pure Red Hat",
       meta => { "inventory", "attribute_name=none" };
 


### PR DESCRIPTION
Changelog: Title