### PR TITLE
Do not dump __lastseenhostslogs in FR dumps

### DIFF
--- a/templates/federated_reporting/10-base_filter.sed
+++ b/templates/federated_reporting/10-base_filter.sed
@@ -14,7 +14,6 @@ s/public\.//g;
 
 # don't reset the promiselog sequence value
 /SELECT pg_catalog.setval('__promiselog_id_seq.*$/d
-/SELECT pg_catalog.setval('__lastseenhostslogs_id_seq.*$/d
 
 # enable more debug messages
 s/client_min_messages = warning/client_min_messages = notice/

--- a/templates/federated_reporting/config.sh.mustache
+++ b/templates/federated_reporting/config.sh.mustache
@@ -21,7 +21,6 @@ __contexts
 __hosts
 __filechangeslog
 __lastseenhosts
-__lastseenhostslogs
 __software
 __softwareupdates
 __variables


### PR DESCRIPTION
This table was dropped in 3.15.0 (and thus on the superhub), see
the commit mentioned below for details.

Ticket: ENT-5052
Changelog: none

(backported from commit c60889a4352fb901537ead8e7be665d4eb700e60)