### PR TITLE
Fix the CFEngine 3.7.x class guard in standalone_self_upgrade.cf

### DIFF
--- a/standalone_self_upgrade.cf.in
+++ b/standalone_self_upgrade.cf.in
@@ -77,7 +77,7 @@ bundle agent cfengine_software
       "pkg_arch" string => "x86_64";
       "package_dir" string => "$(sys.flavour)_$(sys.arch)";
 
-!(cfengine_3_7_1|cfengine_3.7.2|cfengine_3.7.3)::
+!(cfengine_3_7_1|cfengine_3_7_2|cfengine_3_7_3)::
 # After 3.7.4 a fix to ifelse and isvarible allows for actuating the function
 # even thought the promise references an unresolved variable.
 


### PR DESCRIPTION
CFEngine version classes use '_' as a separator between major,
minor and patch version numbers. '.' in a class expression means
logical "and".

Ticket: CFE-3182
Changelog: Fixed the CFEngine 3.7.x class guard in standalone_self_upgrade.cf