### PR TITLE
ENT-5562 Changed m_inventory dumping behavior to exclude when values is null (3.15.x)

### DIFF
--- a/templates/federated_reporting/dump.sh
+++ b/templates/federated_reporting/dump.sh
@@ -58,7 +58,8 @@ log "Dumping tables: $CFE_FR_TABLES"
 
   # in case of 3.12 must copy m_inventory as if it was __inventory
   if [[ "$CFE_VERSION" =~ "3.12." ]]; then
-    "$CFE_BIN_DIR"/psql cfdb -c "COPY (SELECT * FROM m_inventory) TO STDOUT CSV QUOTE '''' FORCE QUOTE *" |
+    # pg_dump will not dump the contents of views so we must run the following SQL:
+    "$CFE_BIN_DIR"/psql cfdb -c "COPY (SELECT * FROM m_inventory WHERE values IS NOT NULL) TO STDOUT CSV QUOTE '''' FORCE QUOTE *" |
       sed -e 's.^.INSERT INTO __inventory (hostkey, values) VALUES (.' \
           -e 's.$.);.'
   fi


### PR DESCRIPTION
Previously an empty values column in m_inventory such as when a
host has not reported would cause corrupt SQL to be dumped.
In this case we should simply not include that host in the
output in a similar way that __inventory is built from v_inventory
in latest schema.

Changelog: Title
Ticket: ENT-5562
(cherry picked from commit 65cd6c4de925d18e198eedb92105b6b84ef71627)