### PR TITLE
Set group to cfpostgres when running pg_ctl

### DIFF
--- a/cfe_internal/update/update_policy.cf
+++ b/cfe_internal/update/update_policy.cf
@@ -409,6 +409,7 @@ body contain u_postgres
 {
   useshell   => "useshell";
   exec_owner => "cfpostgres";
+  exec_group => "cfpostgres";
   chdir      => "/tmp";
   no_output  => "true";
 }


### PR DESCRIPTION
The owners of the '/var/cfengine/state' directory are
root:cfpostgres. So unless we set the group for the pg_ctl
process, it cannot access the '/var/cfengine/state' directory and
thus also '/var/cfengine/state/pg/data'.

(cherry picked from commit f6e274e29e6d65ee74b21190f70ec6817d64e37b)