### PR TITLE
Pipe stderr to /dev/null along with stdout in wait_for_pid()

### DIFF
--- a/travis-scripts/valgrind.sh
+++ b/travis-scripts/valgrind.sh
@@ -6,15 +6,15 @@ wait_for_pid () {
     # $2 -- timeout in seconds
     echo ""
     echo "Checking if $1 is still alive:"
-    ps -p $1 || return 0
+    ps -p "$1" || return 0
     echo ""
     echo -n "Waiting for $1 to terminate"
 
     i=$2
-    while [ $i -gt 0 ] && ps -p $1 2>&1 > /dev/null ; do
-      echo -n "."
-      sleep 1s
-      i=$(($i - 1))
+    while [ "$i" -gt 0 ] && ps -p "$1" > /dev/null 2>&1; do
+        echo -n "."
+        sleep 1s
+        i=$(($i - 1))
     done
     echo ""
     if [ "$i" == 0 ] ; then


### PR DESCRIPTION
Fixed a minor error where stderr would be piped to stdout, instead of to
/dev/null in the while loop in `wait_for_pid()`.

Order is significant when redirecting file-descriptors in Bash. In general, the
original line:

    while [ $i -gt 0 ] && ps -p $1 2>&1 > /dev/null ; do

Its intention is to redirect stderr and stdout to /dev/null, however, what
really happens is that stderr is first redirected to where stdout is currently
pointing (the tty), and then stdout is redirected to /dev/null. The problem is
that stderr is still pointing at the tty, so the error output will not be
ignored.

The correct way of doing it is by changing the order (although it looks somewhat
backwards), is by doing it in the other order, like so:

    while [ "$i" -gt 0 ] && ps -p "$1" > /dev/null 2>&1; do

Then stdout is redirected to /dev/null first, then stderr to where stdout is
currently writing (/dev/null), like intended.

The other fixups are simply nitpicks to keep the shell globbing under control,
and make this approach consistent for the function.

Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>