### PR TITLE
ENT-4906: added ssh_home_t type to cftransport .ssh dir

### DIFF
--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -153,12 +153,17 @@ bundle agent transport_user
           "$(ssh_known_hosts)",
           "$(ssh_config)"
         };
+      "ssh_home_cil_file" string => "/tmp/cftransport_ssh_home_t.cil";
+
   classes:
     enabled::
       "selinux_enabled"
-        expression => strcmp("Enforcing", execresult("getenforce", useshell));
+        expression => strcmp("Enforcing", execresult("$(paths.getenforce)", noshell));
       "missing_ssh_context"
         expression => not( or(
+                               regcmp(".*[\s:]ssh_home_t[\s:].*",
+                                      execresult("ls -Z $(home) | grep .ssh",
+                                                 useshell)),
                                regcmp(".*[\s:]ssh_home_t[\s:].*",
                                       execresult("ls -Z $(ssh_auth_keys)",
                                                  useshell)),
@@ -200,7 +205,18 @@ bundle agent transport_user
       handle => "ssh_config_configured",
       edit_line => default:insert_lines("IdentityFile $(ssh_priv_key)");
 
+    selinux_enabled.missing_ssh_context::
+      "$(ssh_home_cil_file)"
+        create => "true",
+        edit_defaults => default:empty,
+        edit_line => default:insert_lines('(filecon "$(home)/.ssh" any (system_u object_r ssh_home_t ((s0)(s0))))');
+
   commands:
+    selinux_enabled.missing_ssh_context::
+      # the filename becomes the name for the selinux policy (as listed by semodule -l)
+      "$(paths.semodule) -i $(ssh_home_cil_file)";
+      "$(paths.restorecon) -R -F  $(home)/.ssh/";
+
     # Generate a modern ssh keypair (2019-04)
     "/usr/bin/ssh-keygen"
       handle => "ssh_keys_configured",
@@ -208,9 +224,6 @@ bundle agent transport_user
       if => and( isdir( "$(home)/.ssh" ),
                  not( fileexists( "$(ssh_priv_key)" )));
 
-    selinux_enabled.missing_ssh_context::
-      "restorecon -R -F  $(home)/.ssh/"
-        contain => default:in_shell;
 }
 
 bundle agent inventory_refresh_cmd

--- a/lib/paths.cf
+++ b/lib/paths.cf
@@ -345,6 +345,7 @@ bundle common paths
       "path[ethtool]"       string => "/usr/sbin/ethtool";
       "path[find]"          string => "/usr/bin/find";
       "path[free]"          string => "/usr/bin/free";
+      "path[getenforce]"    string => "/usr/sbin/getenforce";
       "path[grep]"          string => "/bin/grep";
       "path[hostname]"      string => "/bin/hostname";
       "path[init]"          string => "/sbin/init";
@@ -357,7 +358,9 @@ bundle common paths
       "path[ping]"          string => "/usr/bin/ping";
       "path[perl]"          string => "/usr/bin/perl";
       "path[printf]"        string => "/usr/bin/printf";
+      "path[restorecon]"    string => "/usr/sbin/restorecon";
       "path[sed]"           string => "/bin/sed";
+      "path[semodule]"      string => "/usr/sbin/semodule";
       "path[sort]"          string => "/bin/sort";
       "path[test]"          string => "/usr/bin/test";
       "path[tr]"            string => "/usr/bin/tr";
@@ -436,6 +439,7 @@ bundle common paths
       "path[ethtool]"       string => "/sbin/ethtool";
       "path[find]"          string => "/usr/bin/find";
       "path[free]"          string => "/usr/bin/free";
+      "path[getenforce]"    string => "/usr/sbin/getenforce";
       "path[grep]"          string => "/bin/grep";
       "path[hostname]"      string => "/bin/hostname";
       "path[init]"          string => "/sbin/init";
@@ -448,7 +452,9 @@ bundle common paths
       "path[ping]"          string => "/bin/ping";
       "path[perl]"          string => "/usr/bin/perl";
       "path[printf]"        string => "/usr/bin/printf";
+      "path[restorecon]"    string => "/sbin/restorecon";
       "path[sed]"           string => "/bin/sed";
+      "path[semodule]"      string => "/usr/sbin/semodule";
       "path[sort]"          string => "/usr/bin/sort";
       "path[test]"          string => "/usr/bin/test";
       "path[tr]"            string => "/usr/bin/tr";


### PR DESCRIPTION
On Centos6 the agent was unable to generate a key with
ssh-keygen due to mismatched contexts on cftransport .ssh
dir.

Changelog: title