### PR TITLE
[3.15.x] Fix two Python 3 incompatibilities in the zypper module

### DIFF
--- a/modules/packages/zypper.in
+++ b/modules/packages/zypper.in
@@ -108,7 +108,7 @@ def subprocess_call(cmd, stdout=None, stderr=None):
     process = subprocess_Popen(cmd, stdout, stderr)
     outs, errs = process.communicate()
     if stderr == subprocess.PIPE:
-        lines = [line for line in errs.decode("utf-8").splitlines()]
+        lines = [line for line in errs.decode().splitlines()]
         if len(lines):
             printed_error = "ErrorMessage=" + " ".join(lines)
             sys.stdout.write(printed_error)
@@ -160,7 +160,7 @@ def list_updates(online):
 
     process = subprocess_Popen([zypper_cmd] + zypper_options + online_flag + ["list-updates"], stdout=subprocess.PIPE)
 
-    for line in process.stdout:
+    for line in (line.decode() for line in process.stdout):
 
 # Zypper's output looks like:
 #
@@ -201,7 +201,7 @@ def one_package_argument(name, arch, version, is_zypper_install):
     if is_zypper_install:
         process = subprocess_Popen([rpm_cmd, "--qf", "%{arch}\n",
                                     "-q", name], stdout=subprocess.PIPE)
-        existing_archs = [line.rstrip() for line in process.stdout]
+        existing_archs = [line.decode().rstrip() for line in process.stdout]
         process.wait()
         if process.returncode == 0 and existing_archs:
             exists = True


### PR DESCRIPTION
process.stdout is of type 'bytes' in Python 3 and needs to be
decoded to get a 'string' object.

Ticket: CFE-3364
Changelog: The zypper module is now fully compatible with Python 3
(cherry picked from commit ba32c3e6089ac50d4032832dce034ec8b1db9936)