### PR TITLE
Inventory OS variable (inventory_os.description in policy) is now based on os-release

### DIFF
--- a/inventory/os.cf
+++ b/inventory/os.cf
@@ -2,6 +2,11 @@ bundle common inventory_os
 {
 vars:
 
+# This bundle uses variable overwriting, so the definitions further
+# down are prioritized.
+
+# Fall back to old LSB based implementation (Lowest priority):
+
 _inventory_lsb_found::
   "description" string => "$(inventory_lsb.os) $(inventory_lsb.release)",
                   meta => { "inventory", "attribute_name=OS" };
@@ -14,4 +19,20 @@ _inventory_lsb_found::
   "description" string => "$(sys.flavor) (LSB missing)",
                   meta => { "inventory", "attribute_name=OS" };
 
+# Hard coded values for exceptions / platforms without os-release:
+
+centos_5::
+  "description" string => "CentOS Linux 5", # Matches format of os-release on 7+
+                  meta => { "inventory", "attribute_name=OS", "derived-from=centos_5" };
+
+centos_6::
+  "description" string => "CentOS Linux 6", # Matches format of os-release on 7+
+                  meta => { "inventory", "attribute_name=OS", "derived-from=centos_6" };
+
+# os-release PRETTY_NAME preferred whenever available (Highest priority):
+
+any::
+  "description" string => "$(sys.os_release[PRETTY_NAME])",
+                    if => isvariable("sys.os_release[PRETTY_NAME]"),
+                meta => { "inventory", "attribute_name=OS", "derived-from=sys.os_release" };
 }


### PR DESCRIPTION
Previously it was based on lsb executable, which is still used as a fallback.

Also added hard coded strings for CentOS 5 and 6.

Debian 7+ and Ubuntu 12+ already have os-release files.