### PR TITLE
Remove bad class guard in the cfe_internal_setup_python_symlink bundle

### DIFF
--- a/cfe_internal/update/update_policy.cf
+++ b/cfe_internal/update/update_policy.cf
@@ -84,7 +84,6 @@ bundle agent cfe_internal_setup_python_symlink(symlink_path)
 # @brief Create the /var/cfengine/bin/python symlink pointing to some installed python (if any)
 {
   vars:
-    debian|redhat::
       "path" string => getenv("PATH", 1024);
       "path_folders" slist => splitstring("$(path)", ":", 128);
 
@@ -109,7 +108,6 @@ bundle agent cfe_internal_setup_python_symlink(symlink_path)
         comment => "Taking the first item from the list (sorted by preference)";
 
   files:
-    debian|redhat::
       "$(symlink_path)"
         delete => u_tidy,
         if => not(isvariable("python"));


### PR DESCRIPTION
The bundle should not care about which OS is being used on. The
policy using this bundle should decide. And it already does.

Changelog: /var/cfengine/bin/python symlink creation on SLES was fixed