### PR TITLE
Travis: Sleep 10 more seconds after killing cf-serverd

### DIFF
--- a/travis-scripts/valgrind.sh
+++ b/travis-scripts/valgrind.sh
@@ -193,7 +193,7 @@ echo "Killing valgrind cf-execd"
 kill $exec_pid
 echo "Killing valgrind cf-serverd"
 kill $server_pid
-sleep 30
+sleep 40
 
 echo "Output from cf-execd in valgrind:"
 cat execd.txt


### PR DESCRIPTION
This test failed 2/5 times in the recent master builds,
because cf-serverd didn't exit in time. Increasing the
sleep from 30 to 40 seconds, to see if this helps.

We could probably work on a system which sleeps 10
seconds at a time, and checks if the process is
still alive.