### PR TITLE
Revert "ENT-4937: Need to specify path relative to this.promise_dirname instead of sys.inputdir. (3.14.0-x)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
         - DATE="${DATE#*>}"
         - DIR_URL="https://builds.cfengine.com/pub/nightly/master/$DATE/output/PACKAGES_x86_64_linux_debian_7"
         - FILE=`wget --no-check-certificate -qO- "$DIR_URL" | grep -o '[^>]*\.deb<'`
-        - FILE="${FILE%%<*}"
+        - FILE="${FILE%<}"
         - wget --no-check-certificate $DIR_URL/$FILE
         - sudo dpkg -i $FILE
 

--- a/cfe_internal/enterprise/CFE_hub_specific.cf
+++ b/cfe_internal/enterprise/CFE_hub_specific.cf
@@ -14,15 +14,9 @@
 #
 ##################################################################
 
-bundle common cfe_hub_specific_file_control
-{
-  vars:
-    "inputs" slist => { "$(this.promise_dirname)/federation/federation.cf" };
-}
-
 body file control
 {
-        inputs => { @(cfe_hub_specific_file_control.inputs) };
+        inputs => { "$(sys.inputdir)/cfe_internal/enterprise/federation/federation.cf" };
 }
 
 bundle common cfe_internal_hub_vars

--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -1,12 +1,6 @@
-bundle common federation_file_control
-{
-  vars:
-    "inputs" slist => { "$(sys.local_libdir)/stdlib.cf", "$(this.promise_dirname)/../CFE_hub_specific.cf" };
-}
-
 body file control
 {
-        inputs => { @(federation_file_control.inputs) };
+        inputs => { "$(sys.libdir)/stdlib.cf", "$(sys.inputdir)/cfe_internal/enterprise/CFE_hub_specific.cf" };
         namespace => "cfengine_enterprise_federation";
 }
 


### PR DESCRIPTION
Reverts cfengine/masterfiles#1488