### PR TITLE
3.10.x: lib/paths.cf: Add usermod path for redhat systems

### DIFF
--- a/lib/paths.cf
+++ b/lib/paths.cf
@@ -343,6 +343,7 @@ bundle common paths
       "path[svc]"       string => "/sbin/service";
       "path[useradd]"   string => "/usr/sbin/useradd";
       "path[userdel]"   string => "/usr/sbin/userdel";
+      "path[usermod]"   string => "/usr/sbin/usermod";
       "path[yum]"       string => "/usr/bin/yum";
 
     darwin::


### PR DESCRIPTION
(cherry picked from commit ffd47c6ac1580af42575a90cdc3cf1e16282431a)