### PR TITLE
Set default access promises for directories only if directories exist (3.12.x)

### DIFF
--- a/controls/cf_serverd.cf
+++ b/controls/cf_serverd.cf
@@ -102,33 +102,39 @@ bundle server access_rules()
       handle => "server_access_grant_access_policy",
       shortcut => "masterfiles",
       comment => "Grant access to the policy updates",
+      if => isdir( "$(def.dir_masterfiles)/" ),
       admit => { @(def.acl) };
 
       "$(def.dir_software)/"
       handle => "server_access_grant_access_datafiles",
       comment => "Grant access to software updates",
+      if => isdir( "$(def.dir_software)/" ),
       admit => { @(def.acl) };
 
       "$(def.dir_bin)/"
       handle => "server_access_grant_access_binary",
       comment => "Grant access to binary for cf-runagent",
+      if => isdir( "$(def.dir_bin)/" ),
       admit => { @(def.acl) };
 
       "$(def.dir_modules)/"
       handle => "server_access_grant_access_modules",
       shortcut => "modules",
       comment => "Grant access to modules directory",
+      if => isdir( "$(def.dir_modules)/" ),
       admit => { @(def.acl) };
 
       "$(def.dir_plugins)/"
       handle => "server_access_grant_access_plugins",
       comment => "Grant access to plugins directory",
+      if => isdir( "$(def.dir_plugins)/" ),
       admit => { @(def.acl) };
 
       "$(def.dir_templates)/"
       handle => "server_access_grant_access_templates",
       shortcut => "templates",
       comment => "Grant access to templates directory",
+      if => isdir( "$(def.dir_templates)/" ),
       admit => { @(def.acl) };
 
       enterprise_edition.policy_server::
@@ -146,6 +152,7 @@ bundle server access_rules()
       "$(sys.workdir)/ppkeys/"
       handle => "server_access_grant_access_ppkeys_hubs",
       comment => "Grant access to ppkeys for HA hubs",
+      if => isdir( "$(sys.workdir)/ppkeys/" ),
       admit => { @(def.policy_servers) };
 
       # Allow slave hub to synchronize cf_robot and appsettings content.
@@ -166,7 +173,8 @@ bundle server access_rules()
       # accessible.
       "/opt/cfengine/notification_scripts/"
       handle => "server_access_grant_access_notification scripts",
-      comment => "Grant access tonotification scripts",
+      comment => "Grant access to notification scripts",
+      if => isdir( "/opt/cfengine/notification_scripts/" ),
       admit => { @(def.policy_servers) };
 
       # When HA is enabled clients are updating active hub IP address
@@ -183,6 +191,7 @@ bundle server access_rules()
       "$(ha_def.hubs_keys_location)/"
       handle => "server_access_grant_access_to_clients",
       comment => "Grant access to hubs' keys to clients",
+      if => isdir("$(ha_def.hubs_keys_location)/"),
       admit => { @(def.acl) };
 
     windows::


### PR DESCRIPTION
Not only when the mpf_control_agent_default_repository class is
defined.

Ticket: CFE-3064
Changelog: Title
(cherry picked from commit b8f0f0ddc29a2c46538c238dd853df2568723d4d)