### PR TITLE
Set default access promises for directories to only share if directory exists (3.10.x)

### DIFF
--- a/controls/cf_serverd.cf
+++ b/controls/cf_serverd.cf
@@ -85,33 +85,39 @@ bundle server access_rules()
       handle => "server_access_grant_access_policy",
       shortcut => "masterfiles",
       comment => "Grant access to the policy updates",
+      if => isdir( "$(def.dir_masterfiles)/" ),
       admit => { @(def.acl) };
 
       "$(def.dir_software)/"
       handle => "server_access_grant_access_datafiles",
       comment => "Grant access to software updates",
+      if => isdir( "$(def.dir_software)/" ),
       admit => { @(def.acl) };
 
       "$(def.dir_bin)/"
       handle => "server_access_grant_access_binary",
       comment => "Grant access to binary for cf-runagent",
+      if => isdir( "$(def.dir_bin)/" ),
       admit => { @(def.acl) };
 
       "$(def.dir_modules)/"
       handle => "server_access_grant_access_modules",
       shortcut => "modules",
       comment => "Grant access to modules directory",
+      if => isdir( "$(def.dir_modules)/" ),
       admit => { @(def.acl) };
 
       "$(def.dir_plugins)/"
       handle => "server_access_grant_access_plugins",
       comment => "Grant access to plugins directory",
+      if => isdir( "$(def.dir_plugins)/" ),
       admit => { @(def.acl) };
 
       "$(def.dir_templates)/"
       handle => "server_access_grant_access_templates",
       shortcut => "templates",
       comment => "Grant access to templates directory",
+      if => isdir( "$(def.dir_templates)/" ),
       admit => { @(def.acl) };
 
       enterprise_edition.policy_server::
@@ -129,6 +135,7 @@ bundle server access_rules()
       "$(sys.workdir)/ppkeys/"
       handle => "server_access_grant_access_ppkeys_hubs",
       comment => "Grant access to ppkeys for HA hubs",
+      if => isdir( "$(sys.workdir)/ppkeys/" ),
       admit => { @(def.policy_servers) };
 
       # Allow slave hub to synchronize cf_robot and appsettings content.
@@ -149,7 +156,8 @@ bundle server access_rules()
       # accessible.
       "/opt/cfengine/notification_scripts/"
       handle => "server_access_grant_access_notification scripts",
-      comment => "Grant access tonotification scripts",
+      comment => "Grant access to notification scripts",
+      if => isdir( "/opt/cfengine/notification_scripts/" ),
       admit => { @(def.policy_servers) };
 
       # When HA is enabled clients are updating active hub IP address
@@ -166,6 +174,7 @@ bundle server access_rules()
       "$(ha_def.hubs_keys_location)/"
       handle => "server_access_grant_access_to_clients",
       comment => "Grant access to hubs' keys to clients",
+      if => isdir("$(ha_def.hubs_keys_location)/"),
       admit => { @(def.acl) };
 
     windows::


### PR DESCRIPTION
In particular, /var/cfengine/templates does not exist by default. Running
cf-serverd with log level info emits messages noting the path does not exist.

info: Failed to canonicalise filename '/var/cfengine/templates/' (realpath: No such file or directory)
info: Path does not exist, it's added as-is in access rules: /var/cfengine/templates/

Instead of sending a user chasing to see if something is wrong, we now just
avoid providing access to paths that are not directories when we expect them to
be.

Ticket: CFE-3060
Changelog: Title
(cherry picked from commit 353169594ff6d1377350d56029fe60dd88677f40)