### PR TITLE
ENT-3153: cf-hub query timeout can now be set from augments

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -889,6 +889,29 @@ For example:
 
 - Added in 3.13.0, 3.12.2
 
+### Change hub to client connection timeout
+
+By default, cf-hub times out a connection after 30 seconds.
+This can be configured in augments.
+
+For example:
+
+```json
+{
+  "vars": {
+    "control_hub_query_timeout": "10"
+  }
+}
+```
+
+**Note:**
+
+- A value of `"0"` will cause the default to be used.
+
+**History:**
+
+- Added in 3.15.0
+
 ### Enable client initiated reporting
 
 In the default configuration for Enterprise report collection the hub

--- a/controls/cf_hub.cf
+++ b/controls/cf_hub.cf
@@ -21,6 +21,8 @@ body hub control
 
       # port => "5308";
 
+      query_timeout => "$(def.control_hub_query_timeout)";
+
       # Hub will discard accumulated reports on the clients
       # and download only information about current state of the client
       # in case of not successfully downloading the reports for defined

--- a/controls/def.cf
+++ b/controls/def.cf
@@ -432,6 +432,11 @@ bundle common def
                     "Min50", "Min55" },
         unless => isvariable(control_hub_hub_schedule);
 
+      "control_hub_query_timeout"
+        comment => "Configurable timeout for cf-hub outgoing connections",
+        string => "0", # 0 = default is set by cf-hub binary
+        unless => isvariable(control_hub_query_timeout);
+
       "control_hub_port"
         comment => "cf-hub performs pull collection on port 5308, unless
                     overridden by augments",


### PR DESCRIPTION
Variable `control_hub_query_timeout`.

Merge together:
https://github.com/cfengine/core/pull/3964
https://github.com/cfengine/masterfiles/pull/1601
https://github.com/cfengine/nova/pull/1560