### PR TITLE
Allow whitespace at the beginning of ini key-values

### DIFF
--- a/lib/files.cf
+++ b/lib/files.cf
@@ -428,7 +428,7 @@ bundle edit_line manage_variable_values_ini(tab, sectionName)
       ifvarclass => "edit_$(cindex[$(index)])";
 
       # match a line starting like the key something
-      "$(index)\s*=.*"
+      "\s*$(index)\s*=.*"
       edit_field => col("=","2","$($(tab)[$(sectionName)][$(index)])","set"),
       select_region => INI_section(escape("$(sectionName)")),
       classes => results("bundle", "manage_variable_values_ini_not_$(cindex[$(index)])"),

--- a/tests/acceptance/lib/files/manage_variable_values_ini.cf
+++ b/tests/acceptance/lib/files/manage_variable_values_ini.cf
@@ -47,6 +47,8 @@ bundle agent test
       "config[CFE-3221][variablename6]" string => "desired value6";
       "config[CFE-3221][variablename7]" string => "desired value7";
       "config[CFE-3221][variablename8]" string => "desired value8";
+      "config[section3][keyone]" string => "1";
+      "config[section3][keytwo]" string => "valuetwo";
 
   files:
       "$(G.testfile).actual"

--- a/tests/acceptance/lib/files/manage_variable_values_ini.cf.finish
+++ b/tests/acceptance/lib/files/manage_variable_values_ini.cf.finish
@@ -10,5 +10,8 @@ variablename3=desired value3
 variablename8=desired value8
 variablename6=desired value6
 variablename7=desired value7
+[section3]
+keyone=1
+keytwo=valuetwo
 [section2]
 wat=WUT

--- a/tests/acceptance/lib/files/manage_variable_values_ini.cf.start
+++ b/tests/acceptance/lib/files/manage_variable_values_ini.cf.start
@@ -9,5 +9,8 @@ variablename3 =desired value3
 # variablename6= desired value6
 # variablename7 = desired value7
 # variablename8 = wrong value8
+[section3]
+  keyone=valueone
+  keytwo=value2
 [section2]
 wat=WUT


### PR DESCRIPTION
Previously the {manage,set}_variable_values_ini did not match on any ini files
containing whitespace at the beginning of a line, hence

[section foo]
key=value

could be handled. However, if the file looks like

[section bar]
  key=value

then the previous regex would not match.

What I can get from the INI spec, is that whitespace is optional. This commit
adds this to the regex, with an optional whitespace match at the beginning of
the line.

Changelog: Title

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>