### PR TITLE
Re-fix CFE-528 by adding back bindtointerface attribute

### DIFF
--- a/controls/cf_serverd.cf
+++ b/controls/cf_serverd.cf
@@ -72,6 +72,11 @@ body server control
                            $(sys.cf_agent) -I -D cf_runagent_initiated -f $(sys.update_policy_path)  ;
                            $(sys.cf_agent) -I -D cf_runagent_initiated";
 
+    !windows::
+      # Bind to all interfaces including ipv6
+      # Adding this on windows will force ipv6 only, so limit to non-windows
+      bindtointerface => "::";
+
 }
 
 ###############################################################################


### PR DESCRIPTION
This attribute was added in 63bd3217083f15db22148c5c7d0ae99b6767f998
(with whitespace fix and issue reference in b29783ed33cb58b1ea1e3559451a971354e4c85a).

Then in 57594018fcb6d16501e57142d01443224714b665 the attribute
was restricted to non-Windows hosts only, however this was done
by *moving* the attribute (to use implicit context) rather than
setting the context explicitly.  As a result, the context was incorrectly
changed (implicitly) in 8fba99bc342bb1ca6851a4a62c7303f73810264e
to limit the ipv6 binding to CFEngine 3.7 hosts only.  (!!)

Then the attribute was removed entirely in 9dc25201c8e03caa98a3b5f47fa83cf0442393c7
for no apparent reason, except that it probably looked like it was part of the
same code block, since it was (incorrectly) using the same context line
implicitly.

This history of errors serves as an excellent illustration of why,
in CFEngine policy codebases I manage, I have a style guideline that
implicit contexts should NOT be used for promises, excepting only
when multiple *very closely related* promises share the same complex
class expression as a context.  For promises that are not closely
related but just happen to have the same context, even if it's "any",
I repeat the context for each individual promise.  It prevents mistakes
caused by auto-merging and similar.