### PR TITLE
ENT-5986 Added state_dir_perms perms body to reflect default perms and group for state dir (3.15.x)

### DIFF
--- a/cfe_internal/enterprise/CFE_knowledge.cf
+++ b/cfe_internal/enterprise/CFE_knowledge.cf
@@ -225,7 +225,7 @@ bundle agent cfe_internal_permissions
 
     !(policy_server|am_policy_hub)::
       "$(sys.statedir)/." -> { "ENT-4773" }
-        perms => system_owned( "0600" ),
+        perms => state_dir_perms(),
         # Important to recurse across file system boundaries, as databases and or state are commonly on different filesystems
         depth_search => recurse_with_base( inf ),
         file_select => all;
@@ -361,4 +361,21 @@ body depth_search cfe_internal_docroot_application_perms
 {
       depth => "inf";
       exclude_dirs => { "logs" };
+}
+
+############################################################################
+
+body perms state_dir_perms
+{
+      mode   => "0600";
+      owners => { "root" };
+
+      freebsd|openbsd|netbsd|darwin::
+        groups => { "wheel" };
+
+      aix::
+        groups => { "system" };
+
+      !(freebsd|openbsd|netbsd|darwin|aix)::
+        groups => { "root" };
 }


### PR DESCRIPTION
Especially this concerns lmdb files.
system_owned perms body was used previously but for solaris systems the use
of "sys" group seems incorrect so changing to "root" for solaris is the
net result of this change.

Ticket: ENT-5986
Changelog: Title
(cherry picked from commit 12f71333d9a63e1e9b03effa2e3c2e064f9bffa6)