### PR TITLE
ENT-4317 Fix standalone_self_upgrade not triggering because of stale data (3.12.x)

### DIFF
--- a/update.cf
+++ b/update.cf
@@ -53,9 +53,38 @@ bundle common cfengine_update_controls
 }
 
 bundle agent cfengine_internal_standalone_self_upgrade
+# @brief Manage desired version state and execution of policy to reach the target version.
+{
+  methods:
+      "cfengine_internal_standalone_self_upgrade_state_data";
+      "cfengine_internal_standalone_self_upgrade_execution";
+}
+bundle agent cfengine_internal_standalone_self_upgrade_state_data
+# @brief Clear stale recorded desired version information from state
+{
+  vars:
+
+      "binary_upgrade_entry"
+        string => "$(this.promise_dirname)/standalone_self_upgrade.cf";
+
+      "desired_pkg_data_path" string =>
+        "$(cfengine_internal_standalone_self_upgrade_execution.desired_pkg_data_path)";
+
+  files:
+
+      # We consider the data stale if it's older than the policy that generated it
+      "$(desired_pkg_data_path)" -> { "ENT-4317" }
+        delete => u_tidy,
+        if => isnewerthan( $(binary_upgrade_entry) , $(desired_pkg_data_path) );
+}
+bundle agent cfengine_internal_standalone_self_upgrade_execution
 # @brief Manage the version of CFEngine that is currently installed. This policy
 # executes a stand alone policy as a sub agent. If systemd is found we assume
 # that it is necessary to escape the current unit via systemd-run.
+#
+# If the running version matches either the desired version information in state
+# or the version supplied from augments, then we skip running the standalone
+# upgrade policy.
 {
   vars:
 
@@ -77,12 +106,15 @@ bundle agent cfengine_internal_standalone_self_upgrade
 
   classes:
       # If we are running the version desired by the self upgrade policy
-      "at_desired_version" -> { "ENT-3592" }
+      "at_desired_version_by_policy_specification" -> { "ENT-3592" }
         expression => strcmp( "$(desired_pkg_data[version])", "$(sys.cf_version)"  );
 
       # If we are running the version explicitly defined by the user
-      "at_desired_version" -> { "ENT-3592" }
+      "at_desired_version_by_user_specification" -> { "ENT-3592" }
         expression => strcmp( "$(def.cfengine_software_pkg_version)", "$(sys.cf_version)" );
+
+      "at_desired_version"
+        or => { "at_desired_version_by_user_specification", "at_desired_version_by_policy_specification" };
 
   files:
 


### PR DESCRIPTION
The desired version state data is written by standalone_self_upgrade.cf, which
is triggered when trigger_upgrade is defined and the running agent version does
not match the desired version.

The desired version defaults to the version of the MPF when it was built and can
be overridden via augments.

Once the agent was at the desired version, the standalone_self_upgrade.cf policy
would never trigger, because the running version would match the desired version
data. Since it would not run, it would not update the desired version data.

This change purges the desired version state data when it is older than the
standalone_self_upgrade.cf. This way, when the policy changes there will not be
stale data preventing upgrade.

Changelog: Title
(cherry picked from commit c3343cfb0cc3921c7641974c0b00abf61b0acfe2)