### PR TITLE
Always set files_single_copy from augments if available (3.10.x)

### DIFF
--- a/controls/cf_agent.cf
+++ b/controls/cf_agent.cf
@@ -32,16 +32,16 @@ body agent control
       # Maximum number of outgoing connections to a remote cf-serverd.
       maxconnections => "$(def.control_agent_maxconnections)";
 
+      # File patterns which allow a file to be copied over only a single time
+      # per agent run.
+
+      files_single_copy => { @(def.control_agent_files_single_copy) };
+
     mpf_control_agent_default_repository::
 
       # Location to backup files before they are edited by cfengine
 
       default_repository => "$(def.control_agent_default_repository)";
-
-      # File patterns which allow a file to be copied over only a single time
-      # per agent run.
-
-      files_single_copy => { @(def.control_agent_files_single_copy) };
 
       # Environment variables based on Distro
 


### PR DESCRIPTION
Not only when the mpf_control_agent_default_repository class is
defined.

(cherry picked from commit b8f0f0ddc29a2c46538c238dd853df2568723d4d)