### PR TITLE
Use the feeder's key digest in names of its dump files

### DIFF
--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -192,6 +192,7 @@ bundle agent federation_manage_files
       string => "$(cfengine_enterprise_federation:config.transport_user)";
     "login" data => parsejson('{"login":"$(cfengine_enterprise_federation:config.login)"}');
     "feeder_username" data => parsejson('{"feeder_username":"$(cfengine_enterprise_federation:config.transport_user)"}');
+    "feeder" data => parsejson('{"feeder": "$(sys.key_digest)"}');
 
   methods:
       "internal_vars" usebundle => "default:cfe_internal_hub_vars",
@@ -243,7 +244,8 @@ bundle agent federation_manage_files
         create => "true",
         template_method => "mustache",
         edit_template => "$(this.promise_dirname)/../../../templates/federated_reporting/config.sh.mustache",
-        template_data => mergedata(@(login), @(feeder_username), @(cfengine_enterprise_federation:inventory_refresh_cmd.cmd)),
+        template_data => mergedata(@(login), @(feeder_username), @(feeder),
+                                   @(cfengine_enterprise_federation:inventory_refresh_cmd.cmd)),
         perms => default:mog( "640", "root", "$(transport_user)" );
 
       # TODO: Instrument augments


### PR DESCRIPTION
The host key is a good unique identifier of the feeder and will
help us to identify the partition/schema to insert the data into.

Ticket: ENT-4613
Changelog: None