### PR TITLE
Add inventory of NFS server(s) (if NFS mounts present)

### DIFF
--- a/inventory/linux.cf
+++ b/inventory/linux.cf
@@ -37,6 +37,24 @@ bundle common inventory_linux
         comment => "Name of the interface where default gateway is routed",
         ifvarclass => strcmp("$(proc_routes[$(routeidx)][1])", "00000000");
 
+    linux::
+      "nfs_servers"
+        comment => "NFS servers (to list hosts impacted by NFS outages)",
+        slist => maplist( regex_replace( $(this) , ":.*", "", "g"),
+                          # NFS server is before the colon (:), that's all we want
+                          # e.g., nfs.example.com:/vol/homedir/user1 /home/user1 ...
+                          #       ^^^^^^^^^^^^^^^
+                          grep( ".* nfs .*",
+                                readstringlist("/proc/mounts", "", "\n", inf, inf)
+                              )
+                        );
+
+
+        "nfs_server[$(nfs_servers)]"
+          string => "$(nfs_servers)",
+          meta => { "inventory", "attribute_name=NFS Server" };
+
+
   classes:
 
     any::


### PR DESCRIPTION
Add inventory of NFS server hostname/address to allow operations personnel
to quickly identify hosts (NFS clients) impacted by NFS server outages.
(i.e., search CFEngine Enterprise database by NFS server, to see all
the hosts that have a mount from that NFS server)

This was discussed in
https://groups.google.com/forum/#!searchin/help-cfengine/NFS%7Csort:date/help-cfengine/68tfbMkblvs/-xsy4su4CwAJ

Changelog: Title

Thanks to Mike Weilgart and Vratislav Podzimek and Nick Anderson for
their input and to @brontolinux for his support