### PR TITLE
ENT-5060: Fixed path for restorecon on redhat systems to /sbin/restorecon

### DIFF
--- a/lib/paths.cf
+++ b/lib/paths.cf
@@ -360,7 +360,7 @@ bundle common paths
       "path[ping]"          string => "/usr/bin/ping";
       "path[perl]"          string => "/usr/bin/perl";
       "path[printf]"        string => "/usr/bin/printf";
-      "path[restorecon]"    string => "/usr/sbin/restorecon";
+      "path[restorecon]"    string => "/sbin/restorecon";
       "path[sed]"           string => "/bin/sed";
       "path[semodule]"      string => "/usr/sbin/semodule";
       "path[sort]"          string => "/bin/sort";


### PR DESCRIPTION
Confirmed correct path on rhel 5 and centos 6 and 7.

Changelog: title
Ticket: ENT-5060