### PR TITLE
ENT-4724: Added explicit perms to setup-status.json

### DIFF
--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -479,6 +479,7 @@ bundle agent setup_status
     superhub_setup_status_complete::
       "$(cfengine_enterprise_federation:config.federation_dir)/cfapache/setup-status.json"
         create => "true",
+        perms => default:mog( "600", "cfapache", "root" ),
         template_method => "inline_mustache",
         edit_template_string => "{{%-top-}}$(const.n)",
         template_data => '{


### PR DESCRIPTION
Makes sure the file is accessible to MP after the first run.
Permissions were being fixed on the second run before.