### PR TITLE
CFE-3244: Tolerate whitespace before key in manage_variable_values_ini and set_variable_values_ini 

### DIFF
--- a/lib/files.cf
+++ b/lib/files.cf
@@ -428,7 +428,7 @@ bundle edit_line manage_variable_values_ini(tab, sectionName)
       ifvarclass => "edit_$(cindex[$(index)])";
 
       # match a line starting like the key something
-      "$(index)\s*=.*"
+      "\s*$(index)\s*=.*"
       edit_field => col("=","2","$($(tab)[$(sectionName)][$(index)])","set"),
       select_region => INI_section(escape("$(sectionName)")),
       classes => results("bundle", "manage_variable_values_ini_not_$(cindex[$(index)])"),
@@ -485,7 +485,7 @@ bundle edit_line set_variable_values_ini(tab, sectionName)
       ifvarclass => "edit_$(cindex[$(index)])";
 
       # match a line starting like the key something
-      "$(index)\s*=.*"
+      "\s*$(index)\s*=.*"
       edit_field => col("\s*=\s*","2","$($(tab)[$(sectionName)][$(index)])","set"),
       select_region => INI_section(escape("$(sectionName)")),
       classes => results("bundle", "set_variable_values_ini_not_$(cindex[$(index)])"),

--- a/tests/acceptance/lib/files/manage_variable_values_ini.cf
+++ b/tests/acceptance/lib/files/manage_variable_values_ini.cf
@@ -32,7 +32,7 @@ bundle agent init
 bundle agent test
 {
   meta:
-      "description" -> { "CFE-3221" }
+      "description" -> { "CFE-3221", "CFE-3244" }
         string => "Test expected behavior of manage_variable_values_ini";
 
   vars:
@@ -47,6 +47,8 @@ bundle agent test
       "config[CFE-3221][variablename6]" string => "desired value6";
       "config[CFE-3221][variablename7]" string => "desired value7";
       "config[CFE-3221][variablename8]" string => "desired value8";
+      "config[CFE-3244][keyone]" string => "1";
+      "config[CFE-3244][keytwo]" string => "valuetwo";
 
   files:
       "$(G.testfile).actual"
@@ -54,6 +56,9 @@ bundle agent test
 
       "$(G.testfile).actual" -> { "CFE-3221" }
         edit_line => manage_variable_values_ini( "test.config", "CFE-3221" );
+
+      "$(G.testfile).actual" -> { "CFE-3244" }
+        edit_line => manage_variable_values_ini( "test.config", "CFE-3244" );
 
 }
 

--- a/tests/acceptance/lib/files/manage_variable_values_ini.cf.finish
+++ b/tests/acceptance/lib/files/manage_variable_values_ini.cf.finish
@@ -10,5 +10,8 @@ variablename3=desired value3
 variablename8=desired value8
 variablename6=desired value6
 variablename7=desired value7
+[CFE-3244]
+keyone=1
+keytwo=valuetwo
 [section2]
 wat=WUT

--- a/tests/acceptance/lib/files/manage_variable_values_ini.cf.finish3.10.x
+++ b/tests/acceptance/lib/files/manage_variable_values_ini.cf.finish3.10.x
@@ -10,5 +10,8 @@ variablename7=desired value7
 variablename8=desired value8
 variablename2=desired value2
 variablename3=desired value3
+[CFE-3244]
+keytwo=valuetwo
+keyone=1
 [section2]
 wat=WUT

--- a/tests/acceptance/lib/files/manage_variable_values_ini.cf.start
+++ b/tests/acceptance/lib/files/manage_variable_values_ini.cf.start
@@ -9,5 +9,8 @@ variablename3 =desired value3
 # variablename6= desired value6
 # variablename7 = desired value7
 # variablename8 = wrong value8
+[CFE-3244]
+  keyone=valueone
+  keytwo=value2
 [section2]
 wat=WUT

--- a/tests/acceptance/lib/files/set_variable_values_ini.cf
+++ b/tests/acceptance/lib/files/set_variable_values_ini.cf
@@ -18,11 +18,11 @@ bundle agent init
   files:
 
       "$(G.testfile).actual"
-      copy_from => local_cp("$(this.promise_filename).start");
+        copy_from => local_cp("$(this.promise_filename).start");
 
 
       "$(G.testfile).expected"
-      copy_from => local_cp("$(this.promise_filename).finish");
+        copy_from => local_cp("$(this.promise_filename).finish");
 
 }
 
@@ -31,7 +31,7 @@ bundle agent init
 bundle agent test
 {
   meta:
-      "description" -> { "CFE-3221" }
+      "description" -> { "CFE-3221", "CFE-3244" }
         string => "Test expected behavior of set_variable_values_ini";
 
   vars:
@@ -47,13 +47,19 @@ bundle agent test
       "config[CFE-3221][variablename7]" string => "desired value7";
       "config[CFE-3221][variablename8]" string => "desired value8";
 
+      "config[CFE-3244][keyone]" string => "1";
+      "config[CFE-3244][keytwo]" string => "valuetwo";
+
   files:
 
       "$(G.testfile).actual"
-      edit_line => set_variable_values_ini("test.config", "section");
+        edit_line => set_variable_values_ini("test.config", "section");
 
       "$(G.testfile).actual" -> { "CFE-3221" }
         edit_line => set_variable_values_ini( "test.config", "CFE-3221" );
+
+      "$(G.testfile).actual" -> { "CFE-3244" }
+        edit_line => set_variable_values_ini( "test.config", "CFE-3244" );
 
 }
 

--- a/tests/acceptance/lib/files/set_variable_values_ini.cf.finish
+++ b/tests/acceptance/lib/files/set_variable_values_ini.cf.finish
@@ -10,5 +10,8 @@ variablename6= desired value6
 variablename7 = desired value7
 variablename8 = desired value8
 variablename4=desired value4
+[CFE-3244]
+  keyone= 1
+keytwo = valuetwo
 [something]
 keyone=something1

--- a/tests/acceptance/lib/files/set_variable_values_ini.cf.start
+++ b/tests/acceptance/lib/files/set_variable_values_ini.cf.start
@@ -9,5 +9,8 @@ variablename3 =desired value3
 # variablename6= desired value6
 # variablename7 = desired value7
 # variablename8 = wrong value8
+[CFE-3244]
+  keyone= foo
+#  keytwo = bar
 [something]
 keyone=something1


### PR DESCRIPTION
Updated with the fix added to `set_variable_values_ini` as well.