### PR TITLE
ENT-5432: Fixed runalerts processes promise on non-systemd systems

### DIFF
--- a/cfe_internal/enterprise/main.cf
+++ b/cfe_internal/enterprise/main.cf
@@ -27,12 +27,14 @@ bundle agent cfe_internal_enterprise_main
       handle => "cfe_internal_management_setup_knowledge",
       comment => "Manage CFE Knowledge Map";
 
-      "hub" usebundle => cfe_internal_php_runalerts,
-      handle => "cfe_internal_management_php_runalerts",
-      comment => "Check status on SQL Alerts";
-
       "Enterprise Maintenance"
         usebundle => cfe_internal_enterprise_maintenance;
+
+      "hub" usebundle => cfe_internal_php_runalerts,
+      handle => "cfe_internal_management_php_runalerts",
+      comment => "To run PHP runalerts to check bundle status on SQL and Sketch.
+                 ENT-5432: must run after cfe_internal_enterprise_maintenance bundle
+                 so that active_hub class is determined";
 
     am_policy_hub.enterprise_edition::
 


### PR DESCRIPTION
active_hub class is needed to properly manage runalerts.php
processes promise on non-systemd systems so had to swap
order of methods promises.

Ticket: ENT-5432
Changelog: title
(cherry picked from commit 4a490adfc881ad0f88cc1fa0c6840c98ab0f861b)
