### PR TITLE
Python 3 support in pkg modules and their unittests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,11 +2,7 @@ ACLOCAL_AMFLAGS = -I m4
 
 SUBDIRS = \
 	modules/packages \
-	tests/unit
-
-if HAVE_CORE
-    SUBDIRS += tests/acceptance
-endif
+	tests/
 
 # See configure.ac for MASTERFILES_INSTALL_TARGETS.
 nobase_dist_masterfiles_DATA = @MASTERFILES_INSTALL_TARGETS@

--- a/configure.ac
+++ b/configure.ac
@@ -240,6 +240,7 @@ AC_CONFIG_FILES([Makefile
                 modules/packages/zypper
                 promises.cf
                 standalone_self_upgrade.cf
+                tests/Makefile
                 tests/acceptance/Makefile
                 tests/unit/Makefile
 ])

--- a/modules/packages/yum.in
+++ b/modules/packages/yum.in
@@ -173,7 +173,7 @@ def one_package_argument(name, arch, version, is_yum_install):
     if is_yum_install:
         process = subprocess_Popen([rpm_cmd, "--qf", "%{arch}\n",
                                     "-q", name], stdout=subprocess.PIPE)
-        existing_archs = [line.rstrip() for line in process.stdout]
+        existing_archs = [line.decode("utf-8").rstrip() for line in process.stdout]
         process.wait()
         if process.returncode == 0 and existing_archs:
             exists = True

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,0 +1,12 @@
+SUBDIRS = . unit
+
+if HAVE_CORE
+SUBDIRS += acceptance
+endif
+
+fix-python-hashbang:
+	@-test -x /usr/bin/python || find $(srcdir) -mindepth 2 -type f -exec sed -ri '\~/usr/bin/python($$|[^0-9])~ s|/usr/bin/python|/usr/bin/python3|' '{}' \;
+
+check-local: fix-python-hashbang
+
+.PHONY: fix-python-hashbang

--- a/tests/acceptance/17_packages/10_new/unsafe/the_great_package_test.cf
+++ b/tests/acceptance/17_packages/10_new/unsafe/the_great_package_test.cf
@@ -31,8 +31,14 @@ bundle agent init
   meta:
       # No package modules written for platforms besides RedHat and Debian.
       "test_skip_needs_work" string => "!debian.!redhat";
+
       # The package module does not support RedHat 4 or Debian 4 (Etch).
       "test_skip_unsupported" string => "centos_4|redhat_4|debian_4|debian_etch";
+
+      # RHEL 8 has broken DNF (upgrading a 32bit package also installs a 64bit
+      # package)
+      "test_soft_fail" string => "rhel_8",
+        meta  => {"CFE-rhbz"};
 
   methods:
     debian|redhat::

--- a/tests/acceptance/17_packages/10_new/unsafe/the_great_package_test_generator.py
+++ b/tests/acceptance/17_packages/10_new/unsafe/the_great_package_test_generator.py
@@ -114,8 +114,14 @@ bundle agent init
   meta:
       # No package modules written for platforms besides RedHat and Debian.
       "test_skip_needs_work" string => "!debian.!redhat";
+
       # The package module does not support RedHat 4 or Debian 4 (Etch).
       "test_skip_unsupported" string => "centos_4|redhat_4|debian_4|debian_etch";
+
+      # RHEL 8 has broken DNF (upgrading a 32bit package also installs a 64bit
+      # package)
+      "test_soft_fail" string => "rhel_8",
+        meta  => {"CFE-rhbz"};
 
   methods:
     debian|redhat::

--- a/tests/unit/test_package_module_apt_get
+++ b/tests/unit/test_package_module_apt_get
@@ -36,13 +36,13 @@ def check(operation, input, no_lines, expected_output, mock_lines, mock_output):
     process = subprocess.Popen(["/usr/bin/python", apt_get_module, operation],
                                stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     for line in input:
-        process.stdin.write(line + "\n")
+        process.stdin.write((line + "\n").encode("utf-8"))
     process.stdin.close()
 
     output = ""
     line_count = 0
     for line in process.stdout:
-        output += line
+        output += line.decode("utf-8")
         line_count += 1
 
     for chunk in expected_output:

--- a/tests/unit/test_package_module_yum
+++ b/tests/unit/test_package_module_yum
@@ -34,13 +34,13 @@ def check(operation, input, no_lines, expected_output, mock_lines, mock_output):
     process = subprocess.Popen(["/usr/bin/python", yum_module, operation],
                                stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     for line in input:
-        process.stdin.write(line + "\n")
+        process.stdin.write((line + "\n").encode("utf-8"))
     process.stdin.close()
 
     output = ""
     line_count = 0
     for line in process.stdout:
-        output += line
+        output += line.decode("utf-8")
         line_count += 1
 
     for chunk in expected_output:


### PR DESCRIPTION
Required for us to be able to run tests on RHEL 8.

Merge together:
https://github.com/cfengine/core/pull/3813
https://github.com/cfengine/masterfiles/pull/1492
https://github.com/cfengine/buildscripts/pull/612