### PR TITLE
ENT-5168 FR: Don't require SELinux Makefile for running semanage / restorecon (3.15)

### DIFF
--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -255,7 +255,7 @@ bundle agent transport_user
 
   commands:
     # _stdlib_path_exists_<command> and paths.<command> are defined is masterfiles/lib/paths.cf
-    selinux_enabled.incorrect_ssh_context.default:_stdlib_path_exists_semanage.default:_stdlib_path_exists_restorecon.selinux_makefile_present::
+    selinux_enabled.incorrect_ssh_context.default:_stdlib_path_exists_semanage.default:_stdlib_path_exists_restorecon::
       "$(paths.semanage) fcontext -a -t ssh_home_t '$(home)/.ssh(/.*)?'";
       "$(paths.restorecon) -R -F $(home)/.ssh/";
 


### PR DESCRIPTION
(cherry picked from commit 4f262e094f433140a37f8c5ce8a3bc3d5da9a4cb)