### PR TITLE
ENT-4912: psql_wrapper needed full path to psql binary

### DIFF
--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -292,8 +292,10 @@ bundle agent federation_manage_files
         copy_from => default:local_dcp( "$(this.promise_dirname)/../../../templates/federated_reporting/parallel.sh" ),
         perms => default:mog( "640", "root", "$(transport_user)" );
 
-      "$(cfengine_enterprise_federation:config.bin_dir)/psql_wrapper.sh"
-        copy_from => default:local_dcp( "$(this.promise_dirname)/../../../templates/federated_reporting/psql_wrapper.sh" ),
+      "$(cfengine_enterprise_federation:config.bin_dir)/psql_wrapper.sh" -> { "ENT-4792"}
+        create => "true",
+        edit_template => "$(this.promise_dirname)/../../../templates/federated_reporting/psql_wrapper.sh.mustache",
+        template_method => "mustache",
         perms => default:mog( "700", "root", "root" );
 
     am_feeder::

--- a/templates/federated_reporting/psql_wrapper.sh
+++ b/templates/federated_reporting/psql_wrapper.sh
@@ -13,7 +13,7 @@ if [ $# -ne 2 ]; then
 fi
 
 TMP=$(mktemp)
-OUT=$(su - cfpostgres --command "psql --quiet --tuples-only --no-align --no-psqlrc \"$1\" --command=\"$2\"" 2> $TMP)
+OUT=$(su - cfpostgres --command "/var/cfengine/bin/psql --quiet --tuples-only --no-align --no-psqlrc \"$1\" --command=\"$2\"" 2> $TMP)
 RETURN_CODE=$?
 ERR=$(<$TMP)
 

--- a/templates/federated_reporting/psql_wrapper.sh.mustache
+++ b/templates/federated_reporting/psql_wrapper.sh.mustache
@@ -13,7 +13,7 @@ if [ $# -ne 2 ]; then
 fi
 
 TMP=$(mktemp)
-OUT=$(su - cfpostgres --command "/var/cfengine/bin/psql --quiet --tuples-only --no-align --no-psqlrc \"$1\" --command=\"$2\"" 2> $TMP)
+OUT=$(su - cfpostgres --command "{{{vars.sys.bindir}}}/psql --quiet --tuples-only --no-align --no-psqlrc \"$1\" --command=\"$2\"" 2> $TMP)
 RETURN_CODE=$?
 ERR=$(<$TMP)
 


### PR DESCRIPTION
On systems which have other versions of psql binary earlier
in $PATH psql_wrapper will likely fail to connect to database.

Changelog: title