### PR TITLE
ENT-5235/3.15.x: Fixed permission flip flop when policy analyzer is enabled

### DIFF
--- a/cfe_internal/enterprise/CFE_hub_specific.cf
+++ b/cfe_internal/enterprise/CFE_hub_specific.cf
@@ -626,7 +626,7 @@ bundle agent cfe_internal_enterprise_policy_analyzer
 
       "$(analyzer_dir)/."
         create => "true",
-        perms => mog( "700", $(def.cf_apache_user), $(def.cf_apache_user) );
+        perms => mog( "500", $(def.cf_apache_user), $(def.cf_apache_user) );
 
        "$(analyzer_dir)/."
          copy_from => analyzer_sync( $(analyzer_source) ),


### PR DESCRIPTION
Ticket: ENT-5235
Changelog: Title
(cherry picked from commit 37a7f3a23a4ce941ac553b551524e5aeca6aee00)