### PR TITLE
ENT-5406/master: Fixed use of standard_services service_method in federation policy

### DIFF
--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -520,7 +520,9 @@ bundle agent pre_import_state
 
   services:
     systemd::
-      "cf-hub" service_policy => "stop";
+      "cf-hub"
+        service_policy => "stop",
+        service_method => default:standard_services;
 
   processes:
     !systemd::
@@ -551,7 +553,9 @@ bundle agent post_import_state
 {
   services:
     systemd::
-      "cf-hub" service_policy => "start";
+      "cf-hub"
+        service_policy => "start",
+        service_method => default:standard_services;
 
   commands:
     !systemd::

--- a/lib/services.cf
+++ b/lib/services.cf
@@ -120,7 +120,7 @@ body service_method standard_services
 #       service_method => standard_services;
 # ```
 {
-        service_bundle => standard_services( $(this.promiser), $(this.service_policy) );
+        service_bundle => default:standard_services( $(this.promiser), $(this.service_policy) );
 }
 
 ##


### PR DESCRIPTION
This change makes sure that standard_services service_method from the default
namespace is used when trying to manage services. Prior to this change, it was
trying to use standard_services service method from the
cfengine_enterprise_federation namespace.

Ticket: ENT-5406
Changelog: None


----

#