### PR TITLE
ENT-4601 Accounted for database needs in state permissions

### DIFF
--- a/cfe_internal/enterprise/CFE_knowledge.cf
+++ b/cfe_internal/enterprise/CFE_knowledge.cf
@@ -192,9 +192,37 @@ bundle agent cfe_internal_setup_knowledge
         comment => "The agent will complain if any other users (group or other)
                     have write access to the modules directory.";
 
-      "$(sys.statedir)/."
-        perms => mog("600", "root", "root");
+    enterprise_edition.(policy_server|am_policy_hub)::
 
+     "$(sys.statedir)/."
+        perms => mog("0640", "root", "cfpostgres"),
+        comment => "The database user must be able to read the parent directory of the database or it won't be accessible";
+
+      "$(sys.statedir)/pg/."
+        perms => mog("0600", "cfpostgres", "cfpostgres"),
+        depth_search => recurse( inf ),
+        comment => "No one except for the database user needs to access where the db is installed.";
+
+
+    !(policy_sever|am_policy_hub)::
+
+      "$(sys.statedir)/."
+        perms => mog("0600", "root", "root");
+
+    any::
+
+      "$(sys.statedir)/."
+        perms => mog("0600", "root", "root"),
+        depth_search => recurse_without_basedir_exclude_pg( inf ),
+        file_select => all;
+}
+
+#############################################################################
+body depth_search recurse_without_basedir_exclude_pg(d)
+{
+        depth => "$(d)";
+        include_basedir => "false";
+        exclude_dirs => { "pg" };
 }
 
 #############################################################################


### PR DESCRIPTION
The database user must be able to access the parent directory of where the
database is installed or it won't function.

Changelog: None