### PR TITLE
CFE-3193/3.12.x: Excluded Enterprise federation policy parsing on incompatible versions

### DIFF
--- a/cfe_internal/enterprise/CFE_hub_specific.cf
+++ b/cfe_internal/enterprise/CFE_hub_specific.cf
@@ -14,6 +14,7 @@
 #
 ##################################################################
 
+@if minimum_version(3.12.0)
 bundle common cfe_hub_specific_file_control
 {
   vars:
@@ -24,6 +25,7 @@ body file control
 {
         inputs => { @(cfe_hub_specific_file_control.inputs) };
 }
+@endif
 
 bundle common cfe_internal_hub_vars
 # @brief Set hub specific variables
@@ -562,8 +564,11 @@ bundle agent cfe_internal_refresh_inventory_view
       "tags" slist => { "enterprise_maintenance" };
 
   methods:
+@if minimum_version(3.12.0)
       # we need to know if we are running on a superhub
       "superhub_config" usebundle => "cfengine_enterprise_federation:config";
+@endif
+
       "inventory_refresh_args" usebundle => "cfe_internal_refresh_inventory_args";
 
   commands:

--- a/cfe_internal/enterprise/CFE_hub_specific.cf
+++ b/cfe_internal/enterprise/CFE_hub_specific.cf
@@ -14,7 +14,7 @@
 #
 ##################################################################
 
-@if minimum_version(3.12.0)
+@if minimum_version(3.12)
 bundle common cfe_hub_specific_file_control
 {
   vars:
@@ -564,7 +564,7 @@ bundle agent cfe_internal_refresh_inventory_view
       "tags" slist => { "enterprise_maintenance" };
 
   methods:
-@if minimum_version(3.12.0)
+@if minimum_version(3.12)
       # we need to know if we are running on a superhub
       "superhub_config" usebundle => "cfengine_enterprise_federation:config";
 @endif

--- a/promises.cf.in
+++ b/promises.cf.in
@@ -183,10 +183,11 @@ bundle common cfe_internal_inputs
         comment => "Policy relating to CFEngine Enterprise Hub, for example
                     software updates, webserver configuration, and alerts";
 
+@if minimum_version(3.12.0)
       "input[enterprise_hub_federation]"
         string => "cfe_internal/enterprise/federation/federation.cf",
         comment => "Policy relating to CFEngine Federated Reporting";
-
+@endif
 
     enterprise_edition::
 

--- a/promises.cf.in
+++ b/promises.cf.in
@@ -183,7 +183,7 @@ bundle common cfe_internal_inputs
         comment => "Policy relating to CFEngine Enterprise Hub, for example
                     software updates, webserver configuration, and alerts";
 
-@if minimum_version(3.12.0)
+@if minimum_version(3.12)
       "input[enterprise_hub_federation]"
         string => "cfe_internal/enterprise/federation/federation.cf",
         comment => "Policy relating to CFEngine Federated Reporting";


### PR DESCRIPTION
The federated reporting in CFEngine Enterprise leverages features that are
unavailable in versions older than 3.12.0. This change prevents the federation
policy from being parsed and generating errors on older versions (both from
including policy containing features not present, and from specifying a bundle
that is not present when the federation policy is not parsed.

3.10.x was not targeted for support because Federated Reporting was targeted for
supported use starting in 3.15.0 as 3.10.x ended it's standard support life.