### PR TITLE
Fixed travis release jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,10 @@ script:
   fi;
   export IS_PRERELEASE
 - cd $TRAVIS_BUILD_DIR/..
-- git clone --depth=1 --branch $CF_VERSION https://github.com/cfengine/core
+- export RELEASE_TAG=$(/var/cfengine/bin/cf-agent --version | awk '{print $3}')
+- export BRANCH="$RELEASE_TAG"
+- [ "CF_VERSION" = "master" ] && export BRANCH="master"
+- git clone --depth=1 --branch $BRANCH https://github.com/cfengine/core
 - chmod -R go-w .
 - cp core/tests/acceptance/*.cf.sub masterfiles/tests/acceptance/
 - umask 077


### PR DESCRIPTION
Travis jobs which test changes to MPF against different versions of core are broken for 3.15.x currently because the .travis.yml script installs 3.15.2 (no cf-secret) but runs testall from core 3.15.x which wants cf-secret.

I will try to change the script to use core with the cf-agent version as a tag instead so things should be "in sync" better.