### PR TITLE
Revert "CFE-3146/3.10: Fix agent disablement on systemd systems"

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -262,20 +262,6 @@ hosts.
 }
 ```
 
-#### agents_to_be_disabled
-
-**Description:** list of agents to disable.
-
-This [augments file][Augments] is a way to specify that `cf-monitord` should be disabled on all hosts.
-
-```
-{
-  "vars": {
-    "agents_to_be_disabled": [ "cf-monitord" ]
-  }
-}
-```
-
 ## Main Policy (promises.cf)
 
 The following settings are defined in `controls/def.cf` can be set from an

--- a/cfe_internal/update/update_processes.cf
+++ b/cfe_internal/update/update_processes.cf
@@ -106,7 +106,7 @@ bundle agent cfe_internal_update_processes
       # class OR if the agent is found in a list of agents to be specifically
       # disabled.
 
-      "disabled[$(all_agents)]"
+      "disable[$(all_agents)]"
         string => "$(all_agents)",
         ifvarclass => or( canonify( "persistent_disable_$(all_agents)" ),
                           some( "$(all_agents)", agents_to_be_disabled ));
@@ -138,11 +138,15 @@ bundle agent cfe_internal_update_processes
 
     systemd_supervised::
 
-      "CFEngine systemd Unit Definitions"
-        usebundle => cfe_internal_systemd_unit_files;
+      # By default when running under systemd supervision, cfengine will not
+      # continue to make sure that the units are enabled or running. To enable
+      # this internal management please uncomment the following.
 
-      "CFEngine systemd Unit States"
-        usebundle => cfe_internal_systemd_service_unit_state;
+    #  "CFEngine systemd Unit Definitions"
+    #    usebundle => cfe_internal_systemd_unit_files;
+
+    #  "CFEngine systemd Unit States"
+    #    usebundle => cfe_internal_systemd_service_unit_state;
 
     am_policy_hub.enterprise.!systemd_supervised::
 


### PR DESCRIPTION
Reverts cfengine/masterfiles#1514 because deploy tests are failing