### PR TITLE
ENT-5187/3.15.x: Guarded policy to create python symlink to debain and redhat

### DIFF
--- a/cfe_internal/update/update_policy.cf
+++ b/cfe_internal/update/update_policy.cf
@@ -84,6 +84,7 @@ bundle agent cfe_internal_setup_python_symlink(symlink_path)
 # @brief Create the /var/cfengine/bin/python symlink pointing to some installed python (if any)
 {
   vars:
+    debian|redhat::
       "path" string => getenv("PATH", 1024);
       "path_folders" slist => splitstring("$(path)", ":", 128);
 
@@ -108,6 +109,7 @@ bundle agent cfe_internal_setup_python_symlink(symlink_path)
         comment => "Taking the first item from the list (sorted by preference)";
 
   files:
+    debian|redhat::
       "$(symlink_path)"
         delete => u_tidy,
         if => not(isvariable("python"));


### PR DESCRIPTION
This bundle is called only on debian and redhat. Without the deep guard, the
vars promises cause warnings on windows.

```
Administrator@WIN-NTO7O3L97A9 C:\>"\Program Files\Cfengine\bin\cf-agent.exe" -KIf update.cf
 warning: Non-absolute path in findfiles(), skipping: C/python[23]
 warning: Non-absolute path in findfiles(), skipping: C/python
 warning: Non-absolute path in findfiles(), skipping: C/python[23]
 warning: Non-absolute path in findfiles(), skipping: C/python
 warning: Non-absolute path in findfiles(), skipping: C/python[23]
 warning: Non-absolute path in findfiles(), skipping: C/python
 warning: Non-absolute path in findfiles(), skipping: C/python[23]
 warning: Non-absolute path in findfiles(), skipping: C/python
 warning: Non-absolute path in findfiles(), skipping: C/python[23]
 warning: Non-absolute path in findfiles(), skipping: C/python
```

Ticket: ENT-5187
Changelog: None
(cherry picked from commit b633d9285f5273193aca8fc6917eafedfc50875c)