### PR TITLE
:CFE-3022: redhat_pure is no longer defined on Fedora hosts

### DIFF
--- a/inventory/redhat.cf
+++ b/inventory/redhat.cf
@@ -4,7 +4,7 @@ bundle common inventory_redhat
 # This common bundle is for Red Hat Linux inventory work.
 {
   classes:
-      "redhat_pure" expression => "redhat.!centos.!oracle",
+      "redhat_pure" expression => "redhat.!(centos|oracle|fedora)",
       comment => "pure Red Hat",
       meta => { "inventory", "attribute_name=none" };
 


### PR DESCRIPTION
Changelog: Title

The agent defines the redhat class on fedora hosts. Fedora isn't really a
derivative of redhat, it's the other way around. But Fedora is definitely not
pure redhat.

(cherry picked from commit b72953241bd91c3f2226379a3fd267d3a33e8fd7)