### PR TITLE
CFE-3362 Changed group for state dir files promise to match defaults per OS 

### DIFF
--- a/cfe_internal/enterprise/CFE_knowledge.cf
+++ b/cfe_internal/enterprise/CFE_knowledge.cf
@@ -225,7 +225,7 @@ bundle agent cfe_internal_permissions
 
     !(policy_server|am_policy_hub)::
       "$(sys.statedir)/." -> { "ENT-4773" }
-        perms => system_owned( "0600" ),
+        perms => state_dir_system_owned(),
         # Important to recurse across file system boundaries, as databases and or state are commonly on different filesystems
         depth_search => recurse_with_base( inf ),
         file_select => all;
@@ -237,7 +237,7 @@ bundle agent cfe_internal_permissions
         comment => "The database user must be able to read the parent directory of the database or it won't be accessible";
 
      "$(sys.statedir)/."
-        perms => mog("0600", "root", "root" ),
+        perms => state_dir_system_owned(),
         depth_search => recurse_except( inf, "pg" ),
         file_select => all,
         comment => "The database user must be able to read the parent directory of the database or it won't be accessible";
@@ -361,4 +361,24 @@ body depth_search cfe_internal_docroot_application_perms
 {
       depth => "inf";
       exclude_dirs => { "logs" };
+}
+
+############################################################################
+
+body perms state_dir_system_owned
+{
+      mode   => "0600";
+      owners => { "root" };
+
+      freebsd|openbsd|netbsd|darwin::
+        groups => { "wheel" };
+
+      aix::
+        groups => { "system" };
+
+      hpux::
+        groups => { "sys" };
+
+      !(freebsd|openbsd|netbsd|darwin|aix|hpux)::
+        groups => { "root" };
 }


### PR DESCRIPTION
Especially this concerns lmdb files.
system_owned perms body was used previously but for solaris systems the use
of "sys" group seems incorrect so changing to "root" for solaris is the
net result of this change.

Ticket: CFE-3362
Changelog: Title

merge with:
https://github.com/cfengine/core/pull/4200