### PR TITLE
Only report on skipped upgrade if trigger_upgrade is set

### DIFF
--- a/update.cf
+++ b/update.cf
@@ -135,7 +135,7 @@ bundle agent cfengine_internal_standalone_self_upgrade_execution
 
   reports:
 
-    inform_mode|verbose_mode|DEBUG|DEBUG_cfengine_internal_standalone_self_upgrade::
+    trigger_upgrade.(inform_mode|verbose_mode|DEBUG|DEBUG_cfengine_internal_standalone_self_upgrade)::
       "Skipped self upgrade because we are running the desired version $(sys.cf_version)" -> { "ENT-3592" }
         if => "at_desired_version";
 


### PR DESCRIPTION
While prepping for a client upgrade, we found this to be too noisy. Before an upgrade attempt, at_desired_version was never set so this never triggered. Once a host upgraded and the standalone_self_upgrade created the json file that provided a defnition for this variable, we see it every time we run update.cf in inform mode.

As a workaround, we changed the code to only provide the report if the trigger_upgrade class is set AND at_desired_version

Mike Weilgart and Aleksey Tsalolikhin asked me to submit this change as an upstream pull request