### PR TITLE
ENT-4628: Could not look up name 'root' (LookupAccountName) (3.12.x)

### DIFF
--- a/cfe_internal/enterprise/main.cf
+++ b/cfe_internal/enterprise/main.cf
@@ -76,7 +76,7 @@ bundle agent cfe_internal_enterprise_main
       handle => "cfe_internal_management_cleanup_agent_reports",
       comment => "Remove accumulated reports if they grow too large in size";
 
-    any::
+    !windows::
       "Permissions and Ownership"
         usebundle => cfe_internal_permissions,
         comment => "Specific expectations for permissions and ownership for cfengine itself";


### PR DESCRIPTION
The "Permissions and Ownership" policy is only suitable for UNIX systems.

Changelog: none
(cherry picked from commit 7e82bb814218bb6f7675994ccd2bab4e4e09b5b0)