### PR TITLE
CFE-3073: Added continual checking for policy_server state (master)

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -1028,6 +1028,31 @@ For example, to only allow any file to be copied a single time:
 
 **History**: Added in 3.11.0, 3.10.2
 
+### Disable automatic policy hub detection
+
+During bootstrap, if the executing host finds the IP address of the target on
+itself it automatically classifies the host as a policy server by ensuring the
+`$(sys.statedir)/am_policy_hub` file exists. When this file exists, the
+`am_policy_hub` and `policy_server` classes are defined. To help avoid
+accidental declassification, the MPF contains policy to regularly check if the
+host is bootstrapped to an IP found on itself, and if so, to ensure the proper
+state file exists.
+
+To disable this check, define `mpf_auto_am_policy_hub_state_disabled`.
+
+For example, to define this class via augments, place the following in your def.json.
+
+```
+{
+  "classes":{
+    "mpf_auto_am_policy_hub_state_disabled": [ "any" ]
+  }
+
+}
+```
+
+**History**: Added in 3.15.0, 3.12.3, 3.10.7
+
 ### Configure default repository for file backups
 
 By default the agent creates a backup of a file before it is edited in the same

--- a/cfe_internal/core/main.cf
+++ b/cfe_internal/core/main.cf
@@ -1,6 +1,13 @@
 bundle agent cfe_internal_core_main
 {
   methods:
+
+    !mpf_auto_am_policy_hub_state_disabled::
+
+      "Verify policy hub state" -> { "CFE-3073" }
+        usebundle => mpf_auto_am_policy_hub_state,
+        if => not( fileexists( "$(sys.statedir)/am_policy_hub" ));
+
     any::
 
 #   NB! On a container host this may kill CFEngine processes inside containers.
@@ -31,6 +38,20 @@ bundle agent cfe_internal_core_main
 
 }
 
+bundle agent mpf_auto_am_policy_hub_state
+# @brief Ensure that `$(sys.statedir)/am_policy_hub` file is present when expected
+{
+  files:
+
+      # We think we are a policy hub if the policy server (the host you
+      # bootstrapped to) resolves to an IP found on the host. This is intended
+      # to prevent accidental removal of the am_policy_hub state file.
+
+      "$(sys.statedir)/am_policy_hub"
+        create => "true",
+        if => some( escape( $(sys.policy_server) ), @(sys.ipaddresses) );
+
+}
 bundle agent mpf_augments_control
 # @brief Restart cfenigne components when one of the control variables has changed.
 #


### PR DESCRIPTION
Previously, we relied only on the presence of the am_policy_hub state file for
classification. This change regularly checks to see if the executing host is
bootstrapped to an ip found on itself, and if so it ensures the state file is
present. This helps to avoid accidental declassification from the accidental
removal of the state file. It uses the same logic that is used during bootstrap.

Ticket: CFE-3073
Changelog: Title