### PR TITLE
ENT-5070/master: Ensured directory for custom action scripts is present

### DIFF
--- a/cfe_internal/enterprise/CFE_knowledge.cf
+++ b/cfe_internal/enterprise/CFE_knowledge.cf
@@ -210,6 +210,13 @@ bundle agent cfe_internal_setup_knowledge
         comment => "The agent will complain if any other users (group or other)
                     have write access to the modules directory.";
 
+      "/opt/cfengine/notification_scripts/." -> { "ENT-5070" }
+        create => "true",
+        perms => mog("770", "root", $(def.cf_apache_group) ),
+        comment => "If this directory is not present and writable by the
+                    web-server, then Mission Portal users will be unable to
+                    upload custom action scripts.";
+
 }
 
 bundle agent cfe_internal_permissions


### PR DESCRIPTION
In CFEngine Enterprise alerts can be based off of observations in the
infrastructure. When these alerts change state a custom action script can be
triggered in response. This change ensures that the directory where custom
action scripts are stored is available and writeable by the webserver. If this
directory is not present and writeable by the webserver, then Mission Portal
users will not be able to upload custom action scripts.

Ticket: ENT-5070
Changelog: Title