### PR TITLE
Add support for pull to FR/transport.sh

### DIFF
--- a/templates/federated_reporting/config.sh.mustache
+++ b/templates/federated_reporting/config.sh.mustache
@@ -50,6 +50,12 @@ CFE_FR_TRANSPORTER="{{transporter}}"
 CFE_FR_TRANSPORTER="${CFE_FR_TRANSPORTER:-rsync}"
 CFE_FR_TRANSPORTER_ARGS="{{transporter_args}}"
 CFE_FR_TRANSPORTER_ARGS="${CFE_FR_TRANSPORTER_ARGS:--av}"
+CFE_FR_SSH="{{ssh}}"
+CFE_FR_SSH="${CFE_FR_SSH:-ssh}"
+CFE_FR_SSH_ARGS="{{ssh_args}}"
+CFE_FR_SSH_ARGS="${CFE_FR_SSH_ARGS:--o StrictHostKeyChecking=no}"
+CFE_FR_FEEDER_USERNAME="{{feeder_username}}"
+CFE_FR_FEEDER_USERNAME="${CFE_FR_FEEDER_USERNAME:-superhub}"
 
 # import phase
 CFE_FR_EXTRACTOR="{{extractor}}"

--- a/templates/federated_reporting/dump.sh
+++ b/templates/federated_reporting/dump.sh
@@ -17,9 +17,11 @@ true "${CFE_FR_COMPRESSOR_ARGS?undefined}"
 true "${CFE_FR_COMPRESSOR_EXT?undefined}"
 true "${CFE_FR_FEEDER?undefined}"
 true "${CFE_FR_TABLES?undefined}"
+true "${CFE_FR_FEEDER_USERNAME?undefined}"
 
 mkdir -p "$CFE_FR_DUMP_DIR"
 mkdir -p "$CFE_FR_TRANSPORT_DIR"
+chown "$CFE_FEEDER_USERNAME" "$CFE_FR_TRANSPORT_DIR"
 
 if ! type "$CFE_FR_COMPRESSOR" >/dev/null; then
   log "Compressor $CFE_FR_COMPRESSOR not available!"
@@ -42,4 +44,5 @@ if [ "$failed" != "0" ]; then
 else
   log "Dumping tables: DONE"
   mv "$in_progress_file" "$CFE_FR_TRANSPORT_DIR/$CFE_FR_FEEDER.sql.$CFE_FR_COMPRESSOR_EXT"
+  chown "$CFE_FEEDER_USERNAME" "$CFE_FR_TRANSPORT_DIR/$CFE_FR_FEEDER.sql.$CFE_FR_COMPRESSOR_EXT"
 fi

