### PR TITLE
CFE-3221/master: Made set_variable_values_ini prefer whitespace around =

### DIFF
--- a/lib/files.cf
+++ b/lib/files.cf
@@ -481,12 +481,12 @@ bundle edit_line set_variable_values_ini(tab, sectionName)
       # If the line is there, but commented out, first uncomment it
       "#+\s*$(index)\s*=.*"
       select_region => INI_section(escape("$(sectionName)")),
-      edit_field => col("=","1","$(index)","set"),
+      edit_field => col("\s*=\s*","1","$(index)","set"),
       ifvarclass => "edit_$(cindex[$(index)])";
 
       # match a line starting like the key something
       "$(index)\s*=.*"
-      edit_field => col("=","2","$($(tab)[$(sectionName)][$(index)])","set"),
+      edit_field => col("\s*=\s*","2","$($(tab)[$(sectionName)][$(index)])","set"),
       select_region => INI_section(escape("$(sectionName)")),
       classes => results("bundle", "set_variable_values_ini_not_$(cindex[$(index)])"),
       ifvarclass => "edit_$(cindex[$(index)])";

--- a/tests/acceptance/lib/files/manage_variable_values_ini.cf
+++ b/tests/acceptance/lib/files/manage_variable_values_ini.cf
@@ -14,6 +14,9 @@ body common control
 
 bundle agent init
 {
+  vars:
+      "expectations" string => ifelse( "cfengine_3_10", "3.10.x", "" );
+
   files:
       # The tested file "actual" is copied from our seeded starting position.
       "$(G.testfile).actual"
@@ -21,20 +24,37 @@ bundle agent init
 
      # Next we place the file which we will compare the final result with.
      "$(G.testfile).expected"
-      copy_from => local_cp("$(this.promise_filename).finish");
+     copy_from => local_cp("$(this.promise_filename).finish$(expectations)");
 }
 
 #######################################################
 
 bundle agent test
 {
+  meta:
+      "description" -> { "CFE-3221" }
+        string => "Test expected behavior of manage_variable_values_ini";
+
   vars:
       "config[section][keyone]" string => "1";
       "config[section][keytwo]" string => "valuetwo";
 
+      "config[CFE-3221][variablename]" string => "desired value";
+      "config[CFE-3221][variablename2]" string => "desired value2";
+      "config[CFE-3221][variablename3]" string => "desired value3";
+      "config[CFE-3221][variablename4]" string => "desired value4";
+      "config[CFE-3221][variablename5]" string => "desired value5";
+      "config[CFE-3221][variablename6]" string => "desired value6";
+      "config[CFE-3221][variablename7]" string => "desired value7";
+      "config[CFE-3221][variablename8]" string => "desired value8";
+
   files:
       "$(G.testfile).actual"
       edit_line => manage_variable_values_ini( "test.config", "section" );
+
+      "$(G.testfile).actual" -> { "CFE-3221" }
+        edit_line => manage_variable_values_ini( "test.config", "CFE-3221" );
+
 }
 
 #######################################################

--- a/tests/acceptance/lib/files/manage_variable_values_ini.cf.finish3.10.x
+++ b/tests/acceptance/lib/files/manage_variable_values_ini.cf.finish3.10.x
@@ -3,12 +3,12 @@ keyone=1
 keytwo=valuetwo
 [CFE-3221]
 variablename4=desired value4
-variablename=desired value
 variablename5=desired value5
+variablename6=desired value6
+variablename=desired value
+variablename7=desired value7
+variablename8=desired value8
 variablename2=desired value2
 variablename3=desired value3
-variablename8=desired value8
-variablename6=desired value6
-variablename7=desired value7
 [section2]
 wat=WUT

--- a/tests/acceptance/lib/files/manage_variable_values_ini.cf.start
+++ b/tests/acceptance/lib/files/manage_variable_values_ini.cf.start
@@ -1,5 +1,13 @@
 [section]
 keyone=valueone
 keytwo=value2
+[CFE-3221]
+variablename= desired value
+variablename2 = desired value2
+variablename3 =desired value3
+# variablename5=desired value5
+# variablename6= desired value6
+# variablename7 = desired value7
+# variablename8 = wrong value8
 [section2]
 wat=WUT

--- a/tests/acceptance/lib/files/set_variable_values_ini.cf
+++ b/tests/acceptance/lib/files/set_variable_values_ini.cf
@@ -30,14 +30,30 @@ bundle agent init
 
 bundle agent test
 {
+  meta:
+      "description" -> { "CFE-3221" }
+        string => "Test expected behavior of set_variable_values_ini";
+
   vars:
       "config[section][keyone]" string => "1";
       "config[section][keytwo]" string => "two";
+
+      "config[CFE-3221][variablename]" string => "desired value";
+      "config[CFE-3221][variablename2]" string => "desired value2";
+      "config[CFE-3221][variablename3]" string => "desired value3";
+      "config[CFE-3221][variablename4]" string => "desired value4";
+      "config[CFE-3221][variablename5]" string => "desired value5";
+      "config[CFE-3221][variablename6]" string => "desired value6";
+      "config[CFE-3221][variablename7]" string => "desired value7";
+      "config[CFE-3221][variablename8]" string => "desired value8";
 
   files:
 
       "$(G.testfile).actual"
       edit_line => set_variable_values_ini("test.config", "section");
+
+      "$(G.testfile).actual" -> { "CFE-3221" }
+        edit_line => set_variable_values_ini( "test.config", "CFE-3221" );
 
 }
 

--- a/tests/acceptance/lib/files/set_variable_values_ini.cf.finish
+++ b/tests/acceptance/lib/files/set_variable_values_ini.cf.finish
@@ -2,13 +2,13 @@
 keyone=1
 keytwo=two
 [CFE-3221]
-variablename=desired value
-variablename2 =desired value2
+variablename= desired value
+variablename2 = desired value2
 variablename3 =desired value3
 variablename5=desired value5
-variablename6=desired value6
-variablename7=desired value7
-variablename8=desired value8
+variablename6= desired value6
+variablename7 = desired value7
+variablename8 = desired value8
 variablename4=desired value4
 [something]
 keyone=something1

--- a/tests/acceptance/lib/files/set_variable_values_ini.cf.finish
+++ b/tests/acceptance/lib/files/set_variable_values_ini.cf.finish
@@ -1,5 +1,14 @@
 [section]
 keyone=1
 keytwo=two
+[CFE-3221]
+variablename=desired value
+variablename2 =desired value2
+variablename3 =desired value3
+variablename5=desired value5
+variablename6=desired value6
+variablename7=desired value7
+variablename8=desired value8
+variablename4=desired value4
 [something]
 keyone=something1

--- a/tests/acceptance/lib/files/set_variable_values_ini.cf.start
+++ b/tests/acceptance/lib/files/set_variable_values_ini.cf.start
@@ -1,5 +1,13 @@
 [section]
 keyone=one
 keytwo=2
+[CFE-3221]
+variablename= desired value
+variablename2 = desired value2
+variablename3 =desired value3
+# variablename5=desired value5
+# variablename6= desired value6
+# variablename7 = desired value7
+# variablename8 = wrong value8
 [something]
 keyone=something1


### PR DESCRIPTION
- Added test that leading whitespace on the RHS is not removed

Ticket: CFE-3221
Changelog: None


----

#