### PR TITLE
CFE-3321/master: Synchronized cf-runagent and cf-agent verbose logging

### DIFF
--- a/controls/cf_serverd.cf
+++ b/controls/cf_serverd.cf
@@ -58,6 +58,8 @@ body server control
     policy_server::
         allowusers => { @(def.control_server_allowusers_policy_server) };
 
+
+    # In the MPF, cf-runagent executes cf-agent with inform level logging by default.
     windows::
       cfruncommand => "$(sys.cf_agent) -I -D cf_runagent_initiated -f \"$(sys.update_policy_path)\"  &
                        $(sys.cf_agent) -I -D cf_runagent_initiated";
@@ -71,6 +73,24 @@ body server control
         cfruncommand => "$(def.cf_runagent_shell) -c \'
                            $(sys.cf_agent) -I -D cf_runagent_initiated -f $(sys.update_policy_path)  ;
                            $(sys.cf_agent) -I -D cf_runagent_initiated";
+
+    # In the MPF, cf-runagent executes cf-agent with verbose level logging if
+    # verbose level logging for cf-runagent is requested
+    windows.verbose_mode::
+        cfruncommand => "$(sys.cf_agent) --verbose -D cf_runagent_initiated -f \"$(sys.update_policy_path)\"  &
+                       $(sys.cf_agent) --verbose -D cf_runagent_initiated";
+
+    !windows.verbose_mode::
+
+      # In 3.10 the quotation is properly closed when EOF is reached. It is left
+      # open so that arguments (like -K and --remote-bundles) can be appended.
+      # 3.10.x does not automatically append -I -Dcfruncommand
+
+        cfruncommand => "$(def.cf_runagent_shell) -c \'
+                           $(sys.cf_agent) --verbose -D cf_runagent_initiated -f $(sys.update_policy_path)  ;
+                           $(sys.cf_agent) --verbose -D cf_runagent_initiated";
+
+
 
     !windows.!(redhat_5|centos_5)::
       # Bind to all interfaces including ipv6


### PR DESCRIPTION
This change makes it so that cf-runagent --verbose will also result in verbose
logging for the execution of cf-agent.

Ticket: CFE-3321
Changelog: Title


----

#