### PR TITLE
CFE-3150/master Fixed re-spawning of cf-execd or cf-monitord after remediating duplicate concurrent processes

### DIFF
--- a/cfe_internal/core/limit_robot_agents.cf
+++ b/cfe_internal/core/limit_robot_agents.cf
@@ -6,6 +6,26 @@
 ###############################################################################
 
 bundle agent cfe_internal_limit_robot_agents
+# @brief Remediate pathological case of duplicate cfengine daemons running concurrently
+{
+  methods:
+    any::
+      "Ensure there are not more than expected cfengine daemons" -> { "CFE-3150" }
+        usebundle => "cfe_internal_limit_robot_agents_reap";
+
+    more_cf_execd_processes_than_expected|more_cf_monitord_process_than_expected::
+
+      # We only look to re-launch daemons if we found a pathological case. It's
+      # important that these promises are in a separate bundle as we want to
+      # refresh our observation of the process table to ensure they are indeed
+      # not running.
+
+      "Ensure expected cfengine daemons are running" -> { "CFE-3150" }
+        usebundle => "cfe_internal_limit_robot_agents_spawn";
+
+}
+bundle agent cfe_internal_limit_robot_agents_reap
+# @brief Ensure that there are not more cfengine daemons running than there should be
 {
   processes:
 
@@ -35,11 +55,6 @@ bundle agent cfe_internal_limit_robot_agents
         comment => "When cf-execd comes undone then kill all and restart the process",
         handle => "cfe_internal_limit_robot_agents_processes_kill_cf_execd";
 
-      "bin/cf-execd" -> { "CFE-2974" }
-        restart_class => "cf_execd_not_running",
-        comment => "If cf-execd isn't running, define a class so that it will be started",
-        handle => "cfe_internal_limit_robot_agents_processes_cf_execd_not_running";
-
 
     more_cf_monitord_processes_than_expected::
 
@@ -48,6 +63,21 @@ bundle agent cfe_internal_limit_robot_agents
         comment => "When cf-monitord comes undone then kill all matching
                     process",
         handle => "cfe_internal_limit_robot_agents_processes_kill_cf_monitord";
+
+}
+
+bundle agent cfe_internal_limit_robot_agents_spawn
+# @brief Ensure that daemons are running after we have possibly reaped a pathological condition where more than the expected number of cfengine daemons was running
+{
+
+  processes:
+
+    !windows::
+
+      "bin/cf-execd" -> { "CFE-2974" }
+        restart_class => "cf_execd_not_running",
+        comment => "If cf-execd isn't running, define a class so that it will be started",
+        handle => "cfe_internal_limit_robot_agents_processes_cf_execd_not_running";
 
       "bin/cf-monitord" -> { "CFE-2963" }
         restart_class => "cf_monitord_not_running",
@@ -61,25 +91,27 @@ bundle agent cfe_internal_limit_robot_agents
     cf_execd_not_running::
 
       "$(sys.cf_execd)"
-      comment => "Restart cf-execd process",
-      handle => "cfe_internal_limit_robot_agents_commands_restart_cf_execd";
+        comment => "Restart cf-execd process",
+        handle => "cfe_internal_limit_robot_agents_commands_restart_cf_execd";
 
     cf_monitord_not_running::
 
       "$(sys.cf_monitord)"
-      comment => "Restart cf-monitord process",
-      handle => "cfe_internal_limit_robot_agents_commands_restart_cf_monitord";
+        comment => "Restart cf-monitord process",
+        handle => "cfe_internal_limit_robot_agents_commands_restart_cf_monitord";
 
 }
 
 body process_count check_execd(n)
 {
       match_range => "0,$(n)";
+      # Note this class is namespace scoped. Other bundles do use it
       out_of_range_define => {"more_cf_execd_processes_than_expected"};
 }
 
 body process_count check_monitord(n)
 {
       match_range => "0,$(n)";
+      # Note this class is namespace scoped. Other bundles do use it
       out_of_range_define => {"more_cf_monitord_processes_than_expected"};
 }


### PR DESCRIPTION
As long as refresh_processes in body agent control is null (which it is in the
MPF by default) cf-agent refreshes the process table each time a bundle is
entered. Re-spawning failed to work because the promises to spawn cf-execd or
cf-monitord were based on direct inspection of the process table, and in the
case of remediation being necessary, there were more than the expected number of
processes running.

This change separates those promises to re-spawn daemons after remediation to a
separate bundle so that the promises will be inspecting a fresh version of the
process table.