### PR TITLE
Moved systemd service management to own bundle

### DIFF
--- a/lib/services.cf
+++ b/lib/services.cf
@@ -131,6 +131,14 @@ bundle agent standard_services(service,state)
 # methods:
 #     "" usebundle => standard_services("sshd", "start"); # direct
 # ```
+#
+# Alternatively, since services promises are an abstraction around bundles, the service state can be promised via a methods type promise.
+#
+# ```cf3
+#
+# methods:
+#     "SSHD should be running" usebundle => standard_services("sshd", "start");
+# ```
 {
   vars:
       "c_service" string => canonify("$(service)");
@@ -279,12 +287,19 @@ bundle agent systemd_services(service,state)
 # @brief Manage systemd service state
 # @author Bryan Burke
 # @param service specific service to control
-# @param state The desired state for that service: "active", "inactive", "restart", "reload", "enabled" and "disabled" are specifically understood states. Any other custom state will be passed through to systemctl.
+# @param state The desired state for that service: "active", "inactive", "restart", "reload", "enabled", "disabled", "start", and "stop" are specifically understood states. Any other custom state will be passed through to systemctl.
+#
 # **State descriptions:**
 #
 # * active - Service should be running, no promise about state on boot made.
 # * inactive - Service should not be running, no promise about state on boot made.
 # * restart - Service should be restarted, no promise about state on boot made.
+# * reload - Service should be reloaded, no promise about state on boot made.
+# * enabled - Service should be enabled, no promise about state on boot made.
+# * disabled - Service should be reloaded, no promise about state on boot made.
+# * start - Service should be running, service should be started on boot (active + enabled).
+# * stop - Service should not be running, service should not be started on boot (inactive + disabled).
+#
 # **Example:**
 #
 # ```cf3
@@ -297,6 +312,14 @@ bundle agent systemd_services(service,state)
 #     "sshd"
 #       service_policy => "running",
 #       service_policy => "systemd_services";
+# ```
+#
+# Alternatively, since services promises are an abstraction around bundles, the service state can be promised via a methods type promise.
+#
+# ```cf3
+#
+# methods:
+#     "SSHD should be running" usebundle => systemd_services("sshd", "enabled");
 # ```
 {
   vars:

--- a/lib/services.cf
+++ b/lib/services.cf
@@ -76,7 +76,20 @@ body service_method standard_services
         service_bundle => default:standard_services( $(this.promiser), $(this.service_policy) );
 }
 
-##
+body service_method systemd_services
+# @brief systemd service method
+#
+# **Example:**
+#
+# ```cf3
+# services:
+#     "ssh"
+#       service_policy => "enabled",
+#       service_method => systemd_services;
+# ```
+{
+        service_bundle => default:systemd_services( $(this.promiser), $(this.service_policy) );
+}
 
 bundle agent standard_services(service,state)
 # @brief Standard services bundle, used by CFEngine by default
@@ -94,7 +107,7 @@ bundle agent standard_services(service,state)
 # This bundle receives the service name and the desired service state,
 # then does the needful to reach the desired state.
 #
-# If you're running systemd, systemctl will be used.
+# If you're running systemd, systemctl will be used via `systemd_services`.
 #
 # Else, if chkconfig is present, it will be used.
 #
@@ -120,8 +133,6 @@ bundle agent standard_services(service,state)
 # ```
 {
   vars:
-      "call_systemctl" string => "$(paths.systemctl) --no-ask-password --global --system";
-      "systemd_properties" string => "-pLoadState,CanStop,UnitFileState,ActiveState,LoadState,CanStart,CanReload";
       "c_service" string => canonify("$(service)");
 
     freebsd::
@@ -139,9 +150,6 @@ bundle agent standard_services(service,state)
     stop|disable::
       "chkconfig_mode" string => "off";
       "svcadm_mode" string => "disable";
-
-    systemd::
-      "systemd_service_info" slist => string_split(execresult("$(call_systemctl) $(systemd_properties) show $(service)", "noshell"), "\n", "10");
 
   classes:
       # define a class named after the desired state
@@ -179,14 +187,131 @@ bundle agent standard_services(service,state)
                     service is not registered it must be added.  Note we do not
                     automatically try to add the service at this time.";
 
-### BEGIN ###
-# @brief probe the state of a systemd service
+  commands:
+
+    chkconfig.stop.onboot::
+      # Only chkconfig disable if it's currently set to start on boot
+      "$(paths.chkconfig) $(service) $(chkconfig_mode)"
+      classes => kept_successful_command,
+      contain => silent;
+
+    chkconfig.start.!onboot::
+      # Only chkconfig enable service if it's not already set to start on boot, and if its a registered chkconfig service
+      "$(paths.chkconfig) $(service) $(chkconfig_mode)"
+      ifvarclass => "!chkconfig_$(c_service)_unregistered",
+      classes => kept_successful_command,
+      contain => silent;
+
+    chkconfig.have_init.(((start|restart).!running)|((stop|restart|reload).running)).non_disabling::
+      "$(init) $(state)"
+      contain => silent;
+
+    sysvservice.start.!running::
+      "$(paths.service) $(service) start"
+      handle => "standard_services_sysvservice_not_running_start",
+      classes => kept_successful_command,
+      comment => "If the service should be running and it is not
+                  currently running then we should issue the standard service
+                  command to start the service.";
+
+    sysvservice.restart::
+      "$(paths.service) $(service) restart"
+      handle => "standard_services_sysvservice_restart",
+      classes => kept_successful_command,
+      comment => "If the service should be restarted we issue the
+                  standard service command to restart or reload the service.
+                  There is no restriction based on the services current state as
+                  restart can start a service that was not already
+                  running.";
+
+    sysvservice.reload.running::
+      "$(paths.service) $(service) reload"
+      handle => "standard_services_sysvservice_reload",
+      classes => kept_successful_command,
+      comment => "If the service should be reloaded we issue the
+                  standard service command to reload the service.
+                  It is restricted to when the service is running as a reload
+                  should not start services that are not already running. This
+                  may not be triggered as service state parameters are limited
+                  and translated to the closest meaning.";
+
+    sysvservice.((stop|disable).running)::
+      "$(paths.service) $(service) stop"
+      handle => "standard_services_sysvservice_stop",
+      classes => kept_successful_command,
+      comment => "If the service should be stopped or disabled and it is
+                  currently running then we should issue the standard service
+                  command to stop the service.";
+
+    smf::
+      "$(paths.svcadm) $(svcadm_mode) $(service)"
+      classes => kept_successful_command;
+
+  methods:
+    fallback::
+      "classic" usebundle => classic_services($(service), $(state));
+
+    systemd::
+      "systemd"
+        usebundle => systemd_services( $(service), $(state) );
+
+  reports:
+    verbose_mode.systemd::
+      "$(this.bundle): using systemd layer to $(state) $(service)";
+    verbose_mode.systemd.!service_loaded::
+      "$(this.bundle): Service $(service) unit file is not loaded; doing nothing";
+    verbose_mode.chkconfig::
+      "$(this.bundle): using chkconfig layer to $(state) $(service) (chkconfig mode $(chkconfig_mode))"
+        ifvarclass => "!chkconfig_$(c_service)_unregistered.((start.!onboot)|(stop.onboot))";
+    verbose_mode.chkconfig::
+      "$(this.bundle): skipping chkconfig layer to $(state) $(service) because $(service) is not registered with chkconfig (chkconfig --list $(service))"
+        ifvarclass => "chkconfig_$(c_service)_unregistered";
+    verbose_mode.sysvservice::
+      "$(this.bundle): using System V service / Upstart layer to $(state) $(service)";
+    verbose_mode.smf::
+      "$(this.bundle): using Solaris SMF to $(state) $(service) (svcadm mode $(svcadm_mode))";
+    verbose_mode.fallback::
+      "$(this.bundle): falling back to classic_services to $(state) $(service)";
+
+}
+
+bundle agent systemd_services(service,state)
+# @brief Manage systemd service state
 # @author Bryan Burke
+# @param service specific service to control
+# @param state The desired state for that service: "active", "inactive", "restart", "reload", "enabled" and "disabled" are specifically understood states. Any other custom state will be passed through to systemctl.
+# **State descriptions:**
 #
-# A collection of classes to determine the capabilities of a given systemd
-# service, then start, stop, etc. the service. Also supports a custom action
-# for anything not supported
+# * active - Service should be running, no promise about state on boot made.
+# * inactive - Service should not be running, no promise about state on boot made.
+# * restart - Service should be restarted, no promise about state on boot made.
+# **Example:**
 #
+# ```cf3
+# services:
+#     # Uses `standard_services`, dynamic decision about init subsystem
+#     "sshd"
+#       service_policy => "enabled";
+#
+#     # Explicitly use `systemd_services`
+#     "sshd"
+#       service_policy => "running",
+#       service_policy => "systemd_services";
+# ```
+{
+  vars:
+    systemd::
+      "call_systemctl"
+        string => "$(paths.systemctl) --no-ask-password --global --system";
+
+      "systemd_properties"
+        string => "-pLoadState,CanStop,UnitFileState,ActiveState,LoadState,CanStart,CanReload";
+
+      "systemd_service_info"
+        slist => string_split(execresult("$(call_systemctl) $(systemd_properties) show $(service)",
+                                         "noshell"), "\n", "10");
+
+  classes:
     systemd::
       "service_enabled" expression => reglist(@(systemd_service_info), "UnitFileState=enabled");
       "service_enabled" -> { "CFE-2923" }
@@ -258,90 +383,9 @@ bundle agent standard_services(service,state)
       "$(call_systemctl) $(state) $(service)"
         ifvarclass => "action_custom";
 
-### END systemd section ###
-
-    chkconfig.stop.onboot::
-      # Only chkconfig disable if it's currently set to start on boot
-      "$(paths.chkconfig) $(service) $(chkconfig_mode)"
-      classes => kept_successful_command,
-      contain => silent;
-
-    chkconfig.start.!onboot::
-      # Only chkconfig enable service if it's not already set to start on boot, and if its a registered chkconfig service
-      "$(paths.chkconfig) $(service) $(chkconfig_mode)"
-      ifvarclass => "!chkconfig_$(c_service)_unregistered",
-      classes => kept_successful_command,
-      contain => silent;
-
-    chkconfig.have_init.(((start|restart).!running)|((stop|restart|reload).running)).non_disabling::
-      "$(init) $(state)"
-      contain => silent;
-
-    sysvservice.start.!running::
-      "$(paths.service) $(service) start"
-      handle => "standard_services_sysvservice_not_running_start",
-      classes => kept_successful_command,
-      comment => "If the service should be running and it is not
-                  currently running then we should issue the standard service
-                  command to start the service.";
-
-    sysvservice.restart::
-      "$(paths.service) $(service) restart"
-      handle => "standard_services_sysvservice_restart",
-      classes => kept_successful_command,
-      comment => "If the service should be restarted we issue the
-                  standard service command to restart or reload the service.
-                  There is no restriction based on the services current state as
-                  restart can start a service that was not already
-                  running.";
-
-    sysvservice.reload.running::
-      "$(paths.service) $(service) reload"
-      handle => "standard_services_sysvservice_reload",
-      classes => kept_successful_command,
-      comment => "If the service should be reloaded we issue the
-                  standard service command to reload the service.
-                  It is restricted to when the service is running as a reload
-                  should not start services that are not already running. This
-                  may not be triggered as service state parameters are limited
-                  and translated to the closest meaning.";
-
-    sysvservice.((stop|disable).running)::
-      "$(paths.service) $(service) stop"
-      handle => "standard_services_sysvservice_stop",
-      classes => kept_successful_command,
-      comment => "If the service should be stopped or disabled and it is
-                  currently running then we should issue the standard service
-                  command to stop the service.";
-
-    smf::
-      "$(paths.svcadm) $(svcadm_mode) $(service)"
-      classes => kept_successful_command;
-
-  methods:
-    fallback::
-      "classic" usebundle => classic_services($(service), $(state));
-
   reports:
-    verbose_mode.systemd::
-      "$(this.bundle): using systemd layer to $(state) $(service)";
-    verbose_mode.systemd.!service_loaded::
-      "$(this.bundle): Service $(service) unit file is not loaded; doing nothing";
-    verbose_mode.chkconfig::
-      "$(this.bundle): using chkconfig layer to $(state) $(service) (chkconfig mode $(chkconfig_mode))"
-        ifvarclass => "!chkconfig_$(c_service)_unregistered.((start.!onboot)|(stop.onboot))";
-    verbose_mode.chkconfig::
-      "$(this.bundle): skipping chkconfig layer to $(state) $(service) because $(service) is not registered with chkconfig (chkconfig --list $(service))"
-        ifvarclass => "chkconfig_$(c_service)_unregistered";
-    verbose_mode.sysvservice::
-      "$(this.bundle): using System V service / Upstart layer to $(state) $(service)";
-    verbose_mode.smf::
-      "$(this.bundle): using Solaris SMF to $(state) $(service) (svcadm mode $(svcadm_mode))";
-    verbose_mode.fallback::
-      "$(this.bundle): falling back to classic_services to $(state) $(service)";
-
-    systemd.service_notfound.(start|restart|reload).(inform_mode|verbose_mode)::
-        "$(this.bundle): Could not find service: $(service)";
+    systemd.service_notfound.(inform_mode|verbose_mode)::
+      "$(this.bundle): Could not find service: $(service)";
 }
 
 bundle agent classic_services(service,state)


### PR DESCRIPTION
This change moves the systemd service management promises to their own bundle.
There should be no change in behavior as using standard_services when systemd is
present will still result in the use of the same promises. This change makes it
easier to maintain the policy as it is logically separate and allows explicit
management of systemd services.