### PR TITLE
Removed policy based parsing of def.json

### DIFF
--- a/controls/def.cf
+++ b/controls/def.cf
@@ -158,18 +158,6 @@ bundle common def
       # then get a regular list from using getvalues().
 
       "tbse" data => mergedata( "def.control_common_bundlesequence_end" );
-
-      # Since we have @(def.bundlesequence_end) in body common control
-      # bundlesequence we must have a list variable defined. It can be empty, but it
-      # must be defined. If it is not defined the agent will error complaining
-      # that '@(def.bundlesequence_end) is not a defined bundle.
-
-      # As noted in CFE-2460 getvalues behaviour varies between versions. 3.7.x
-      # getvalues will return an empty list when run on a non existant data
-      # container.  On 3.9.1 it does not return an empty list.
-      # So we initialize it as an empty list first to be safe.
-
-      "bundlesequence_end" slist => {};
       "bundlesequence_end" slist => getvalues( tbse );
 
       "control_common_ignore_missing_bundles" -> { "CFE-2773" }

--- a/controls/def.cf
+++ b/controls/def.cf
@@ -7,36 +7,7 @@
 bundle common def
 # @brief Common settings for the Masterfiles Policy Framework
 {
-  classes:
-    "_workaround_CFE_2333" -> { "https://tracker.mender.io/browse/CFE-2333" }
-      or => { "cfengine_3_7_3", "cfengine_3_8_1", "cfengine_3_8_2" };
-
-    # If the augments_file is parsed from C then we do not need ot do this work
-    # from policy
-    !(feature_def_json_preparse)|(_workaround_CFE_2333)::
-      "have_augments_file" expression => fileexists($(augments_file)), scope => "bundle";
-      "have_augments_classes" expression => isvariable("augments[classes]"), scope => "bundle";
-      "have_augments_inputs" expression => isvariable("augments[inputs]"), scope => "bundle";
-
-    have_augments_classes.!(feature_def_json_preparse)|(_workaround_CFE_2333)::
-      "$(augments_classes_data_keys)"
-        expression => classmatch("$(augments[classes][$(augments_classes_data_keys)])"),
-        meta => { "augments_class", "derived_from=$(augments_file)" };
-
   vars:
-
-    !(feature_def_json_preparse)|(_workaround_CFE_2333)::
-      "augments_file" string => "$(this.promise_dirname)/../../def.json";
-
-      "defvars" slist => variablesmatching("default:def\..*", "defvar");
-
-    have_augments_file.!feature_def_json_preparse|(_workaround_CFE_2333)::
-      "augments" data => readjson($(augments_file), 100k), ifvarclass => "have_augments_file";
-
-      "augments_inputs" slist => getvalues("augments[inputs]");
-      "override_vars" slist => getindices("augments[vars]");
-      "override_data_$(override_vars)" data => mergedata("augments[vars][$(override_vars)]");
-      "override_data_s_$(override_vars)" string => format("%S", "override_data_$(override_vars)");
 
     any::
       "augments_inputs"
@@ -44,13 +15,6 @@ bundle common def
         ifvarclass => not( isvariable( "augments_inputs" ) ),
         comment => "It's important that we define this list, even if it's empty
                     or we get errors about the list being unresolved.";
-
-    have_augments_classes.!(feature_def_json_preparse)|(_workaround_CFE_2333)::
-      "augments_classes_data" data => mergedata("augments[classes]");
-      "augments_classes_data_keys" slist => getindices("augments_classes_data");
-
-    any::
-      # Begin change
 
       # Your domain name, for use in access control
       # Note: this default may be inaccurate!
@@ -74,14 +38,6 @@ bundle common def
         ifvarclass => not(isvariable("smtpserver"));
 
       # List here the IP masks that we grant access to on the server
-
-      # Only define here if we are not capable of parsing augments from C
-      "acl"
-        slist => getvalues("override_data_acl"),
-        comment => "JSON-sourced: Define an acl for the machines to be granted accesses",
-        handle => "common_def_json_vars_acl",
-        ifvarclass => and(isvariable("override_data_acl"), "!feature_def_json_preparse"),
-        meta => { "defvar" };
 
       "acl"
         slist => {
@@ -109,13 +65,6 @@ bundle common def
 
       # Out of the hosts in allowconnects, trust new keys only from the
       # following ones.  This is open by default for bootstrapping.
-
-      # Only define here if we are not capable of parsing augments from C
-      "trustkeysfrom"
-        slist => getvalues("override_data_trustkeysfrom"),
-        comment => "JSON-sourced: define from which machines keys can be trusted",
-        ifvarclass => and(isvariable("override_data_trustkeysfrom"), "!feature_def_json_preparse"),
-        meta => { "defvar" };
 
       "trustkeysfrom"
         slist => {
@@ -580,24 +529,6 @@ bundle common def
       "cfconsumer_in_enterprise"  -> { "ENT-2797" }
         or => { "cfengine_3_7", "cfengine_3_8", "cfengine_3_9", "cfengine_3_10", "cfengine_3_11" };
 
-  reports:
-    DEBUG|DEBUG_def::
-      "DEBUG: $(this.bundle)";
-
-      "$(const.t) def.json was found at $(augments_file)"
-        ifvarclass => fileexists( $(augments_file) );
-
-      "$(const.t) override request $(override_vars) to '$(override_data_s_$(override_vars))'; new value '$($(override_vars))'"
-      ifvarclass => isvariable("override_data_$(override_vars)");
-
-      "$(const.t) defined class '$(augments_classes_data_keys)' because of classmatch('$(augments[classes][$(augments_classes_data_keys)])')"
-      ifvarclass => "$(augments_classes_data_keys)";
-
-      "$(const.t) $(defvars) = $($(defvars))";
-      "DEBUG $(this.bundle): Agent parsed augments_file"
-        ifvarclass => "have_augments_file.feature_def_json_preparse";
-      "DEBUG $(this.bundle): Policy parsed augments_file"
-        ifvarclass => "have_augments_file.!feature_def_json_preparse";
 }
 
 bundle common inventory_control

--- a/controls/update_def.cf.in
+++ b/controls/update_def.cf.in
@@ -2,36 +2,12 @@ bundle common update_def
 # @brief Main default settings for update policy
 {
   classes:
-    !feature_def_json_preparse::
-      "have_augments_file" expression => fileexists($(augments_file)), scope => "bundle";
-      "have_augments_classes" expression => isvariable("augments[classes]"), scope => "bundle";
-
-    have_augments_classes.!feature_def_json_preparse::
-      "$(augments_classes_data_keys)"
-        expression => classmatch("$(augments[classes][$(augments_classes_data_keys)])"),
-        meta => { "augments_class", "derived_from=$(augments_file)" };
     any::
       "sys_policy_hub_port_exists" expression => isvariable("sys.policy_hub_port");
   vars:
-      "current_version" string => "@VERSION@";
-
-    !feature_def_json_preparse::
-      "augments_file" string => "$(this.promise_dirname)/../../def.json";
-
-      "defvars" slist => variablesmatching("default:update_def\..*", "defvar");
-
-    have_augments_file.!feature_def_json_preparse::
-      "augments" data => readjson($(augments_file), 100k), ifvarclass => "have_augments_file";
-
-      "override_vars" slist => getindices("augments[vars]");
-      "override_data_$(override_vars)" data => mergedata("augments[vars][$(override_vars)]");
-      "override_data_s_$(override_vars)" string => format("%S", "override_data_$(override_vars)");
-
-    have_augments_classes.!feature_def_json_preparse::
-      "augments_classes_data" data => mergedata("augments[classes]");
-      "augments_classes_data_keys" slist => getindices("augments_classes_data");
-
     any::
+
+      "current_version" string => "@VERSION@";
 
       # MPF Controls
 
@@ -63,18 +39,6 @@ bundle common update_def
         slist => { @(def.update_inputs) },
         ifvarclass => isvariable( "def.update_inputs" );
 
-      # Begin change
-
-      # When parsing the augments_file from policy, we set input_name_patterns
-      # based on the data extracted from within policy
-      "input_name_patterns"
-        slist => getvalues("override_data_input_name_patterns"),
-        comment => "JSON-sourced filename patterns to match when updating the policy
-                    (see update/update_policy.cf)",
-        handle => "common_def_json_vars_input_name_patterns_without_feature_def_json_preparse",
-        ifvarclass => and(isvariable("override_data_input_name_patterns"), "!feature_def_json_preparse"),
-        meta => { "defvar" };
-
       # Default the input name patterns, if we don't find it defined in def
       # (from the augments_file).
       "input_name_patterns"
@@ -95,7 +59,7 @@ bundle common update_def
         slist => { @(def.input_name_patterns) },
         comment => "Filename patterns to match when updating the policy
                     (see update/update_policy.cf)",
-        handle => "common_def_vars_input_name_patterns_from_def_with_feature_def_json_preparse",
+        handle => "common_def_vars_input_name_patterns",
         ifvarclass => and( isvariable("def.input_name_patterns"),
                            not(isvariable("input_name_patterns"))),
         meta => { "defvar" };
@@ -239,22 +203,4 @@ bundle common update_def
       "cfconsumer_in_enterprise"  -> { "ENT-2797" }
         or => { "cfengine_3_7", "cfengine_3_8", "cfengine_3_9", "cfengine_3_10", "cfengine_3_11" };
 
-  reports:
-    DEBUG|DEBUG_update_def::
-      "DEBUG: $(this.bundle)";
-      "$(const.t) override request $(override_vars) to '$(override_data_s_$(override_vars))'; new value '$($(override_vars))'"
-        ifvarclass => isvariable("override_data_$(override_vars)");
-
-      "$(const.t) defined class role/byname $(extra_roles[byname][$(roles_byname_keys)]) because of classmatch('$(roles_byname_keys)')"
-        ifvarclass => "$(extra_roles[byname][$(roles_byname_keys)])";
-
-      "$(const.t) defined class role/byrole $(roles_byrole_keys) because of classmatch('$(extra_roles[byrole][$(roles_byrole_keys)])')"
-        ifvarclass => "$(roles_byrole_keys)";
-
-      "$(const.t) $(defvars) = $($(defvars))";
-      "DEBUG $(this.bundle): Agent parsed augments_file"
-        ifvarclass => "have_augments_file.feature_def_json_preparse";
-      "DEBUG $(this.bundle): Policy parsed augments_file"
-        ifvarclass => "have_augments_file.!feature_def_json_preparse";
-      "DEBUG $(this.bundle): input_name_pattern = '$(input_name_patterns)'";
 }

--- a/lib/bundles.cf
+++ b/lib/bundles.cf
@@ -39,7 +39,6 @@
 # the online docs
 #
 
-# For CFEngine Core: 3.7.0 to 3.7.x
 # Bundles
 
 ###################################################

--- a/lib/cfe_internal_hub.cf
+++ b/lib/cfe_internal_hub.cf
@@ -39,9 +39,6 @@
 # the online docs
 #
 
-# For CFEngine Core: 3.7.0 to 3.7.x
-# Internal hub maintenance bundles, incompatible with 3.5.x
-
 ###################################################
 # If you find CFEngine useful, please consider    #
 # purchasing a commercial version of the software.#

--- a/lib/cfengine_enterprise_hub_ha.cf
+++ b/lib/cfengine_enterprise_hub_ha.cf
@@ -39,8 +39,6 @@
 # the online docs
 #
 
-# For CFEngine Core: 3.7.0 to 3.7.x
-
 #################################################
 # CFEngine Enterprise Hub HA policy inclusion
 #################################################

--- a/lib/commands.cf
+++ b/lib/commands.cf
@@ -39,7 +39,6 @@
 # the online docs
 #
 
-# For CFEngine Core: 3.7.0 to 3.7.x
 # Commands bodies
 
 ###################################################

--- a/lib/common.cf
+++ b/lib/common.cf
@@ -39,7 +39,6 @@
 # the online docs
 #
 
-# For CFEngine Core: 3.7.0 to 3.7.x
 # Common bodies
 
 ###################################################

--- a/lib/databases.cf
+++ b/lib/databases.cf
@@ -39,7 +39,6 @@
 # the online docs
 #
 
-# For CFEngine Core: 3.7.0 to 3.7.x
 # Databases bodies
 
 ###################################################

--- a/lib/edit_xml.cf
+++ b/lib/edit_xml.cf
@@ -39,7 +39,6 @@
 # the online docs
 #
 
-# For CFEngine Core: 3.7.0 to 3.7.x
 # edit_xml bundles
 
 ###################################################

--- a/lib/examples.cf
+++ b/lib/examples.cf
@@ -39,7 +39,6 @@
 # the online docs
 #
 
-# For CFEngine Core: 3.7.0 to 3.7.x
 # Examples you may find useful
 
 ###################################################

--- a/lib/files.cf
+++ b/lib/files.cf
@@ -39,7 +39,6 @@
 # the online docs
 #
 
-# For CFEngine Core: 3.7.0 to 3.7.x
 # Files bodies
 
 ###################################################

--- a/lib/guest_environments.cf
+++ b/lib/guest_environments.cf
@@ -39,7 +39,6 @@
 # the online docs
 #
 
-# For CFEngine Core: 3.7.0 to 3.7.x
 # Guest environments bodies
 
 ###################################################

--- a/lib/monitor.cf
+++ b/lib/monitor.cf
@@ -39,7 +39,6 @@
 # the online docs
 #
 
-# For CFEngine Core: 3.7.0 to 3.7.x
 # Monitor bodies
 
 ###################################################

--- a/lib/packages.cf
+++ b/lib/packages.cf
@@ -39,7 +39,6 @@
 # the online docs
 #
 
-# For CFEngine Core: 3.7.0 to 3.7.x
 # Packages bodies
 
 ###################################################

--- a/lib/paths.cf
+++ b/lib/paths.cf
@@ -39,7 +39,6 @@
 # the online docs
 #
 
-# For CFEngine Core: 3.7.0 to 3.7.x
 # Paths bundle (used by other bodies)
 
 ###################################################

--- a/lib/processes.cf
+++ b/lib/processes.cf
@@ -39,7 +39,6 @@
 # the online docs
 #
 
-# For CFEngine Core: 3.7.0 to 3.7.x
 # Processes bodies
 
 ###################################################

--- a/lib/services.cf
+++ b/lib/services.cf
@@ -39,7 +39,6 @@
 # the online docs
 #
 
-# For CFEngine Core: 3.7.0 to 3.7.x
 # Services bodies
 
 ###################################################

--- a/lib/stdlib.cf
+++ b/lib/stdlib.cf
@@ -39,7 +39,6 @@
 # the online docs
 #
 
-# For CFEngine Core: 3.7.0 to 3.7.x
 # Main COPBL include file
 
 ###################################################

--- a/lib/storage.cf
+++ b/lib/storage.cf
@@ -39,7 +39,6 @@
 # the online docs
 #
 
-# For CFEngine Core: 3.7.0 to 3.7.x
 # Storage bodies
 
 ###################################################

--- a/lib/users.cf
+++ b/lib/users.cf
@@ -39,7 +39,6 @@
 # the online docs
 #
 
-# For CFEngine Core: 3.7.0 to 3.7.x
 # Users bodies
 
 ###################################################

--- a/lib/vcs.cf
+++ b/lib/vcs.cf
@@ -39,7 +39,6 @@
 # the online docs
 #
 
-# For CFEngine Core: 3.7.0 to 3.7.x
 # VCS Bundles
 
 ###################################################


### PR DESCRIPTION
In 3.7.3 def.json started being parsed natively by the agent (CFE-2156). No
currently supported versions require this policy based parsing, so we can redact
it and simplify the policy.


----

#