--- a/templates/federated_reporting/pull_dumps_from.sh
+++ b/templates/federated_reporting/pull_dumps_from.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# A script to pull dumps from a given feeder hub to the $PWD/$feeder folder.
+#
+# $1 -- feeder hub hostname/IP to pull the dumps from
+#
+
+set -e
+
+# make sure a failure in any part of a pipe sequence is a failure
+set -o pipefail
+
+source "$(dirname "$0")/config.sh"
+
+# check that we have all the variables we need
+true "${CFE_FR_TRANSPORT_DIR?undefined}"
+true "${CFE_FR_SUPERHUB_DROP_DIR?undefined}"
+true "${CFE_FR_TRANSPORTER?undefined}"
+true "${CFE_FR_TRANSPORTER_ARGS?undefined}"
+true "${CFE_FR_SSH?undefined}"
+true "${CFE_FR_SSH_ARGS?undefined}"
+true "${CFE_FR_COMPRESSOR_EXT?undefined}"
+true "${CFE_FR_FEEDER_USERNAME?undefined}"
+
+if [ $# != 1 ]; then
+  log "Invalid number of arguments ($#) given to $0, exiting!"
+  exit 1
+fi
+
+feeder="$1"
+
+mkdir -p "$feeder"
+
+# move the files so that they don't get overwritten/deleted during the transport
+"$CFE_FR_SSH" $CFE_FR_SSH_ARGS "$CFE_FR_FEEDER_USERNAME@$feeder" "mkdir $CFE_FR_TRANSPORT_DIR/$$.transporting"
+"$CFE_FR_SSH" $CFE_FR_SSH_ARGS "$CFE_FR_FEEDER_USERNAME@$feeder" "mv $CFE_FR_TRANSPORT_DIR/*.sql.$CFE_FR_COMPRESSOR_EXT $CFE_FR_TRANSPORT_DIR/$$.transporting/"
+
+failed=0
+"$CFE_FR_TRANSPORTER" $CFE_FR_TRANSPORTER_ARGS "$CFE_FR_FEEDER_USERNAME@$feeder:/$CFE_FR_TRANSPORT_DIR/$$.transporting/*.sql.$CFE_FR_COMPRESSOR_EXT" "$feeder/" ||
+  failed=1
+
+"$CFE_FR_SSH" $CFE_FR_SSH_ARGS "$CFE_FR_FEEDER_USERNAME@$feeder" "rm -rf $CFE_FR_TRANSPORT_DIR/$$.transporting"
+
+if [ "$failed" != "0" ]; then
+  touch "$feeder.failed"
+  rm -rf "$feeder"
+  exit 1
+fi

--- a/templates/federated_reporting/transport.sh
+++ b/templates/federated_reporting/transport.sh
@@ -1,4 +1,15 @@
 #!/bin/bash
+#
+# Transport dump files from the feeder hubs to the superhub.
+#
+# Can be run as:
+#   transport.sh
+#         On a feeder hub, pushes dump files to the superhub.
+#   transport.sh push
+#         The same as with no arguments.
+#   transport.sh pull FEEDER_HUB [FEEDER_HUB2...FEEDER_HUBn]
+#         On the superhub, pull dumps from the given feeder hubs (in parallel).
+#
 
 set -e
 
@@ -7,6 +18,7 @@ set -o pipefail
 
 source "$(dirname "$0")/config.sh"
 source "$(dirname "$0")/log.sh"
+source "$(dirname "$0")/parallel.sh"
 
 # check that we have all the variables we need
 true "${CFE_FR_TRANSPORT_DIR?undefined}"
@@ -21,28 +33,108 @@ if ! type "$CFE_FR_TRANSPORTER" >/dev/null; then
   exit 1
 fi
 
-dump_files="$(ls -1 "$CFE_FR_TRANSPORT_DIR/"*".sql.$CFE_FR_COMPRESSOR_EXT" 2>/dev/null)" ||
-  {
-    log "No files to transport."
-    exit 0
-  }
+function push() {
+  # Runs on the feeder hub, pushes dumps to the superhub.
 
-log "Transporting files: $dump_files"
-some_failed=0
-for dump_file in $dump_files; do
-  failed=0
-  mv "$dump_file" "$dump_file.transporting"
-  "$CFE_FR_TRANSPORTER" "$CFE_FR_TRANSPORTER_ARGS" "$dump_file.transporting" "$CFE_FR_SUPERHUB_LOGIN:$CFE_FR_SUPERHUB_DROP_DIR/$(basename "$dump_file")" &&
-    rm -f "$dump_file.transporting" || failed=1
-  if [ "$failed" != 0 ]; then
-    log "Transporting file $dump_file failed!"
-    some_failed=1
+  dump_files="$(ls -1 "$CFE_FR_TRANSPORT_DIR/"*".sql.$CFE_FR_COMPRESSOR_EXT" 2>/dev/null)" ||
+    {
+      log "No files to transport."
+      exit 0
+    }
+
+  log "Transporting files: $dump_files"
+  some_failed=0
+  for dump_file in $dump_files; do
+    failed=0
+    mv "$dump_file" "$dump_file.transporting"
+    "$CFE_FR_TRANSPORTER" "$CFE_FR_TRANSPORTER_ARGS" "$dump_file.transporting" "$CFE_FR_SUPERHUB_LOGIN:$CFE_FR_SUPERHUB_DROP_DIR/$(basename "$dump_file")" &&
+      rm -f "$dump_file.transporting" || failed=1
+    if [ "$failed" != 0 ]; then
+      log "Transporting file $dump_file failed!"
+      some_failed=1
+    fi
+  done
+
+  if [ "$some_failed" != "0" ]; then
+    log "Transporting files: FAILED"
+    return 1
+  else
+    log "Transporting files: DONE"
+    return 0
   fi
-done
+}
 
-if [ "$some_failed" != "0" ]; then
-  log "Transporting files: FAILED"
-  exit 1
+function pull() {
+  # $@ -- feeder hubs to pull the dumps from
+  feeder_lines="$(printf "%s\n" "$@")"
+  log "Pulling dumps from: $feeder_lines"
+
+  chmod u+x "$(dirname "$0")/pull_dumps_from.sh"
+
+  # create and work inside a process specific sub-directory for WIP
+  mkdir "$CFE_FR_SUPERHUB_DROP_DIR/$$"
+
+  # Determine the absolute path of the pull_dumps_from.sh script. If this was
+  # run with absolute path, use the absolute path, otherwise use the relative
+  # part as the base path.
+  if [ "${0:0:1}" = "/" ]; then
+    pull_dumps_path="$(dirname "$0")/pull_dumps_from.sh"
+  else
+    pull_dumps_path="$PWD/$(dirname "$0")/pull_dumps_from.sh"
+  fi
+
+  pushd "$CFE_FR_SUPERHUB_DROP_DIR/$$" >/dev/null
+
+  failed=0
+  echo "$feeder_lines" | run_in_parallel "$pull_dumps_path" - || failed=1
+  if [ "$failed" != "0" ]; then
+    log "Pulling dumps: FAILED"
+    for feeder in "$@"; do
+      if [ -f "$feeder.failed" ]; then
+        log "Failed to pull dumps from: $feeder"
+        rm -f "$feeder.failed"
+      fi
+    done
+  else
+    log "Pulling dumps: DONE"
+  fi
+
+  for feeder in "$@"; do
+    if ! ls "$feeder/"*".sql.$CFE_FR_COMPRESSOR_EXT" >/dev/null 2>/dev/null; then
+      log "No dump files from $feeder"
+      continue
+    fi
+    mv "$feeder/"*".sql.$CFE_FR_COMPRESSOR_EXT" "$CFE_FR_SUPERHUB_DROP_DIR/"
+
+    # the $feeder directory is not supposed to contain anything else
+    rmdir "$feeder" || log "Failed to remove directory after $feeder"
+  done
+
+  popd >/dev/null
+  rm -rf "$CFE_FR_SUPERHUB_DROP_DIR/$$"
+  return $failed
+}
+
+if [ $# = 0 ]; then
+  push
+elif [ $# = 1 ]; then
+  if [ "$1" = "push" ]; then
+    push
+  else
+    if [ "$1" = "pull" ]; then
+      log "No feeder hubs given to pull from"
+    else
+      log "Invalid command given to $0: $1"
+    fi
+    exit 1
+  fi
 else
-  log "Transporting files: DONE"
+  # more than one argument given
+  if [ "$1" = "pull" ]; then
+    shift
+    pull "$@"
+  else
+    log "Invalid command given to $0: $1"
+    exit 1
+  fi
 fi


### PR DESCRIPTION
Making the superhub pull the dump files from the feeder hubs is a
better strategy than pushing the files from the feeder hubs to
the superhub. The superhub knows better when it has a capacity to
process the files and also, there's only one SSH private key that
has to be kept safe -- the superhub's key.

However, in some situations the push approach may be necessary so
let's not just delete the functionality. The transport.sh script
can easily support both modes.

Ticket: ENT-4499
Changelog: None