### PR TITLE
ENT-5406/3.15.x: Fixed selection of standard_services when used from non-default namespace

### DIFF
--- a/lib/services.cf
+++ b/lib/services.cf
@@ -120,7 +120,7 @@ body service_method standard_services
 #       service_method => standard_services;
 # ```
 {
-        service_bundle => standard_services( $(this.promiser), $(this.service_policy) );
+        service_bundle => default:standard_services( $(this.promiser), $(this.service_policy) );
 }
 
 ##


### PR DESCRIPTION
Prior to this change, if you were in a non-default namespace and specified
default:standard_service as the service method, the bundle would not be found
because it was looking in the callers namespace and not the default namespace.
This change makes sure that any time standard_services service_method from the
default namespace is requested that the standard_services bundle from the
default namespace is used for the implementation.
