### PR TITLE
Added minimum version macro to query timeout

### DIFF
--- a/controls/cf_hub.cf
+++ b/controls/cf_hub.cf
@@ -21,7 +21,9 @@ body hub control
 
       # port => "5308";
 
+@if minimum_version(3.15)
       query_timeout => "$(def.control_hub_query_timeout)";
+@endif
 
       # Hub will discard accumulated reports on the clients
       # and download only information about current state of the client


### PR DESCRIPTION
This change broke upgrade because older hubs won't understand
this new attribute.