### PR TITLE
[3.12.x] Do not run DB maintenance tasks on a passive HA hub

### DIFF
--- a/cfe_internal/enterprise/CFE_hub_specific.cf
+++ b/cfe_internal/enterprise/CFE_hub_specific.cf
@@ -263,21 +263,6 @@ bundle agent cfe_internal_php_runalerts
                     when available. Prior to 3.10 the service is supervised
                     directly by CFEngine policy.";
 
-      # NOTE The `hub_active` class is a hard class defined by the ha_plugin in
-      # the enterprise agent.
-      "active_hub"
-      comment => "The runalerts service should only run on policy servers that
-                  are active.",
-      scope => "bundle",
-      expression => "policy_server.(!enable_cfengine_enterprise_hub_ha|(enable_cfengine_enterprise_hub_ha.hub_active))";
-
-      # TODO Consider using `hub_passive` instead of `!hub_active`
-      "passive_ha_hub"
-      comment => "To avoid duplicate alerts the runalerts service should not run
-                  on standby hubs.",
-      scope => "bundle",
-      expression => "policy_server.(enable_cfengine_enterprise_hub_ha.!hub_active)";
-
   files:
 
     any::
@@ -488,6 +473,23 @@ bundle agent log_cfengine_enterprise_license_utilization
 
 }
 
+bundle agent cfe_internal_enterprise_HA_classes
+{
+  classes:
+      # NOTE The `hub_active` class is a hard class defined by the ha_plugin in
+      # the enterprise agent.
+      "active_hub"
+        expression => "policy_server.(!enable_cfengine_enterprise_hub_ha|(enable_cfengine_enterprise_hub_ha.hub_active))",
+        scope => "namespace",
+        comment => "This means this is a hub that is not in an HA setup or the active one in a HA setup";
+
+      # TODO Consider using `hub_passive` instead of `!hub_active`
+      "passive_ha_hub"
+        expression => "policy_server.(enable_cfengine_enterprise_hub_ha.!hub_active)",
+        scope => "namespace",
+        comment => "This means this is a passive hub in an HA setup";
+}
+
 bundle agent cfe_internal_enterprise_maintenance
 # @brief Actuate bundles tagged with `enterprise_maintenance` in lexically sorted order
 {
@@ -506,6 +508,11 @@ bundle agent cfe_internal_enterprise_maintenance
         int => length( enterprise_maintenance_bundles );
 
   methods:
+
+    enterprise_edition::
+      "HA classes"
+        usebundle => "cfe_internal_enterprise_HA_classes",
+        comment => "Set the HA-related classes for the maintenance bundles";
 
       "Enterprise Maintenance"
         usebundle => $(enterprise_maintenance_bundles),
@@ -533,7 +540,7 @@ bundle agent cfe_internal_refresh_inventory_view
 
   commands:
 
-    (policy_server|am_policy_hub).enterprise_edition::
+    (policy_server|am_policy_hub).enterprise_edition.active_hub::
 
       "$(sys.workdir)/httpd/php/bin/php"
         args => "$(cfe_internal_hub_vars.docroot)/index.php cli_tasks inventory_refresh",
@@ -555,7 +562,7 @@ bundle agent cfe_internal_refresh_hosts_view
 
   commands:
 
-    (policy_server|am_policy_hub).enterprise_edition::
+    (policy_server|am_policy_hub).enterprise_edition.active_hub::
 
       "$(sys.workdir)/httpd/php/bin/php" -> { "ENT-3482" }
         args => "$(cfe_internal_hub_vars.docroot)/index.php cli_tasks materialized_hosts_view_refresh",
@@ -577,7 +584,7 @@ bundle agent cfe_internal_clear_last_seen_hosts_logs
 
   commands:
 
-    (policy_server|am_policy_hub).enterprise_edition::
+    (policy_server|am_policy_hub).enterprise_edition.active_hub::
 
       "$(sys.workdir)/httpd/php/bin/php" -> { "ENT-3550" }
         args => "$(cfe_internal_hub_vars.docroot)/index.php cli_tasks clearLastSeenHostsLogs",
@@ -599,7 +606,7 @@ bundle agent cfe_internal_refresh_events_table
 
   commands:
 
-    (policy_server|am_policy_hub).enterprise_edition::
+    (policy_server|am_policy_hub).enterprise_edition.active_hub::
 
       "$(sys.workdir)/httpd/php/bin/php"
         args => "$(cfe_internal_hub_vars.docroot)/index.php cli_tasks process_api_events",


### PR DESCRIPTION
They all just fail because the DB is read-only on a passive HA
hub. Changes are done on the active one and replicated.

Ticket: ENT-4706
Changelog: Title
(cherry picked from commit 704e262c54ff818d3bd622a48fe70d65d9bc5bf2)