### PR TITLE
Fix failure propagation in parallel.sh when using background jobs

### DIFF
--- a/templates/federated_reporting/parallel.sh
+++ b/templates/federated_reporting/parallel.sh
@@ -76,7 +76,18 @@ _run_using_for() {
     "$1" "$item" &
     job_slots="$(expr $job_slots - 1)"
   done < $input_arg
-  wait
+
+  # wait for the jobs one by one and check the exit statuses (127 means there
+  # are no more jobs to wait for)
+  wait -n
+  exit_status=$?
+  while [ $exit_status != 127 ]; do
+    wait -n
+    exit_status=$?
+    if [ $exit_status != 0 ] && [ $exit_status != 127 ] && [ $failure = 0 ]; then
+      failure=1
+    fi
+  done
   return $failure
 }
 


### PR DESCRIPTION
When waiting for the jobs to finish, we need to wait for one at a
time, check its exit code and record it in case of
failure. Waiting for all jobs at once just gives us an exit code
of a random one of them. So a failure can potentially be
ignored. 'xargs' and 'parallel' both handle this for us.