### PR TITLE
Revert "CFE-3237 Copy modules from masterfiles to workdir on hub during update"

### DIFF
--- a/cfe_internal/update/update_policy.cf
+++ b/cfe_internal/update/update_policy.cf
@@ -236,17 +236,15 @@ bundle agent cfe_internal_update_policy_cpv
       action => u_immediate,
       classes => u_if_repaired("validated_updates_ready");
 
-    any::
+    !am_policy_hub::
 
       "$(sys.workdir)$(const.dirsep)modules"
-      comment => "Update modules from masterfiles",
+      comment => "Always update modules files on client side",
       handle => "cfe_internal_update_policy_files_update_modules",
-      copy_from => u_cp("$(master_location)$(const.dirsep)modules"),
+      copy_from => u_rcp("$(modules_dir_source)", @(update_def.policy_servers)),
       depth_search => u_recurse("inf"),
       perms => u_m("755"),
       action => u_immediate;
-
-    !am_policy_hub::
 
       "$(sys.workdir)$(const.dirsep)plugins"
       comment => "Always update plugins files on client side",

--- a/modules/packages/Makefile.am
+++ b/modules/packages/Makefile.am
@@ -1,3 +1,3 @@
-package_modulesdir = $(prefix)/masterfiles/modules/packages
+package_modulesdir = $(prefix)/modules/packages
 
 dist_package_modules_SCRIPTS = apt_get yum pkg nimclient pkgsrc freebsd_ports zypper slackpkg msiexec.bat WiRunSQL.vbs


### PR DESCRIPTION
Reverts cfengine/masterfiles#1738

Was failing several jenkins CI tests. See https://github.com/cfengine/masterfiles/pull/1738 for details.