### PR TITLE
Add scripts and templates for Federated Reporting

### DIFF
--- a/templates/federated_reporting/config.sh.mustache
+++ b/templates/federated_reporting/config.sh.mustache
@@ -1,0 +1,62 @@
+# -*- mode: shell-script -*-
+# Configuration file that is supposed to be sourced into bash scripts.
+
+DEFAULT_PREFIX="/opt/cfengine/federation/"
+
+# generic configuration
+CFE_BIN_DIR="{{bindir}}"
+CFE_BIN_DIR="${CFE_BIN_DIR:-/var/cfengine/bin}"
+
+# specific feeder name
+CFE_FR_FEEDER="{{feeder}}"
+CFE_FR_FEEDER="${CFE_FR_FEEDER:-$(hostname)}"
+
+# tables to dump and import
+DEFAULT_TABLES="__agentstatus
+__contexts
+__hosts
+__filechangeslog
+__lastseenhosts
+__software
+__softwareupdates
+__variables
+__benchmarkslog
+__contextslog
+__promiseexecutions
+__promiselog
+contextcache"
+CFE_FR_TABLES="{{tables}}"
+CFE_FR_TABLES="${CFE_FR_TABLES:-$DEFAULT_TABLES}"
+
+# dump phase
+CFE_FR_COMPRESSOR="{{compressor}}"
+CFE_FR_COMPRESSOR="${CFE_FR_COMPRESSOR:-gzip}"
+CFE_FR_COMPRESSOR_ARGS="{{compressor_args}}" # no extra args by default
+CFE_FR_COMPRESSOR_EXT="{{compressor_ext}}"
+CFE_FR_COMPRESSOR_EXT="${CFE_FR_COMPRESSOR_EXT:-gz}"
+CFE_FR_DUMP_DIR="{{dump_dir}}"
+CFE_FR_DUMP_DIR="${CFE_FR_DUMP_DIR:-$DEFAULT_PREFIX/fedhub/dump}"
+
+# transport phase
+CFE_FR_SUPERHUB_DROP_DIR="{{drop_dir}}"
+CFE_FR_SUPERHUB_DROP_DIR="${CFE_FR_SUPERHUB_DROP_DIR:-$DEFAULT_PREFIX/superhub/drop}"
+CFE_FR_SUPERHUB_IMPORT_DIR="{{import_dir}}"
+CFE_FR_SUPERHUB_IMPORT_DIR="${CFE_FR_SUPERHUB_IMPORT_DIR:-$DEFAULT_PREFIX/superhub/import}"
+CFE_FR_SUPERHUB_LOGIN="{{login}}"
+CFE_FR_SUPERHUB_LOGIN="${CFE_FR_SUPERHUB_LOGIN:-cfdrop@superhub}"
+CFE_FR_TRANSPORT_DIR="{{transport_dir}}"
+CFE_FR_TRANSPORT_DIR="${CFE_FR_TRANSPORT_DIR:-$DEFAULT_PREFIX/fedhub/transport}"
+CFE_FR_TRANSPORTER="{{transporter}}"
+CFE_FR_TRANSPORTER="${CFE_FR_TRANSPORTER:-rsync}"
+CFE_FR_TRANSPORTER_ARGS="{{transporter_args}}"
+CFE_FR_TRANSPORTER_ARGS="${CFE_FR_TRANSPORTER_ARGS:--av}"
+
+# import phase
+CFE_FR_EXTRACTOR="{{extractor}}"
+CFE_FR_EXTRACTOR="${CFE_FR_EXTRACTOR:-zcat}"
+CFE_FR_EXTRACTOR_ARGS="{{extractor_args}}" # no extra args by default
+CFE_FR_IMPORT_NJOBS="{{n_jobs}}"           # no explicit limit of jobs by default
+                                           # (will use all the CPUs available)
+CFE_FR_SED_ARGS="{{sed_args}}" # no extra args by default
+CFE_FR_SED_FILTERS_DIR="{{sed_filters_dir}}"
+CFE_FR_SED_FILTERS_DIR="${CFE_FR_SED_FILTERS_DIR:-$DEFAULT_PREFIX/superhub/import/filters}"

