### PR TITLE
[3.12.x] Fixed access promises sharing configuration with HA hubs

### DIFF
--- a/controls/cf_serverd.cf
+++ b/controls/cf_serverd.cf
@@ -158,16 +158,34 @@ bundle server access_rules()
       if => isdir( "$(sys.workdir)/ppkeys/" ),
       admit => { @(def.policy_servers) };
 
-      # Allow slave hub to synchronize cf_robot and appsettings content.
+      # Allow slave hub to synchronize cf_robot and appsettings, application
+      # config config, ldap config settings, and ldap api config settings.
       # Files are containing configuration that must be the same on all hubs.
       "$(sys.workdir)/httpd/htdocs/application/config/cf_robot.php"
       handle => "server_access_grant_access_cf_robot",
       comment => "Grant access to cf_robot file for HA hubs",
       admit => { @(def.policy_servers) };
 
-      "$(sys.workdir)/share/GUI/application/config/appsettings.php"
+      "$(sys.workdir)/httpd/htdocs/application/config/appsettings.php"
       handle => "server_access_grant_access_appsettings",
       comment => "Grant access to appsettings for HA hubs",
+      admit => { @(def.policy_servers) };
+
+      "$(sys.workdir)/httpd/htdocs/application/config/config.php" -> { "ENT-4944" }
+      handle => "server_access_grant_access_application_config_config_php",
+      comment => "Grant access to application config for HA hubs",
+      admit => { @(def.policy_servers) };
+
+
+      "$(sys.workdir)/httpd/htdocs/ldap/config/settings.php" -> { "ENT-4944" }
+      handle => "server_access_grant_access_ldap_config_settings_php",
+      comment => "Grant access to ldap config settings for HA hubs",
+      admit => { @(def.policy_servers) };
+
+
+      "$(sys.workdir)/httpd/htdocs/api/config/config.php" -> { "ENT-4944" }
+      handle => "server_access_grant_access_api_config_settings_php",
+      comment => "Grant access to LDAP api config for HA hubs",
       admit => { @(def.policy_servers) };
 
       # Allow access to notification_scripts directory so passive hub


### PR DESCRIPTION
Promises not kept when HA slave hub tries to synchronize configuration from
master.

- [X] `ha_sync_application_config`

  - Fixed access promise path to `application/config/appsettings.php`, should
  come from live config, not share/GUI

  - Added missing access promise to share `application/config/config.php`

- [X] `ha_sync_api_config`
  - Added missing access promsie to share `ldap/config/settings.php`
  - Added missing access promsie to share `api/config/config.php`

This is a follow-up to a previous fix that has yet to be released. No changelog
entry needed.

Ticket: ENT-4944
Changelog: None