### PR TITLE
added exclusion for centos_6_0 in yum locking

### DIFF
--- a/lib/packages.cf
+++ b/lib/packages.cf
@@ -271,9 +271,9 @@ bundle common rpm_knowledge
 bundle common redhat_no_locking_knowledge {
   vars:
     # Option was introduced in rhel 6.1
-    redhat.!(redhat_3|redhat_4|redhat_5|redhat_6_0)::
+    redhat.!(redhat_3|redhat_4|redhat_5|redhat_6_0|centos_6_0)::
       "no_locking_option" string => "--setopt=exit_on_lock=True";
-    redhat_3|redhat_4|redhat_5|redhat_6_0::
+    redhat_3|redhat_4|redhat_5|redhat_6_0|centos_6_0::
       "no_locking_option" string => "";
 }
 


### PR DESCRIPTION
centos_6_0 doesn't classify as redhat_6_0 so it was necessary to specify it individually. This will work around CFE-3027