--- a/templates/federated_reporting/dump.sh
+++ b/templates/federated_reporting/dump.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -e
+
+# make sure a failure in any part of a pipe sequence is a failure
+set -o pipefail
+
+source "$(dirname "$0")/config.sh"
+source "$(dirname "$0")/log.sh"
+
+# check that we have all the variables we need
+true "${CFE_BIN_DIR?undefined}"
+true "${CFE_FR_DUMP_DIR?undefined}"
+true "${CFE_FR_TRANSPORT_DIR?undefined}"
+true "${CFE_FR_COMPRESSOR?undefined}"
+true "${CFE_FR_COMPRESSOR_ARGS?undefined}"
+true "${CFE_FR_COMPRESSOR_EXT?undefined}"
+true "${CFE_FR_FEEDER?undefined}"
+true "${CFE_FR_TABLES?undefined}"
+
+mkdir -p "$CFE_FR_DUMP_DIR"
+mkdir -p "$CFE_FR_TRANSPORT_DIR"
+
+if ! type "$CFE_FR_COMPRESSOR" >/dev/null; then
+  log "Compressor $CFE_FR_COMPRESSOR not available!"
+  exit 1
+fi
+
+failed=0
+ts="$(date -Iseconds)"  # ISO 8601 format that doesn't have spaces in it
+in_progress_file="$CFE_FR_DUMP_DIR/$CFE_FR_FEEDER_$ts.sql.$CFE_FR_COMPRESSOR_EXT.dumping"
+
+log "Dumping tables: $CFE_FR_TABLES"
+"$CFE_BIN_DIR"/pg_dump --inserts --data-only $(printf ' -t "%s"' $CFE_FR_TABLES) cfdb |
+  "$CFE_FR_COMPRESSOR" $CFE_FR_COMPRESSOR_ARGS > "$in_progress_file" || failed=1
+
+if [ "$failed" != "0" ]; then
+  log "Dumping tables: FAILED"
+  echo "$in_progress_file" >> "$CFE_FR_DUMP_DIR/failed"
+  rm -f "$in_progress_file"
+  exit 1
+else
+  log "Dumping tables: DONE"
+  mv "$in_progress_file" "$CFE_FR_TRANSPORT_DIR/$CFE_FR_FEEDER.sql.$CFE_FR_COMPRESSOR_EXT"
+fi

--- a/templates/federated_reporting/filter.sed
+++ b/templates/federated_reporting/filter.sed
@@ -1,0 +1,5 @@
+s/SELECT pg_catalog.set_config('search_path', '', false);/SET search_path = public, pg_catalog;/;
+
+# Prevent setval() entries from being replayed on the superhub
+# e.g., SELECT pg_catalog.setval('__promiselog_id_seq', 44075, true);
+/^SELECT pg_catalog.setval/d;

--- a/templates/federated_reporting/import.sh
+++ b/templates/federated_reporting/import.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -e
+
+# make sure a failure in any part of a pipe sequence is a failure
+set -o pipefail
+
+source "$(dirname "$0")/config.sh"
+source "$(dirname "$0")/log.sh"
+source "$(dirname "$0")/parallel.sh"
+
+# check that we have all the variables we need
+true "${CFE_BIN_DIR?undefined}"
+true "${CFE_FR_SUPERHUB_DROP_DIR?undefined}"
+true "${CFE_FR_SUPERHUB_IMPORT_DIR?undefined}"
+true "${CFE_FR_COMPRESSOR_EXT?undefined}"
+true "${CFE_FR_EXTRACTOR?undefined}"
+true "${CFE_FR_TABLES?undefined}"
+
+if ! type "$CFE_FR_EXTRACTOR" >/dev/null; then
+  log "Extractor $CFE_FR_EXTRACTOR not available!"
+  exit 1
+fi
+
+# TODO: we should do some validation of the files here
+mkdir -p "$CFE_FR_SUPERHUB_IMPORT_DIR"
+mv "$CFE_FR_SUPERHUB_DROP_DIR/"*".sql.$CFE_FR_COMPRESSOR_EXT" "$CFE_FR_SUPERHUB_IMPORT_DIR" || true
+
+dump_files="$(ls -1 "$CFE_FR_SUPERHUB_IMPORT_DIR/"*".sql.$CFE_FR_COMPRESSOR_EXT" 2>/dev/null)" ||
+  {
+    log "No files to import."
+    exit 0
+  }
+
+log "Database cleanup"
+{
+  cat<<EOF
+\set QUIET on
+\set ON_ERROR_STOP 1
+SET session_replication_role = replica;
+EOF
+  # XXX: this needs to be moved into the importing transaction once partitioning
+  #      is done
+  printf 'TRUNCATE %s;\n' $CFE_FR_TABLES
+} | "$CFE_BIN_DIR"/psql -U cfpostgres -d cfdb
+log "Database cleanup: DONE"
+
+# make sure the script we are about to run is executable
+chmod u+x "$(dirname "$0")/import_file.sh"
+
+log "Importing files: $dump_files"
+failed=0
+echo "$dump_files" | run_in_parallel "$(dirname "$0")/import_file.sh" - $CFE_FR_IMPORT_NJOBS ||
+  failed=1
+
+if [ "$failed" != "0" ]; then
+  log "Importing files: FAILED"
+  for file in "$CFE_FR_SUPERHUB_IMPORT_DIR/"*".sql.$CFE_FR_COMPRESSOR_EXT.failed"; do
+    log "Failed to import file '${file%%.failed}'"
+    rm -f "$file"
+  done
+  exit 1
+else
+  log "Importing files: DONE"
+fi

