### PR TITLE
ENT-4992/master Fixed cleanup of future timestamps from status table

### DIFF
--- a/lib/cfe_internal_hub.cf
+++ b/lib/cfe_internal_hub.cf
@@ -230,8 +230,8 @@ bundle agent cfe_internal_database_cleanup_consumer_status (row_count)
         string => "DELETE FROM $(status_table_name) WHERE ts IN (SELECT ts FROM $(status_table_name) ORDER BY ts DESC OFFSET 50000);";
 
 
-      "delete_future_ts_query" -> { "ENT-4362" }
-        string => "DELETE FROM status WHERE  to_timestamp(ts::bigint) > (now() + interval '2 days')::timestamp;";
+      "delete_future_ts_query" -> { "ENT-4362", "ENT-4992" }
+        string => "DELETE FROM $(status_table_name) WHERE to_timestamp(ts::bigint) > (now() + interval '2 days')::timestamp;";
 
     has_sql_function_cleanup_historical_data::
 


### PR DESCRIPTION
This promise to purge timestamps from the future was not adjusted with the
change in name of the status table in ENT-4331. It results in this error being
emitted once a day.

```
error: Finished command related to promiser '/var/cfengine/bin/psql cfdb -c
"DELETE FROM status WHERE to_timestamp(ts::bigint) > (now() + interval '2
days')::timestamp;"' – an error occurred, returned 1
notice: Q: "...e/bin/psql cfdb": ERROR: unrecognized configuration parameter
"rbac.filter"
error: Method 'cfe_internal_database_cleanup_consumer_status' failed in some
repairs
```