### PR TITLE
CFE-3283/3.12.x: Added paths support for opensuse

### DIFF
--- a/lib/paths.cf
+++ b/lib/paths.cf
@@ -500,6 +500,52 @@ bundle common paths
     !(suse|sles)::
       "path[logger]"        string => "/usr/bin/logger";
 
+    opensuse::
+      "path[ls]"        string => "/usr/bin/ls";
+      "path[lsof]"      string => "/usr/bin/lsof";
+      "path[awk]"       string => "/usr/bin/awk";
+      "path[cat]"       string => "/usr/bin/cat";
+      "path[cksum]"     string => "/usr/bin/cksum";
+      "path[crontab]"   string => "/usr/bin/crontab";
+      "path[curl]"      string => "/usr/bin/curl";
+      "path[cut]"       string => "/usr/bin/cut";
+      "path[df]"        string => "/usr/bin/df";
+      "path[diff]"      string => "/usr/bin/diff";
+      "path[dig]"       string => "/usr/bin/dig";
+      "path[dmidecode]" string => "/usr/sbin/dmidecode";
+      "path[echo]"      string => "/usr/bin/echo";
+      "path[egrep]"     string => "/usr/bin/egrep";
+      "path[ethtool]"   string => "/usr/sbin/ethtool";
+      "path[find]"      string => "/usr/bin/find";
+      "path[free]"      string => "/usr/bin/free";
+      "path[grep]"      string => "/usr/bin/grep";
+      "path[hostname]"  string => "/usr/bin/hostname";
+      "path[init]"      string => "/sbin/init";
+      "path[iptables]"  string => "/usr/sbin/iptables";
+      "path[ls]"        string => "/usr/bin/ls";
+      "path[lsof]"      string => "/usr/bin/lsof";
+      "path[nologin]"   string => "/sbin/nologin";
+      "path[ping]"      string => "/usr/bin/ping";
+      "path[perl]"      string => "/usr/bin/perl";
+      "path[printf]"    string => "/usr/bin/printf";
+      "path[sed]"       string => "/usr/bin/sed";
+      "path[sort]"      string => "/usr/bin/sort";
+      "path[test]"      string => "/usr/bin/test";
+      "path[tr]"        string => "/usr/bin/tr";
+      "path[logger]"    string => "/usr/bin/logger";
+      "path[wget]"      string => "/usr/bin/wget";
+      "path[chkconfig]" string => "/sbin/chkconfig";
+      "path[groupadd]"  string => "/usr/sbin/groupadd";
+      "path[groupdel]"  string => "/usr/sbin/groupdel";
+      "path[groupmod]"  string => "/usr/sbin/groupmod";
+      "path[ip]"        string => "/sbin/ip";
+      "path[rpm]"       string => "/usr/bin/rpm";
+      "path[service]"   string => "/sbin/service";
+      "path[useradd]"   string => "/usr/sbin/useradd";
+      "path[userdel]"   string => "/usr/sbin/userdel";
+      "path[usermod]"   string => "/usr/sbin/usermod";
+      "path[zypper]"    string => "/usr/bin/zypper";
+
     suse|sles::
 
       "path[awk]"           string => "/usr/bin/awk";


### PR DESCRIPTION
The paths observed on an opensuse 15 host varied a bit from the paths defined
for sles|suse, so it got a new section.

Ticket: CFE-3283
Changelog: Title
(cherry picked from commit 95da1a7d0845590dbc50a498d245b3cceb113f4a)