### PR TITLE
Handle exit_on_lock for centos (3.10.x)

### DIFF
--- a/lib/packages.cf
+++ b/lib/packages.cf
@@ -253,9 +253,9 @@ bundle common rpm_knowledge
 bundle common redhat_no_locking_knowledge {
   vars:
     # Option was introduced in rhel 6.1
-    redhat.!(redhat_3|redhat_4|redhat_5|redhat_6_0)::
+    (redhat|centos).!(redhat_3|redhat_4|redhat_5|redhat_6_0|centos_3|centos_4|centos_5|centos_6_0)::
       "no_locking_option" string => "--setopt=exit_on_lock=True";
-    redhat_3|redhat_4|redhat_5|redhat_6_0::
+    redhat_3|redhat_4|redhat_5|redhat_6_0|centos_3|centos_4|centos_5|centos_6_0::
       "no_locking_option" string => "";
 }
 


### PR DESCRIPTION
centos and redhat don't have exactly the same classes. For example, on centos
6.5 you will find centos, centos_6, centos_6_5, redhat, and redhat_derived

```
[root@hub ~]# cf-promises --show-classes | awk '/centos|redhat/ {print $1}'
centos
centos_6
centos_6_5
redhat
redhat_derived
```

Changelog: None
(cherry picked from commit b561c38a99c49dc0f32fbbbd78c1fecd53dc07a5)