### PR TITLE
ENT-5071: Added m_inventory dumping to __inventory for 3.12.x feeders

### DIFF
--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -253,6 +253,7 @@ bundle agent federation_manage_files
     "login" data => parsejson('{"login":"$(cfengine_enterprise_federation:config.login)"}');
     "feeder_username" data => parsejson('{"feeder_username":"$(cfengine_enterprise_federation:config.transport_user)"}');
     "feeder" data => parsejson('{"feeder": "$(sys.key_digest)"}');
+    "cf_version" data => parsejson('{"cf_version":"$(sys.cf_version)"}');
 
   methods:
       "internal_vars" usebundle => "default:cfe_internal_hub_vars",
@@ -307,7 +308,7 @@ bundle agent federation_manage_files
         create => "true",
         template_method => "mustache",
         edit_template => "$(this.promise_dirname)/../../../templates/federated_reporting/config.sh.mustache",
-        template_data => mergedata(@(login), @(feeder_username), @(feeder),
+        template_data => mergedata(@(login), @(feeder_username), @(feeder), @(cf_version),
                                    @(cfengine_enterprise_federation:inventory_refresh_cmd.cmd)),
         perms => default:mog( "640", "root", "$(transport_user)" );
 

--- a/templates/federated_reporting/config.sh.mustache
+++ b/templates/federated_reporting/config.sh.mustache
@@ -9,6 +9,7 @@ CFE_BIN_DIR="{{bindir}}"
 CFE_BIN_DIR="${CFE_BIN_DIR:-/var/cfengine/bin}"
 CFE_FR_SED_ARGS="{{sed_args}}" # no extra args by default
 CFE_FR_AWK_ARGS="{{awk_args}}" # no extra args by default
+CFE_VERSION="{{cf_version}}"
 
 # specific feeder name
 CFE_FR_FEEDER="{{feeder}}"


### PR DESCRIPTION
If hub is 3.12* version we assume that inventory is in a materialized view
named m_inventory and dump this data as INSERTs into an __inventory table
as 3.15+ superhub will expect it.

Changelog: title
Ticket: ENT-5071

merge with https://github.com/cfengine/system-testing/pull/266