### PR TITLE
Changed policies related to __lastseenhostslog

### DIFF
--- a/cfe_internal/enterprise/CFE_hub_specific.cf
+++ b/cfe_internal/enterprise/CFE_hub_specific.cf
@@ -548,7 +548,7 @@ bundle agent cfe_internal_clear_last_seen_hosts_logs
 
   commands:
 
-    (policy_server|am_policy_hub).enterprise_edition.active_hub::
+    (policy_server|am_policy_hub).enterprise_edition.active_hub.(cfengine_3_12|cfengine_3_13|cfengine_3_14)::
 
       "$(sys.workdir)/httpd/php/bin/php" -> { "ENT-3550" }
         args => "$(cfe_internal_hub_vars.docroot)/index.php cli_tasks clearLastSeenHostsLogs",

--- a/templates/federated_reporting/10-base_filter.sed
+++ b/templates/federated_reporting/10-base_filter.sed
@@ -14,7 +14,6 @@ s/public\.//g;
 
 # don't reset the promiselog sequence value
 /SELECT pg_catalog.setval('__promiselog_id_seq.*$/d
-/SELECT pg_catalog.setval('__lastseenhostslogs_id_seq.*$/d
 
 # enable more debug messages
 s/client_min_messages = warning/client_min_messages = notice/

--- a/templates/federated_reporting/config.sh.mustache
+++ b/templates/federated_reporting/config.sh.mustache
@@ -20,7 +20,6 @@ __contexts
 __hosts
 __filechangeslog
 __lastseenhosts
-__lastseenhostslogs
 __software
 __softwareupdates
 __variables


### PR DESCRIPTION
ChangeLog: Changed CFEngine versions to execute policy that clears last seen hosts log. Only 3.12.x, 3.13.x and 3.14.x are allowed.
Removed __lastseenhostslogs from federation config.

Ticket: ENT-5052

Merge together: 
https://github.com/cfengine/mission-portal/pull/931
https://github.com/cfengine/nova/pull/1543