### PR TITLE
Fixed continual repair of permissions for ha_enabled semaphore in Enterprise edition

### DIFF
--- a/cfe_internal/enterprise/ha/ha.cf
+++ b/cfe_internal/enterprise/ha/ha.cf
@@ -24,14 +24,16 @@ bundle agent ha_manage_mp_status_file
   policy_server.!enable_cfengine_enterprise_hub_ha::
     "$(sys.workdir)/httpd/htdocs/ha_enabled" -> { "Mission Portal" }
       delete => tidy,
+      handle => "cfengine_enterprise_ha_enabled_semaphore_absent",
       comment => "If this file is present when HA is not enabled
                   Mission Portal will incorrectly report HA status.";
 
   policy_server.enable_cfengine_enterprise_hub_ha::
-    "$(sys.workdir)/httpd/htdocs/ha_enabled" -> { "Mission Portal" }
+    "$(sys.workdir)/httpd/htdocs/ha_enabled" -> { "Mission Portal", "ENT-4751" }
      create => "true",
-     perms => mog("0644",$(def.cf_apache_user),$(def.cf_apache_group)),
-     comment => "This file is used by mission portal to know that HA
+     handle => "cfengine_enterprise_ha_enabled_semaphore_present",
+     perms => mog("0440",$(def.cf_apache_user),$(def.cf_apache_group)),
+     comment => "This file is read by mission portal to know that HA
                  is enabled. Without it the UI will not report the
                  correct HA status.";
 }


### PR DESCRIPTION
Aligned explicit permissions for ha_enabled semaphore with default for htdocs
preventing continual permission repair.

Ticket: ENT-4715
Changelog: None
(cherry picked from commit 49294d9ff01c10157838ce4af3d313036cb8004c)