### PR TITLE
ENT-5555: Modified cftransport cleanup to avoid errors

### DIFF
--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -294,9 +294,13 @@ bundle agent clean_when_off
   methods:
     "rm_rf_cftransport_home_dir" usebundle => default:rm_rf("$(home)");
 
+  classes:
+    selinux_enabled.default:_stdlib_path_exists_semanage::
+      "has_cftransport_fcontext" expression => returnszero("$(paths.semanage) fcontext -l | grep $(home)", "useshell");
+
   commands:
     # _stdlib_path_exists_<command> and paths.<command> are defined is masterfiles/lib/paths.cf
-    selinux_enabled.default:_stdlib_path_exists_semanage::
+    selinux_enabled.default:_stdlib_path_exists_semanage.has_cftransport_fcontext::
       "$(paths.semanage) fcontext -d '$(home)/.ssh(/.*)?'";
 
 }


### PR DESCRIPTION
We weren't checking to see if an fcontext existed for the
cftransport user before attempting to remove it.

Ticket: ENT-5555
Changelog: Title