### PR TITLE
Fixed agent disabling on systemd systems

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -365,8 +365,6 @@ This [augments file][Augments] will ensure that `cf-monitord` is disabled on hos
 }
 ```
 
-**Note:** By default MPF does not manage systemd units. This must be enabled by uncommenting policy in [cfe_internal_update_processes](https://github.com/cfengine/masterfiles/blob/master/cfe_internal/update/update_processes.cf#L149)
-
 #### clear_persistent\_disable\_*DAEMON*
 
 **Description:** Re-enable a previously disabled CFEngine Enterprise daemon

--- a/MPF.md
+++ b/MPF.md
@@ -365,6 +365,8 @@ This [augments file][Augments] will ensure that `cf-monitord` is disabled on hos
 }
 ```
 
+**Note:** By default MPF does not manage systemd units. This must be enabled by uncommenting policy in [cfe_internal_update_processes](https://github.com/cfengine/masterfiles/blob/master/cfe_internal/update/update_processes.cf#L149)
+
 #### clear_persistent\_disable\_*DAEMON*
 
 **Description:** Re-enable a previously disabled CFEngine Enterprise daemon
@@ -379,6 +381,20 @@ hosts.
 {
   "classes": {
     "clear_persistent_disable_cf_monitord": [ "redhat" ]
+  }
+}
+```
+
+#### agents_to_be_disabled
+
+**Description:** list of agents to disable.
+
+This [augments file][Augments] is a way to specify that `cf-monitord` should be disabled on all hosts.
+
+```
+{
+  "vars": {
+    "agents_to_be_disabled": [ "cf-monitord" ]
   }
 }
 ```

--- a/cfe_internal/update/update_processes.cf
+++ b/cfe_internal/update/update_processes.cf
@@ -114,7 +114,7 @@ bundle agent cfe_internal_update_processes
       # class OR if the agent is found in a list of agents to be specifically
       # disabled.
 
-      "disable[$(all_agents)]"
+      "disabled[$(all_agents)]"
         string => "$(all_agents)",
         ifvarclass => or( canonify( "persistent_disable_$(all_agents)" ),
                           some( "$(all_agents)", agents_to_be_disabled ));

--- a/cfe_internal/update/update_processes.cf
+++ b/cfe_internal/update/update_processes.cf
@@ -146,15 +146,11 @@ bundle agent cfe_internal_update_processes
 
     systemd_supervised::
 
-      # By default when running under systemd supervision, cfengine will not
-      # continue to make sure that the units are enabled or running. To enable
-      # this internal management please uncomment the following.
+      "CFEngine systemd Unit Definitions"
+        usebundle => cfe_internal_systemd_unit_files;
 
-    #  "CFEngine systemd Unit Definitions"
-    #    usebundle => cfe_internal_systemd_unit_files;
-
-    #  "CFEngine systemd Unit States"
-    #    usebundle => cfe_internal_systemd_service_unit_state;
+      "CFEngine systemd Unit States"
+        usebundle => cfe_internal_systemd_service_unit_state;
 
     am_policy_hub.enterprise.!systemd_supervised::
 


### PR DESCRIPTION
A small typo prevented non-default systemd unit management to fail.
By default MPF doesn't manage systemd units. This must be enabled
in cfe_internal/update/update_processes.cf. After this the standard
disabling mechanism works: https://docs.cfengine.com/docs/3.12/reference-masterfiles-policy-framework.html#enable-or-disable-cfengine-components

Changelog: title