### PR TITLE
ENT-5190/master: Prevented inventory of unresolved variables for diskfree and loadavg

### DIFF
--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -171,8 +171,10 @@ bundle agent cfe_autorun_inventory_disk
 {
   vars:
     enterprise::
-      "free" string => "$(mon.value_diskfree)",
-               meta => { "inventory", "attribute_name=Disk free (%)" };
+      "free" -> { "ENT-5190" }
+        string => "$(mon.value_diskfree)",
+        meta => { "inventory", "attribute_name=Disk free (%)" },
+        if => isvariable( "mon.value_diskfree" );
 }
 
 bundle agent cfe_autorun_inventory_memory
@@ -300,8 +302,10 @@ bundle agent cfe_autorun_inventory_loadaverage
 {
   vars:
     enterprise::
-      "value" string => "$(mon.value_loadavg)",
-      meta => { "report" };
+      "value" -> { "ENT-5190" }
+        string => "$(mon.value_loadavg)",
+        meta => { "report" },
+        if => isvariable( "mon.value_loadavg" );
 }
 
 bundle agent cfe_autorun_inventory_proc


### PR DESCRIPTION
If cf-monitord is not running, or is simply unable to resolve these variables,
then they are inventoried as is. Instead of confusing the user with some
unexpanded variable, it's better to not even inventory the unresolved value.

Ticket: ENT-5190
Changelog: Title