### PR TITLE
ENT-4551 Ensure that asynchronous query API semaphores are writable (3.10.x)

### DIFF
--- a/cfe_internal/enterprise/CFE_knowledge.cf
+++ b/cfe_internal/enterprise/CFE_knowledge.cf
@@ -127,6 +127,13 @@ bundle agent cfe_internal_setup_knowledge
       file_select => cfe_internal_docroot_api_static_perms,
       perms => mog("0440", "root", $(def.cf_apache_group) );
 
+      "$(cfe_internal_hub_vars.docroot)/api/static/." -> { "ENT-4551" }
+        comment => ".status, .pid, and potentially .abort files need to be writeable so that the async query API will function properly",
+        handle => "cfe_internal_setup_knowledge_files_doc_root_api_static_async_query_status",
+        depth_search => recurse("inf"),
+        file_select => cfe_internal_docroot_api_static_async_query_status_status_perms,
+        perms => mog("0660", "root", $(def.cf_apache_group) );
+
       "$(sys.workdir)/httpd/logs/."
       comment => "Ensure permissions for $(sys.workdir)/httpd/logs",
       handle => "cfe_internal_setup_knowledge_files_httpd_logs",
@@ -282,8 +289,23 @@ body file_select cfe_internal_exclude_index_html
 
 body file_select cfe_internal_docroot_api_static_perms
 {
-  leaf_name => { "\.htaccess" };
+      # ENT-4551 - .status, .pid, and potentially .abort files used by async
+      # query mechanism need to be writeable by the webserver, we exclude those
+      # files here to avoid continual promise repair.
+
+  leaf_name => { "\.htaccess", "\.status", "\.pid", "\.abort" };
   file_result => "!leaf_name";
+}
+############################################################################
+
+body file_select cfe_internal_docroot_api_static_async_query_status_status_perms
+# @brief .status, .pid and .abort files are used by the asynchronous query API and need to be writeable
+{
+      # ENT-4551 - .status, .pid, and potentially .abort files used by async
+      # query mechanism need to be writeable by the webserver
+
+        leaf_name => { "\.status", "\.pid", "\.abort" };
+        file_result => "leaf_name";
 }
 
 ############################################################################


### PR DESCRIPTION
Changelog: Title

This change ensures that the files used by the asynchronous query API are
writable by the web server, so that the status can be correctly updated. Without
being writable scheduled reports may hang and never complete.

(cherry picked from commit 446b54e46f9dd804a8b5329eacb361009b568e1b)