### PR TITLE
CFE-3161/3.10.x: Added ability to avoid limiting robot agents

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -148,6 +148,24 @@ This [augments file][Augments] will enable this behavior for all clients.
 }
 ```
 
+### Disable limiting robot agents
+
+By default the MPF (Masterfiles Policy Framework) contains active policy that is intended to remediate a pathological condition where multiple agent component daemons (like cf-execd) are running concurrently.
+
+Define the class ```mpf_disable_cfe_internal_limit_robot_agents``` to disable this automatic remediation.
+
+```json
+{
+  "classes": {
+    "mpf_disable_cfe_internal_limit_robot_agents": [ "any" ]
+  }
+}
+```
+
+**History:**
+
+- Introduced in 3.15.0, 3.12.3
+
 ### Automatically deploy masterfiles from Version Control
 
 On a CFEngine Enterprise Hub during the update policy if the class

--- a/cfe_internal/core/main.cf
+++ b/cfe_internal/core/main.cf
@@ -13,9 +13,12 @@ bundle agent cfe_internal_core_main
 #   NB! On a container host this may kill CFEngine processes inside containers.
 #       See https://dev.cfengine.com/issues/6906
 
+    !mpf_disable_cfe_internal_limit_robot_agents::
       "any" usebundle => cfe_internal_limit_robot_agents,
         handle => "cfe_internal_management_limit_cfe_agents",
         comment => "Manage CFE processes";
+
+    any::
 
       "any"
         usebundle => cfe_internal_log_rotation,


### PR DESCRIPTION
This change implements support for avoiding the policy to limit robot agent
daemons without having to modify vendord policy. Useful in testing, and in
environemnts where you might expect to find multiple agent daemon proceses
when looking at a hosts process table (cfengine running inside containers
for example).

Ticket: CFE-3161 Changelog: Title

(cherry picked from commit 19bec84cdf4f6f5f7188341a9cacf38f97c82e7b)
(cherry picked from commit bd5557a47319ddbdb289d849d6c5e78f9b374da4)