### PR TITLE
[3.15.x] Add the release number to the pkg.tar.gz tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -27,6 +27,6 @@ tar-package:
             find . -name '*.cf*' | xargs -n1 chmod go-w  &&  \
 	    tardir=.  &&  $(am__tar) |  \
 	        GZIP=$(GZIP_ENV) gzip -c  \
-	        > "$$origdir"/$(PACKAGE)-$(VERSION).pkg.tar.gz  \
+	        > "$$origdir"/$(PACKAGE)-$(VERSION)-$(RELEASE).pkg.tar.gz  \
 	)  ;  \
 	[ x$$pkgdir != x ]  &&  rm -rf $$pkgdir

--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,7 @@ m4_undefine([cfversion])
 m4_undefine([cfversion_from_file])
 m4_undefine([cfversion_from_env])
 
+AS_IF([test -n "$RELEASE"], [AC_SUBST([RELEASE], ["$RELEASE"])], [AC_SUBST([RELEASE], [1])])
 
 AC_CANONICAL_TARGET
 


### PR DESCRIPTION
So that re-releases have distinctive file names.

Ticket: ENT-5429
Changelog: Release number was added to MPF tarballs
(cherry picked from commit 3a711f59be67eccb0de1e2e16d28fa9cab8bff7a)