--- a/templates/federated_reporting/import_file.sh
+++ b/templates/federated_reporting/import_file.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# A script to import a compressed SQL file
+#
+# $1 -- compressed SQL file to import
+
+source "$(dirname "$0")/config.sh"
+
+true "${CFE_BIN_DIR?undefined}"
+true "${CFE_FR_SED_FILTERS_DIR?undefined}"
+true "${CFE_FR_SED_ARGS?undefined}"
+true "${CFE_FR_EXTRACTOR?undefined}"
+true "${CFE_FR_EXTRACTOR_ARGS?undefined}"
+
+file="$1"
+
+sed_scripts="$(ls -1 "$CFE_FR_SED_FILTERS_DIR/"*".sed" 2>/dev/null)"
+
+mv "$file" "$file.importing"
+{
+  cat<<EOF
+\set QUIET on
+\set ON_ERROR_STOP 1
+SET session_replication_role = replica;
+BEGIN;
+EOF
+
+  "$CFE_FR_EXTRACTOR" $CFE_FR_EXTRACTOR_ARGS "$file.importing" | sed $CFE_FR_SED_ARGS $(printf ' -f %s' $sed_scripts)
+
+  printf "COMMIT;"
+} | "$CFE_BIN_DIR"/psql -U cfpostgres -d cfdb &&
+  rm -f "$file.importing" || mv "$file.importing" "$file.failed"
+

--- a/templates/federated_reporting/log.sh.mustache
+++ b/templates/federated_reporting/log.sh.mustache
@@ -1,0 +1,18 @@
+# -*- mode: shell-script -*-
+# A bash "library" providing logging functionality
+
+CFE_LOGGER="{{logger}}"
+CFE_LOGGER="${CFE_LOGGER:-echo}"
+CFE_LOGGER_ARGS="{{logger_args}}" # no extra args by default
+CFE_TIMESTAMP_CMD="{{timestamp_cmd}}" # use 'true' to disable explicit timestamps
+CFE_TIMESTAMP_CMD="${CFE_TIMESTAMP_CMD:-date}"
+
+function log() {
+  # $1 -- message to log
+  ts="$($CFE_TIMESTAMP_CMD)"
+  if [ -n "$ts" ]; then
+    "${CFE_LOGGER}" "[$ts] $1"
+  else
+    "${CFE_LOGGER}" "$1"
+  fi
+}

