### PR TITLE
ENT-5124/master: Stopped including inputs from federation policy

### DIFF
--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -1,15 +1,3 @@
-bundle common federation_file_control
-{
-  vars:
-    "inputs" slist => { "$(sys.local_libdir)/stdlib.cf", "$(this.promise_dirname)/../CFE_hub_specific.cf" };
-}
-
-body file control
-{
-        inputs => { @(federation_file_control.inputs) };
-        namespace => "cfengine_enterprise_federation";
-}
-
 bundle agent config
 # @brief Read/parse config JSON, define variables and classes for use later
 {

--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -1,3 +1,7 @@
+body file control
+{
+        namespace => "cfengine_enterprise_federation";
+}
 bundle agent config
 # @brief Read/parse config JSON, define variables and classes for use later
 {


### PR DESCRIPTION
This change alters the federation policy so that it is no longer able to be run
does not include it's dependencies. It can no longer be run directly as a policy
entry.

This was dropped because it prevents us from rendering the json representation
of the policy in the documentation build.

Ticket: ENT-5124
Changelog: Title