### PR TITLE
ENT-6074/3.15.x: Added service states "active" and "inactive" for systemd

### DIFF
--- a/lib/services.cf
+++ b/lib/services.cf
@@ -129,7 +129,7 @@ bundle agent standard_services(service,state)
 # @brief Standard services bundle, used by CFEngine by default
 # @author CFEngine AS
 # @param service Name of service to control
-# @param state The desired state for that service: "start", "restart", "reload", "stop", or "disable". "enable", "enabled", and "disabled" are also able to be used when systemd is detected.
+# @param state The desired state for that service: "start", "restart", "reload", "stop", or "disable". "enable", "enabled", and "disabled" are also able to be used when systemd is detected. "active" and "inactive" states are supported for systemd managed hosts and can be used for controlling the services currently running state, but make no promises about the service state on boot.
 #
 # This bundle is used by CFEngine if you don't specify a services
 # handler explicitly, and will work with systemd or chkconfig or other
@@ -256,9 +256,12 @@ bundle agent standard_services(service,state)
       "request_enable"   expression => strcmp("enable", "$(state)");
       "request_enabled"  expression => strcmp("enabled", "$(state)");
 
-      "action_custom"  expression => "!(request_start|request_stop|request_reload|request_restart|request_disable|request_disabled|request_enable|request_enabled)";
-      "action_start"   expression => "request_start.!service_active.can_start_service";
-      "action_stop"    expression => "request_stop.service_active.can_stop_service";
+      "request_active"   expression => strcmp("active", "$(state)");
+      "request_inactive" expression => strcmp("inactive", "$(state)");
+
+      "action_custom"  expression => "!(request_start|request_stop|request_reload|request_restart|request_disable|request_disabled|request_enable|request_enabled|request_active|request_inactive)";
+      "action_start"   expression => "(request_start|request_active).!service_active.can_start_service";
+      "action_stop"    expression => "(request_stop|request_inactive).service_active.can_stop_service";
       "action_reload"  expression => "request_reload.service_active.can_reload_service";
       "action_restart"         or => {
                                       "request_restart",


### PR DESCRIPTION
This change brings understanding of "active" and "inactive" states for services
when managed by systemd. An "active" service state means the service should be
running. An "inactive" service state means the service should not be running.

NOTE: When "active" or "inactive" service states are used, no promises about a
services state on boot are made.

Ticket: ENT-6074
Changelog: Title
(cherry picked from commit 5d1a01ff3293c2c39325720b64ea0c77f9acf503)