### PR TITLE
Only check the 'semanage' package if SELinux is enabled (in FR)

### DIFF
--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -258,7 +258,8 @@ bundle agent transport_user
       edit_line => default:insert_lines("IdentityFile $(ssh_priv_key)");
 
   methods:
-    "semanage_installed" usebundle => semanage_installed;
+    selinux_enabled::
+      "semanage_installed" usebundle => semanage_installed;
 
   commands:
     # _stdlib_path_exists_<command> and paths.<command> are defined is masterfiles/lib/paths.cf


### PR DESCRIPTION
Otherwise the promise is not kept and blocks the setup from being
completed even if SELinux is disabled and the 'semanage' package
is not actually needed at all.

Ticket: ENT-5124
Changelog: none