### PR TITLE
CFE-3291/master: Made python symlink fall back to platform-python

### DIFF
--- a/cfe_internal/update/update_policy.cf
+++ b/cfe_internal/update/update_policy.cf
@@ -109,11 +109,15 @@ bundle agent cfe_internal_setup_python_symlink(symlink_path)
 
       "python_exact[$(exact_version_globs)]" slist => findfiles("$(exact_version_globs)");
       "python_generic[$(generic_python_globs)]" slist => findfiles("$(generic_python_globs)");
+      "python_platform_fallback[/usr/libexec/platform-python]" -> { "CFE-3291" }
+        slist => { "/usr/libexec/platform-python" };
 
       "python_exact_sorted" slist => reverse(sort(getvalues(@(python_exact)), "lex")),
         comment => "Prefer higher major versions of Python";
 
-      "pythons" slist => getvalues(mergedata(@(python_exact_sorted), getvalues(@(python_generic)))),
+      "pythons" slist => getvalues(mergedata(@(python_exact_sorted),
+                                             getvalues(@(python_generic)),
+                                             getvalues(@(python_platform_fallback)))),
         comment => "Prefer exact versions over unknown";
 
       "python" string => nth(@(pythons), 0),

--- a/cfe_internal/update/update_policy.cf
+++ b/cfe_internal/update/update_policy.cf
@@ -85,7 +85,9 @@ bundle agent cfe_internal_setup_python_symlink(symlink_path)
 {
   vars:
       "path" string => getenv("PATH", 1024);
-      "path_folders" slist => splitstring("$(path)", ":", 128);
+      "path_folders" slist => filter("$(sys.bindir)",
+                                     splitstring("$(path)", ":", 128),
+                                     false, true, 128);
 
     windows::
       "abs_path_folders" -> {"CFE-2309"}

--- a/cfe_internal/update/update_policy.cf
+++ b/cfe_internal/update/update_policy.cf
@@ -293,8 +293,7 @@ bundle agent cfe_internal_update_policy_cpv
   methods:
     debian|redhat|amazon_linux|suse|sles|opensuse::
       # Only needed on distros with Python-based package modules
-      "setup_python_symlink" usebundle => cfe_internal_setup_python_symlink("$(python_symlink)"),
-        if => not(fileexists("$(python_symlink)"));
+      "setup_python_symlink" usebundle => cfe_internal_setup_python_symlink("$(python_symlink)");
 }
 
 #########################################################


### PR DESCRIPTION
EL8 stopped shipping python and python[23] by default. This change falls back to
the platform-python if no other version is available so that package modules
written in python can work without requiring external dependencies. If python or
pyton[23] is found in PATH, they are preferred.

Also, this PR includes a change that prevents considering sys.bindir as a location for python symlink target. It's sometimes in PATH, and if it's considered, it can result in a self-referential link.