### PR TITLE
CFE-3233/master: apt_get package module now check package state

### DIFF
--- a/modules/packages/apt_get.in
+++ b/modules/packages/apt_get.in
@@ -140,9 +140,13 @@ def list_installed():
         if PY3:
             line = line.decode("utf-8")
         line = line.rstrip("\n")
-        # The space before "installed" is important, because it can be "not-installed".
-        if line.startswith("Status=") and line.split("=", 1)[1].find(" installed") >= 0:
-            installed_package = True
+        # 'Status=install ok <state>' or 'Status=hold ok <state>'
+        if line.startswith("Status=install") or line.startswith("Status=hold"):
+            state = line.split()[2]
+            if state in [ "installed", "half-configured", "half-installed" ]:
+                installed_package = True
+            else:
+                installed_package = False
         elif line.startswith("Status="):
             installed_package = False
         elif installed_package:


### PR DESCRIPTION
list_installed check the state of a package for package action
hold/install. If the package state is installed, half-installed or
half-configured is considered as "installed". So we can also delete this
packages  with cfengine

Ticket: CFE-3233
Changelog: Title