### PR TITLE
Refresh inventory after import on superhub

### DIFF
--- a/cfe_internal/enterprise/CFE_hub_specific.cf
+++ b/cfe_internal/enterprise/CFE_hub_specific.cf
@@ -14,6 +14,11 @@
 #
 ##################################################################
 
+body file control
+{
+        inputs => { "$(sys.inputdir)/cfe_internal/enterprise/federation/federation.cf" };
+}
+
 bundle common cfe_internal_hub_vars
 # @brief Set hub specific variables
 {
@@ -459,6 +464,18 @@ bundle agent cfe_internal_enterprise_maintenance
         ifvarclass => isgreaterthan( $(enterprise_maintenance_bundle_count), 0 );
 }
 
+bundle agent cfe_internal_refresh_inventory_args
+{
+  vars:
+    cfengine_enterprise_federation:am_superhub::
+      "args" -> {"ENT-4527"}
+        string => "inventory_refresh_by_hostkey $(sys.key_digest)",
+        comment => "Only refresh inventory for the superhub, other hosts get refreshed on data import";
+
+    !cfengine_enterprise_federation:am_superhub::
+      "args" string => "inventory_refresh";
+}
+
 bundle agent cfe_internal_refresh_inventory_view
 # @brief Refresh materialized view every 5 minutes
 {
@@ -468,17 +485,21 @@ bundle agent cfe_internal_refresh_inventory_view
 
       "tags" slist => { "enterprise_maintenance" };
 
+  methods:
+      # we need to know if we are running on a superhub
+      "superhub_config" usebundle => "cfengine_enterprise_federation:config";
+      "inventory_refresh_args" usebundle => "cfe_internal_refresh_inventory_args";
+
   commands:
 
     (policy_server|am_policy_hub).enterprise_edition::
 
       "$(sys.workdir)/httpd/php/bin/php"
-        args => "$(cfe_internal_hub_vars.docroot)/index.php cli_tasks inventory_refresh",
+        args => "$(cfe_internal_hub_vars.docroot)/index.php cli_tasks $(cfe_internal_refresh_inventory_args.args)",
         contain => silent,
         comment => "This refreshes the inventory view. If the inventory view is not refreshed then it will contain stale data.",
         handle  => "mpf_fresh_inventory_view",
         if => isdir( "$(cfe_internal_hub_vars.docroot)/api/modules/inventory" );
-
 }
 
 bundle agent cfe_internal_refresh_hosts_view

--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -1,6 +1,6 @@
 body file control
 {
-        inputs => { "$(sys.libdir)/stdlib.cf" };
+        inputs => { "$(sys.libdir)/stdlib.cf", "$(sys.inputdir)/cfe_internal/enterprise/CFE_hub_specific.cf" };
         namespace => "cfengine_enterprise_federation";
 }
 
@@ -149,15 +149,28 @@ bundle agent transport_user
         contain => default:in_shell;
 }
 
+bundle agent inventory_refresh_cmd
+{
+  vars:
+    "cmd" data => parsejson('{"inventory_refresh_cmd":
+                                "$(sys.workdir)/httpd/php/bin/php $(cfe_internal_hub_vars.docroot)/index.php cli_tasks inventory_refresh"}');
+}
 
 bundle agent federation_manage_files
 # @brief Manage files, directories and permissions in $(cfengine_enterprise_federation:config.federation_dir)
 {
+
   vars:
     "transport_user"
       string => "$(cfengine_enterprise_federation:config.transport_user)";
     "login" data => parsejson('{"login":"$(cfengine_enterprise_federation:config.login)"}');
     "feeder_username" data => parsejson('{"feeder_username":"$(cfengine_enterprise_federation:config.transport_user)"}');
+
+  methods:
+      "internal_vars" usebundle => "default:cfe_internal_hub_vars",
+        comment => "We need the path to the inventory refresh PHP script before we use it.";
+      "inventory_refresh_cmd" usebundle => "cfengine_enterprise_federation:inventory_refresh_cmd",
+        comment => "Needs to be in a separate bundle so that it gets evaluated *after* cfe_internal_hub_vars.";
 
   files:
     enterprise_edition.(policy_server|am_policy_hub)::
@@ -203,7 +216,7 @@ bundle agent federation_manage_files
         create => "true",
         template_method => "mustache",
         edit_template => "$(this.promise_dirname)/../../../templates/federated_reporting/config.sh.mustache",
-        template_data => mergedata(login, feeder_username),
+        template_data => mergedata(@(login), @(feeder_username), @(cfengine_enterprise_federation:inventory_refresh_cmd.cmd)),
         perms => default:mog( "640", "root", "$(transport_user)" );
 
       # TODO: Instrument augments

--- a/templates/federated_reporting/config.sh.mustache
+++ b/templates/federated_reporting/config.sh.mustache
@@ -66,3 +66,5 @@ CFE_FR_IMPORT_NJOBS="{{n_jobs}}"           # no explicit limit of jobs by defaul
 CFE_FR_SED_ARGS="{{sed_args}}" # no extra args by default
 CFE_FR_SED_FILTERS_DIR="{{sed_filters_dir}}"
 CFE_FR_SED_FILTERS_DIR="${CFE_FR_SED_FILTERS_DIR:-$DEFAULT_PREFIX/superhub/import/filters}"
+# no inventory refresh command by default (=> no inventory refresh after import)
+CFE_FR_INVENTORY_REFRESH_CMD="{{inventory_refresh_cmd}}"

--- a/templates/federated_reporting/import.sh
+++ b/templates/federated_reporting/import.sh
@@ -16,6 +16,7 @@ true "${CFE_FR_SUPERHUB_IMPORT_DIR?undefined}"
 true "${CFE_FR_COMPRESSOR_EXT?undefined}"
 true "${CFE_FR_EXTRACTOR?undefined}"
 true "${CFE_FR_TABLES?undefined}"
+true "${CFE_FR_INVENTORY_REFRESH_CMD?undefined}"
 
 if ! type "$CFE_FR_EXTRACTOR" >/dev/null; then
   log "Extractor $CFE_FR_EXTRACTOR not available!"
@@ -72,4 +73,15 @@ if [ "$failed" != "0" ]; then
   exit 1
 else
   log "Importing files: DONE"
+  if [ -n "$CFE_FR_INVENTORY_REFRESH_CMD" ]; then
+    log "Refreshing inventory"
+    inv_refresh_failed=0
+    $CFE_FR_INVENTORY_REFRESH_CMD || inv_refresh_failed=1
+    if [ "$inv_refresh_failed" != "0" ]; then
+      log "Refreshing inventory: FAILED"
+      exit 1
+    else
+      log "Refreshing inventory: DONE"
+    fi
+  fi
 fi


### PR DESCRIPTION
Refreshing inventory on a superhub with tens of thousands of
hosts can easily take a couple minutes and thus should not be
part of every agent run. It's also not necessary to refresh the
inventory on a superhub too often because reporting data only
changes when successfully imported from the feeder hubs.

Let's just refresh the inventory after a successfull data import
on the superhub.

Ticket: ENT-4527
Changelog: None