### PR TITLE
ENT-4842: partitioned __inventory table for federated reporting

### DIFF
--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -370,11 +370,20 @@ body contain cfpostgres_user
 bundle agent exported_data
 # @brief Run script to dump pg data on feeder hub
 {
+  methods:
+    am_feeder::
+      "Refresh Inventory"
+        usebundle => "default:cfe_internal_refresh_inventory_view",
+        handle => "fr_inventory_refresh",
+        comment => "Use standard inventory refresh so that we don't run it twice";
+
   commands:
     am_feeder::
       "/bin/bash"
         arglist => {"$(cfengine_enterprise_federation:config.bin_dir)/dump.sh"},
-        contain => default:in_shell;
+        contain => default:in_shell,
+        depends_on => { "fr_inventory_refresh" },
+        comment => "Refresh Inventory must be completed before dumping data";
 }
 
 bundle agent data_transport

--- a/templates/federated_reporting/config.sh.mustache
+++ b/templates/federated_reporting/config.sh.mustache
@@ -28,6 +28,7 @@ __benchmarkslog
 __contextslog
 __promiseexecutions
 __promiselog_*
+__inventory
 contextcache"
 CFE_FR_TABLES="{{tables}}"
 CFE_FR_TABLES="${CFE_FR_TABLES:-$DEFAULT_TABLES}"
@@ -70,7 +71,6 @@ CFE_FR_IMPORT_NJOBS="{{n_jobs}}"           # no explicit limit of jobs by defaul
                                            # (will use all the CPUs available)
 CFE_FR_IMPORT_FILTERS_DIR="{{import_filters_dir}}"
 CFE_FR_IMPORT_FILTERS_DIR="${CFE_FR_IMPORT_FILTERS_DIR:-$DEFAULT_PREFIX/superhub/import/filters}"
-# no inventory refresh command by default (=> no inventory refresh after import)
 CFE_FR_INVENTORY_REFRESH_CMD="{{inventory_refresh_cmd}}"
 CFE_FR_DB_USER="{{db_user}}"
 CFE_FR_DB_USER="${CFE_FR_DB_USER:-cfpostgres}"

--- a/templates/federated_reporting/import.sh
+++ b/templates/federated_reporting/import.sh
@@ -62,6 +62,8 @@ else
     hostkey=$(basename "$file" | cut -d. -f1)
     "$CFE_BIN_DIR"/psql -U $CFE_FR_DB_USER -d cfdb -c "SELECT drop_feeder_schema('$hostkey');" || true
   done
+  echo "last 10 lines of schema_setup.log"
+  tail -n 10 schema_setup.log
   exit 1
 fi
 
@@ -103,6 +105,8 @@ else
   # attach_feeder_schema() makes sure the feeder's import schema is removed in
   # case of failure
   log "Attaching schemas: FAILED"
+  log "last 10 lines of schema_attach.log"
+  tail -n 10 schema_attach.log
   exit 1
 fi
 

--- a/templates/federated_reporting/import_file.sh
+++ b/templates/federated_reporting/import_file.sh
@@ -60,5 +60,7 @@ EOF
   exit 0
 } || {
   mv "$file.importing" "$file.failed"
+  echo "last 10 lines of log $file.log.$CFE_FR_COMPRESSOR_EXT"
+  "$CFE_FR_COMPRESSOR" "$file.log.$CFE_FR_COMPRESSOR_EXT" | tail -n 10
   exit 1
 }


### PR DESCRIPTION
Added __inventory table to whitelist of tables to import.
Rely on feeders for __inventory data instead of running large
update on superhub.

Changelog: Title

merge with https://github.com/cfengine/nova/pull/1461