### PR TITLE
Add commented out default 'allowtlsversion' value

### DIFF
--- a/controls/cf_serverd.cf
+++ b/controls/cf_serverd.cf
@@ -13,6 +13,10 @@ body server control
       # for "openssl ciphers". Default is "AES256-GCM-SHA384:AES256-SHA"
       #allowciphers          => "AES256-GCM-SHA384:AES256-SHA";
 
+      # Minimum required version of TLS. Set to "1.0" if you need clients
+      # running CFEngine in a version lower than 3.7.0 to connect.
+      #allowtlsversion => "1.1";
+
       # List of hosts that may connect (change the ACL in def.cf)
       allowconnects         => { "127.0.0.1" , "::1", @(def.acl) };
 


### PR DESCRIPTION
An easy way to let people know this configuration option exists,
what the default is and what to do if CFEngine in versions older
than 3.7.0 needs to be supported.

The default was changed to TLS 1.1 in
cfengine/core@959aa35ce6987a96c18bb2da9c61deab624e88c5.

Ticket: ENT-4616
Changelog: none

Merge together:
https://github.com/cfengine/core/pull/3936
https://github.com/cfengine/masterfiles/pull/1574