### PR TITLE
ENT-5420 Fall back to '--mode fast' when restarting PostgreSQL in FR policy

### DIFF
--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -453,17 +453,10 @@ bundle agent postgres_config
 
   commands:
     am_superhub.postgresql_conf_repaired::
-      "$(sys.bindir)/pg_ctl"
-        arglist => {
-                     "restart",
-                     "-w", # Wait for startup or shutdown to complete, -W (do not wait) is the default for start and restart modes
-                     "-D",
-                     "$(sys.statedir)/pg/data",
-                     "-l",
-                     "/var/log/postgresql.log",
-                     "-m",
-                     "smart" # wait for online backup mode to finish and all clients to disconnect
-        },
+      # smart mode tries to wait for operations to finish and clients to
+      # disconnect, fast mode terminates open connections gracefully
+      "$(sys.bindir)/pg_ctl --pgdata $(sys.statedir)/pg/data --log /var/log/postgresql.log --wait --mode smart restart ||
+       $(sys.bindir)/pg_ctl --pgdata $(sys.statedir)/pg/data --log /var/log/postgresql.log --wait --mode fast  restart"
         contain => cfpostgres_user;
 }
 


### PR DESCRIPTION
'pg_ctl --mode smart restart' tries to wait for running
operations to finish and for open connections to be
closed. However, if there are some long-time connections (like
the notify handler added to cf-hub in cfengine/nova#1584), the
restart fails. In such cases we need to do 'pg_ctl --mode fast'
which terminates the remaining open connections gracefully. Doing
'--mode smart' first should provide a good grace period for other
(short-time) connections to finish all the operations.

Also let's use self-documenting long options instead of short
options with comments.

Ticket: ENT-4864
Changelog: None
(cherry picked from commit 2906524e1e6554ad9ae33415e61ec6f5f24f6896)