### PR TITLE
ENT-4601: Refactored sys.statedir permission and ownership handling (3.10)

### DIFF
--- a/cfe_internal/enterprise/CFE_knowledge.cf
+++ b/cfe_internal/enterprise/CFE_knowledge.cf
@@ -192,37 +192,45 @@ bundle agent cfe_internal_setup_knowledge
         comment => "The agent will complain if any other users (group or other)
                     have write access to the modules directory.";
 
+}
+
+bundle agent cfe_internal_permissions
+# @brief Specific expectations for permissions and ownership of CFEngine with respect to the Enterprise Edition
+{
+
+  files:
+
+    !(policy_server|am_policy_hub)::
+      "$(sys.statedir)/."
+        perms => mog("0600", "root", "root"),
+        # Important to recurse across file system boundaries, as databases and or state are commonly on different filesystems
+        depth_search => recurse_with_base( inf ),
+        file_select => all;
+
     enterprise_edition.(policy_server|am_policy_hub)::
 
      "$(sys.statedir)/."
         perms => mog("0640", "root", "cfpostgres"),
         comment => "The database user must be able to read the parent directory of the database or it won't be accessible";
 
+     "$(sys.statedir)/."
+        perms => mog("0600", "root", "root" ),
+        depth_search => recurse_except( inf, "pg" ),
+        file_select => all,
+        comment => "The database user must be able to read the parent directory of the database or it won't be accessible";
+
       "$(sys.statedir)/pg/."
         perms => mog("0600", "cfpostgres", "cfpostgres"),
-        depth_search => recurse( inf ),
+        depth_search => recurse_with_base( inf ),
         comment => "No one except for the database user needs to access where the db is installed.";
-
-
-    !(policy_sever|am_policy_hub)::
-
-      "$(sys.statedir)/."
-        perms => mog("0600", "root", "root");
-
-    !(policy_server|am_policy_hub)::
-
-      "$(sys.statedir)/."
-        perms => mog("0600", "root", "root"),
-        depth_search => recurse_without_basedir_exclude_pg( inf ),
-        file_select => all;
 }
 
 #############################################################################
-body depth_search recurse_without_basedir_exclude_pg(d)
+body depth_search recurse_except( d, exception)
 {
         depth => "$(d)";
         include_basedir => "false";
-        exclude_dirs => { "pg" };
+        exclude_dirs => { $(exception) };
 }
 
 #############################################################################

--- a/cfe_internal/enterprise/main.cf
+++ b/cfe_internal/enterprise/main.cf
@@ -71,4 +71,10 @@ bundle agent cfe_internal_enterprise_main
       "any" usebundle => cfe_internal_cleanup_agent_reports,
       handle => "cfe_internal_management_cleanup_agent_reports",
       comment => "Remove accumulated reports if they grow too large in size";
+
+    any::
+      "Permissions and Ownership"
+        usebundle => cfe_internal_permissions,
+        comment => "Specific expectations for permissions and ownership for cfengine itself";
+
 }


### PR DESCRIPTION
statedir promises have been moved from bundle agent cfe_internal_setup_knowledge
which was only run on a hub to a bundle that executes on clients as well so that
we can be sure that client permissions are restrictive as well.

Changelog: None
Ticket: ENT-4601