### PR TITLE
Make the 'selinux_enabled' in FR policy class namespace-scoped

### DIFF
--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -200,7 +200,8 @@ bundle agent transport_user
     # _stdlib_path_exists_getenforce and paths.getenforce are defined by masterfiles/lib/paths.cf
     enabled.default:_stdlib_path_exists_getenforce::
         "selinux_enabled"
-          expression => strcmp("Enforcing", execresult("$(paths.getenforce)", useshell));
+        expression => strcmp("Enforcing", execresult("$(paths.getenforce)", useshell)),
+        scope => "namespace";
 
     enabled.selinux_enabled::
         "incorrect_ssh_context"


### PR DESCRIPTION
It's used outside of the bundle in which it is defined.