### PR TITLE
3.12.x: Added 'data' shortcut to cf-serverd, defaults to sys.workdir/data

### DIFF
--- a/controls/cf_serverd.cf
+++ b/controls/cf_serverd.cf
@@ -111,6 +111,13 @@ bundle server access_rules()
       if => isdir( "$(def.dir_bin)/" ),
       admit => { @(def.acl) };
 
+      "$(def.dir_data)/"
+      handle => "server_access_grant_access_data",
+      shortcut => "data",
+      comment => "Grant access to data directory",
+      if => isdir( "$(def.dir_data)/" ),
+      admit => { @(def.acl) };
+
       "$(def.dir_modules)/"
       handle => "server_access_grant_access_modules",
       shortcut => "modules",

--- a/controls/def.cf
+++ b/controls/def.cf
@@ -280,6 +280,13 @@ bundle common def
       comment => "Define binary path",
       handle => "common_def_vars_dir_bin";
 
+      "dir_data"
+        string => ifelse( isvariable( "def.dir_data"),
+                          $(def.dir_data),
+                          "$(sys.workdir)/data"),
+      comment => "Define data path",
+      handle => "common_def_vars_dir_data";
+
       "dir_modules"     string => translatepath("$(sys.workdir)/modules"),
       comment => "Define modules path",
       handle => "common_def_vars_dir_modules";


### PR DESCRIPTION
Changelog: Title
(cherry picked from commit 19bde59d04e034260d9ab2547ecd00ad7328fad0)