--- a/templates/federated_reporting/parallel.sh
+++ b/templates/federated_reporting/parallel.sh
@@ -1,0 +1,127 @@
+# A shell "library" providing a function to run a given command on multiple
+# arguments in parallel.
+#
+# For best results, make sure 'parallel' is installed.
+#
+
+if type parallel >/dev/null; then
+  HAVE_PARALLEL=1
+else
+  HAVE_PARALLEL=0
+fi
+
+if type xargs >/dev/null; then
+  HAVE_XARGS=1
+else
+  HAVE_XARGS=0
+fi
+
+if type getconf >/dev/null; then
+  NCPUs="$(getconf _NPROCESSORS_ONLN)"
+else
+  NCPUs="$(grep processor /proc/cpuinfo | wc -l)"
+fi
+
+
+_run_using_parallel() {
+  max_jobs=""
+  if [ $# -gt 2 ]; then
+    max_jobs="-j$3"
+  fi
+
+  if [ "$2" = "-" ]; then
+    parallel $max_jobs "$1 {}"
+  else
+    parallel $max_jobs "$1 {}" :::: "$2"
+  fi
+  return $?
+}
+
+_run_using_xargs() {
+  if [ $# -gt 2 ]; then
+    max_jobs="-P$3"
+  else
+    max_jobs="-P$NCPUs"
+  fi
+
+  if [ "$2" = "-" ]; then
+    xargs -n1 $max_jobs "$1"
+  else
+    xargs -n1 $max_jobs -a "$2" "$1"
+  fi
+  return $?
+}
+
+_run_using_for() {
+  if [ $# -gt 2 ]; then
+    job_slots="$3"
+  else
+    job_slots="$NCPUs"
+  fi
+
+  if [ "$2" = "-" ]; then
+    input_arg="/dev/stdin"
+  else
+    input_arg="$2"
+  fi
+  failure=0
+  while read item; do
+    if [ "$job_slots" = 0 ]; then
+      wait -n
+      if [ $? != 0 ] && [ $failure = 0 ]; then
+        failure=1
+      fi
+      job_slots="$(expr $job_slots + 1)"
+    fi
+    "$1" "$item" &
+    job_slots="$(expr $job_slots - 1)"
+  done < $input_arg
+  wait
+  return $failure
+}
+
+run_in_parallel() {
+  # Run the given command with the read arguments in parallel
+  #
+  # $1     -- command to run
+  # $2     -- path to the file to read the argument items from,
+  #           or "-" to load from STDIN
+  # $3     -- OPTIONAL, maximum number of parallel jobs to run,
+  #           defaults to the number of CPUs
+  # return -- 0 if all runs of the command exited with 0, 1 otherwise
+  #
+  # Reads the arguments (one arg per line) and runs the given command in
+  # parallel with them. One argument per command. Uses 'parallel', 'xargs' or a
+  # for-loop with background jobs in respective order of preference.
+
+  # we need to know if $1 is a function because 'xargs' doesn't support
+  # functions at all and for 'parallel' we need to export the function
+  if type "$1" | head -n1 | grep "$1 is a function" >/dev/null; then
+    IS_A_FUNC=1
+  else
+    IS_A_FUNC=0
+  fi
+
+  if [ $HAVE_PARALLEL = 1 ]; then
+    if [ $IS_A_FUNC = 1 ]; then
+      export -f "$1"
+    fi
+
+    _run_using_parallel "$@"
+    if [ $? = 0 ]; then
+      return 0
+    else
+      return 1
+    fi
+  elif [ $HAVE_XARGS = 1 ] && [ $IS_A_FUNC != 1 ]; then
+    _run_using_xargs "$@"
+    if [ $? = 0 ]; then
+      return 0
+    else
+      return 1
+    fi
+  else
+    _run_using_for "$@"
+    return $?
+  fi
+}

--- a/templates/federated_reporting/transport.sh
+++ b/templates/federated_reporting/transport.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -e
+
+# make sure a failure in any part of a pipe sequence is a failure
+set -o pipefail
+
+source "$(dirname "$0")/config.sh"
+source "$(dirname "$0")/log.sh"
+
+# check that we have all the variables we need
+true "${CFE_FR_TRANSPORT_DIR?undefined}"
+true "${CFE_FR_SUPERHUB_DROP_DIR?undefined}"
+true "${CFE_FR_TRANSPORTER?undefined}"
+true "${CFE_FR_TRANSPORTER_ARGS?undefined}"
+true "${CFE_FR_COMPRESSOR_EXT?undefined}"
+true "${CFE_FR_SUPERHUB_LOGIN?undefined}"
+
+if ! type "$CFE_FR_TRANSPORTER" >/dev/null; then
+  log "Transporter $CFE_FR_TRANSPORTER not available!"
+  exit 1
+fi
+
+dump_files="$(ls -1 "$CFE_FR_TRANSPORT_DIR/"*".sql.$CFE_FR_COMPRESSOR_EXT" 2>/dev/null)" ||
+  {
+    log "No files to transport."
+    exit 0
+  }
+
+log "Transporting files: $dump_files"
+some_failed=0
+for dump_file in $dump_files; do
+  failed=0
+  mv "$dump_file" "$dump_file.transporting"
+  "$CFE_FR_TRANSPORTER" "$CFE_FR_TRANSPORTER_ARGS" "$dump_file.transporting" "$CFE_FR_SUPERHUB_LOGIN:$CFE_FR_SUPERHUB_DROP_DIR/$(basename "$dump_file")" &&
+    rm -f "$dump_file.transporting" || failed=1
+  if [ "$failed" != 0 ]; then
+    log "Transporting file $dump_file failed!"
+    some_failed=1
+  fi
+done
+
+if [ "$some_failed" != "0" ]; then
+  log "Transporting files: FAILED"
+  exit 1
+else
+  log "Transporting files: DONE"
+fi


### PR DESCRIPTION
The configurable parts are only in the config.sh.mustache and
log.sh.mustache files, the other files just use the configuration
rendered by the policy with those two templates.

Ticket: ENT-4473
Changelog: Added scripts and templates for Federated Reporting