### PR TITLE
CFE-3372/3.15.x: Stopped trying to edit fields in manage_variable_values_ini

### DIFF
--- a/lib/files.cf
+++ b/lib/files.cf
@@ -412,28 +412,6 @@ bundle edit_line manage_variable_values_ini(tab, sectionName)
   vars:
       "index" slist => getindices("$(tab)[$(sectionName)]");
 
-      # Be careful if the index string contains funny chars
-      "cindex[$(index)]" string => canonify("$(index)");
-
-  classes:
-      "edit_$(cindex[$(index)])"     not => strcmp("$($(tab)[$(sectionName)][$(index)])","dontchange"),
-      comment => "Create conditions to make changes";
-
-  field_edits:
-
-      # If the line is there, but commented out, first uncomment it
-      "#+\s*$(index)\s*=.*"
-      select_region => INI_section(escape("$(sectionName)")),
-      edit_field => col("=","1","$(index)","set"),
-      ifvarclass => "edit_$(cindex[$(index)])";
-
-      # match a line starting like the key something
-      "$(index)\s*=.*"
-      edit_field => col("=","2","$($(tab)[$(sectionName)][$(index)])","set"),
-      select_region => INI_section(escape("$(sectionName)")),
-      classes => results("bundle", "manage_variable_values_ini_not_$(cindex[$(index)])"),
-      ifvarclass => "edit_$(cindex[$(index)])";
-
   delete_lines:
       ".*"
       select_region => INI_section(escape("$(sectionName)")),
@@ -445,9 +423,7 @@ bundle edit_line manage_variable_values_ini(tab, sectionName)
       comment => "Insert lines";
 
       "$(index)=$($(tab)[$(sectionName)][$(index)])"
-      select_region => INI_section(escape("$(sectionName)")),
-        ifvarclass => "!(manage_variable_values_ini_not_$(cindex[$(index)])_kept|manage_variable_values_ini_not_$(cindex[$(index)])_repaired).edit_$(cindex[$(index)])";
-
+      select_region => INI_section(escape("$(sectionName)"));
 }
 
 ##


### PR DESCRIPTION
manage_variable_values_ini no longer tries to edit fields in the particular INI
file section. It's unnecessary because there is a promise to delete all entries
from the section before inserting to ensure that all entries are completely
managed. So trying to edit the fields doesn't make sense.
set_variable_values_ini is available for editing specific values in an INI
section.

Ticket: CFE-3372
Changelog: Title
(cherry picked from commit 91ae46590c80638574486e2613d81fe1adf83048)