### PR TITLE
ENT-5281 Do not bind to "::" on RHEL/CentOS 5 by default (3.15.x)

### DIFF
--- a/controls/cf_serverd.cf
+++ b/controls/cf_serverd.cf
@@ -72,6 +72,12 @@ body server control
                            $(sys.cf_agent) -I -D cf_runagent_initiated -f $(sys.update_policy_path)  ;
                            $(sys.cf_agent) -I -D cf_runagent_initiated";
 
+    !windows.!(redhat_5|centos_5)::
+      # Bind to all interfaces including ipv6
+      # Adding this on windows will force ipv6 only, so limit to non-windows
+      # On RHEL/CentOS 5 binding to interface "::" fails.
+      bindtointerface => "::";
+
 }
 
 ###############################################################################


### PR DESCRIPTION
Trying to bind to "::" (IPV6_ANY) fails on RHEL/CentOS 5.

(cherry picked from commit 021a718c9fe356093da18a910a9bc051ac16d06d)

Conflicts:
	controls/cf_serverd.cf

Ticket: ENT-5281
Changelog: Title