### PR TITLE
pkgsrc: read -u 0 doesn't work on Solaris/NetBSD

### DIFF
--- a/modules/packages/pkgsrc
+++ b/modules/packages/pkgsrc
@@ -140,7 +140,7 @@ parse_pkg_data () {
 }
 
 # Cfengine passes data on STDIN. Absorb that and convert to shell variables.
-while IFS= read -r -u 0 line; do
+while IFS= read -r line; do
   eval "$line"
   # options can be passed multiple times so we need to avoid clobbering
   # previous instances. Plus, what we really want to eval is the value of


### PR DESCRIPTION
In the package module: pkgsrc read -r -u 0 is used.
-u 0 doesn't work on Solaris or NetBSD. Because of this the pkgsrc modules doesn't work on these platforms.
-u 0 dictates to read from STDIN, that is the default. Becuase of this is harmless to remove the -u 0 parameter. I have tested in Solaris 11 using the pkgsrc module.