### PR TITLE
Fix Python 3 incompatibility in yum package module

### DIFF
--- a/modules/packages/yum.in
+++ b/modules/packages/yum.in
@@ -133,7 +133,7 @@ def list_updates(online):
         # Nothing to do for us here anyway
         return process.returncode
     lastline = ""
-    for line in stdoutdata.splitlines():
+    for line in stdoutdata.decode("utf-8").splitlines():
         # Combine multiline entries into one line. A line without at least three
         # space separated fields gets combined with the next line, if that line
         # starts with a space.


### PR DESCRIPTION
Process output in Python 3 is of type 'bytes' which cannot be
treated as string. It first needs to be decoded into a (unicode)
string. In Python 2 it is a string which can be decoded into a
unicode object. So in both cases it is safe to do
`output.decode("utf-8")` to get a valid string-like object.

Changelog: Fixed Python 3 incompatibility in yum package module