### PR TITLE
CONTRIBUTING.md: Fixed links to core documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Contributing to the CFEngine masterfiles
 
-* Follow the [Core contribution guidelines](https://github.com/cfengine/core/blob/master/HACKING.md#how-to-contribute-to-cfengine)
+* Follow the [Core contribution guidelines](https://github.com/cfengine/core/blob/master/CONTRIBUTING.md#how-to-contribute-to-cfengine)
 * * Prefix commit subjects with the issue identifier
-* * Don't forget to include a [ChangeLog Entry](https://github.com/cfengine/core/blob/master/HACKING.md#changelog-entries)
+* * Don't forget to include a [ChangeLog Entry](https://github.com/cfengine/core/blob/master/CONTRIBUTING.md#changelog)
 * Follow the [policy style guide](https://docs.cfengine.com/docs/latest/guide-writing-and-serving-policy-policy-style.html)
 * Test thoroughly, provide [acceptance tests](https://github.com/cfengine/core/blob/master/tests/acceptance/README) to run in core or masterfiles using the [DCS framework](https://github.com/cfengine/core/blob/master/tests/acceptance/DCS.org)
 * Document well See [MPF.md](MPF.md)


### PR DESCRIPTION
Link target was renamed in cfengine/core@57a6fe96.