### PR TITLE
ENT-4953/3.10.x: Added and transitioned to using master_software_updates shortcut

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -197,7 +197,7 @@ This [augments file][Augments] will defines `trigger_upgrade` on hosts with IPv4
 - The negative look ahead regular expression is useful because it automatically
   turns off on hosts after they reach the target version.
 
-#### Configure path that software is served for autonomous agent upgrades
+#### Configure path that software is served from for autonomous agent upgrades
 
 {% comment %}ENT-4953{% endcomment %}
 `def.master_software_updates` defines the path that cfengine policy servers

--- a/MPF.md
+++ b/MPF.md
@@ -197,6 +197,28 @@ This [augments file][Augments] will defines `trigger_upgrade` on hosts with IPv4
 - The negative look ahead regular expression is useful because it automatically
   turns off on hosts after they reach the target version.
 
+#### Configure path that software is served for autonomous agent upgrades
+
+{% comment %}ENT-4953{% endcomment %}
+`def.master_software_updates` defines the path that cfengine policy servers
+share software updates from. Remote agents access this path via the
+`master_software_updates` *shortcut*. By default this path is
+`$(sys.workdir)/master_software_updates`. This path can be overridden via
+`vars.dir_master_software_updates` in augments.
+
+For example:
+
+```json
+{
+   "vars": {
+     "dir_master_software_updates": "/srv/cfengine-software-updates/"
+   }
+}
+```
+
+**History:**
+- Introduced 3.15.0, 3.12.3, 3.10.8
+
 ### Files considered for copy during policy updates
 
 The default update policy only copies files that match regular expressions

--- a/controls/cf_serverd.cf
+++ b/controls/cf_serverd.cf
@@ -88,12 +88,6 @@ bundle server access_rules()
       if => isdir( "$(def.dir_masterfiles)/" ),
       admit => { @(def.acl) };
 
-      "$(def.dir_software)/"
-      handle => "server_access_grant_access_datafiles",
-      comment => "Grant access to software updates",
-      if => isdir( "$(def.dir_software)/" ),
-      admit => { @(def.acl) };
-
       "$(def.dir_bin)/"
       handle => "server_access_grant_access_binary",
       comment => "Grant access to binary for cf-runagent",
@@ -119,6 +113,15 @@ bundle server access_rules()
       comment => "Grant access to templates directory",
       if => isdir( "$(def.dir_templates)/" ),
       admit => { @(def.acl) };
+
+    policy_server|am_policy_hub::
+
+      "$(def.dir_master_software_updates)/" -> { "ENT-4953" }
+        handle => "server_access_grant_access_master_software_updates",
+        shortcut => "master_software_updates",
+        comment => "Grant access for hosts to download cfengine packages for self upgrade",
+        if => isdir( "$(sys.workdir)/master_software_updates" ),
+        admit => { @(def.acl) };
 
       enterprise_edition.policy_server::
         "collect_calls"

--- a/controls/def.cf
+++ b/controls/def.cf
@@ -200,10 +200,6 @@ bundle common def
       comment => "Define reports path",
       handle => "common_def_vars_dir_reports";
 
-      "dir_software"    string => translatepath("$(sys.workdir)/master_software_updates"),
-      comment => "Define software path",
-      handle => "common_def_vars_dir_software";
-
       "dir_bin"         string => translatepath("$(sys.bindir)"),
       comment => "Define binary path",
       handle => "common_def_vars_dir_bin";
@@ -231,6 +227,19 @@ bundle common def
       "cf_apache_group" string => "cfapache",
       comment => "Group that CFEngine Enterprise webserver runs as",
       handle => "common_def_vars_cf_cfapache_group";
+
+    policy_server|am_policy_hub::
+
+      # Only hubs serve software updates
+
+      "dir_master_software_updates" -> { "ENT-4953" }
+        string => "$(sys.workdir)/master_software_updates",
+        handle => "common_def_vars_dir_serve_master_software_updates",
+        comment => "Path where software updates are served from the policy hub.
+        This variable is overridable via augments as
+        vars.dir_master_software_updates. All remote agents request this path
+        via the master_software_updates shortcut.",
+        if => not( isvariable( "def.dir_master_software_updates" ));
 
     solaris::
       "cf_runagent_shell"

--- a/standalone_self_upgrade.cf.in
+++ b/standalone_self_upgrade.cf.in
@@ -168,8 +168,8 @@ bundle agent cfengine_software_cached_locally
       "package_dir"
         string => "$(cfengine_software.package_dir)";
 
-      # TODO Add shortcut for this path
-      "master_software_location"  string => "/var/cfengine/master_software_updates",
+      "master_software_location" -> { "ENT-4953" }
+        string => "master_software_updates",
         comment => "The Cfengine binary updates directory on the policy server",
         handle => "cfe_internal_update_bins_vars_master_software_location";
 
@@ -562,9 +562,10 @@ bundle agent cfengine_master_software_content
       "dir[ubuntu_16_i686]" string => "$(dir[debian_4_i386])";
 
       "platform_dir" slist => getindices( dir );
+      "download_dir" string => "$(sys.workdir)/master_software_updates";
 
   files:
-      "/var/cfengine/master_software_updates/$(platform_dir)/."
+      "$(download_dir)/$(platform_dir)/."
        create => "true",
        comment => "We need a place to download each packge we build";
 
@@ -572,11 +573,11 @@ bundle agent cfengine_master_software_content
       # Fetch each package that we don't already have
        "/usr/bin/curl"
         args => "-s $(base_url)/$(dir[$(platform_dir)])/$(cfengine_package_names.pkg[$(platform_dir)]) --output /var/cfengine/master_software_updates/$(platform_dir)/$(cfengine_package_names.pkg[$(platform_dir)])",
-        if => not( fileexists( "/var/cfengine/master_software_updates/$(platform_dir)/$(cfengine_package_names.pkg[$(platform_dir)])" ) );
+        if => not( fileexists( "$(download_dir)/$(platform_dir)/$(cfengine_package_names.pkg[$(platform_dir)])" ) );
 
   reports:
     DEBUG|DEBUG_cfengine_master_software_content::
-      "curl -s $(base_url)/$(dir[$(i)])/$(cfengine_package_names.pkg[$(i)]) --output /var/cfengine/master_software_updates/$(i)/$(cfengine_pacakge_names.pkg[$(i)])";
+      "curl -s $(base_url)/$(dir[$(i)])/$(cfengine_package_names.pkg[$(i)]) --output $(download_dir)/$(i)/$(cfengine_pacakge_names.pkg[$(i)])";
 }
 
 bundle edit_line u_backup_script


### PR DESCRIPTION
The self upgrade policy previously fetched from a fully qualified path. This is
problematic when the hub does not use the standard WORKDIR (/var/cfengine). This
change implements a shortcut for the directory so that only the hub is required
to know the full path and switches copy_from to use paths relative to the
shortcut. Additionally, the path can be customized via augments.

Ticket: ENT-4953
Changelog: Title
(cherry picked from commit 21ab5b938ef40f4967871dd934f6f51dcc8f5b9d)