### PR TITLE
ENT-6117/3.12.x: Added replace_uncommented_substrings

### DIFF
--- a/lib/files.cf
+++ b/lib/files.cf
@@ -289,6 +289,41 @@ bundle edit_line replace_line_end(start,end)
       edit_field => line("(^|\s)$(start)\s*", "2", "$(end)","set");
 }
 
+bundle edit_line replace_uncommented_substrings( _comment, _find, _replace )
+# @brief Replace all occurrences of `_find` with `_replace` on lines that do not follow a `_comment`
+# @param _comment Sequence of characters, each indicating the start of a comment.
+# @param _find String matching substring to replace
+# @param _replace String to substitute `_find` with
+#
+# **Example:**
+#
+# ```cf3
+# bundle agent example_replace_uncommented_substrings
+# {
+#   files:
+#     "/tmp/file.txt"
+#       edit_line => replace_uncommented_substrings( "#", "ME", "YOU");
+# }
+# ```
+#
+# **Notes:**
+#
+# * Only single character comments are supported as `_comment` is used in the PCRE character group (`[^...]`).
+# * `-` in `_comment` is interpreted as a range unless it's used as the first or last character. For example, setting `_comment` to `0-9` means any digit starts a comment.
+#
+# **History:**
+#
+# * Introduced 3.17.0
+{
+  vars:
+      "_reg_match_uncommented_lines_containing_find"
+        string => "^([^$(_comment)]*)\Q$(_find)\E(.*$)";
+
+  replace_patterns:
+    "$(_reg_match_uncommented_lines_containing_find)"
+      replace_with => text_between_match1_and_match2( $(_replace) );
+}
+
 ##
 
 bundle edit_line append_to_line_end(start,end)
@@ -1189,6 +1224,14 @@ body edit_field line(split,col,newval,method)
 }
 
 ##
+
+body replace_with text_between_match1_and_match2( _text )
+# @brief Replace matched line with substituted string
+# @param _text String to substitute between first and second match
+{
+        replace_value => "$(match.1)$(_text)$(match.2)";
+        occurrences => "all";
+}
 
 body replace_with value(x)
 # @brief Replace matching lines

--- a/tests/acceptance/lib/files/replace_uncommented_substrings.cf
+++ b/tests/acceptance/lib/files/replace_uncommented_substrings.cf
@@ -1,0 +1,41 @@
+body common control
+{
+        inputs => { '../../default.cf.sub',
+        };
+        bundlesequence  => { default("$(this.promise_filename)") };
+        version => "1.0";
+}
+#######################################################
+
+bundle common classes
+{
+  classes:
+
+      "testing_masterfiles_policy_framework"
+        comment => "This class is needed so that dcs.cf.sub includes the stdlib instead of using plucked.cf.sub from core which might get out of date and cause us to not test current code from the MPF.";
+}
+
+bundle agent test
+{
+  meta:
+      "description" -> { "ENT-6117" }
+        string => "Test that replace_uncommented_substrings behaves as expected";
+
+  files:
+      "$(this.promise_filename).before"
+        edit_line => replace_uncommented_substrings( "#", "ME", "YOU");
+}
+bundle agent check
+{
+  methods:
+
+      # Note: .before and .after differ beyond the substitution in that .after
+      # has a trailing newline. edit_line seems to append a trailing new line
+      # when it edits, perhaps related to CFE-270.
+
+      "check"
+        usebundle => dcs_check_diff( "$(this.promise_filename).before",
+                                     "$(this.promise_filename).after",
+                                     "$(this.promise_filename)");
+
+}

--- a/tests/acceptance/lib/files/replace_uncommented_substrings.cf
+++ b/tests/acceptance/lib/files/replace_uncommented_substrings.cf
@@ -12,6 +12,7 @@ bundle common classes
   classes:
 
       "testing_masterfiles_policy_framework"
+        expression => "any",
         comment => "This class is needed so that dcs.cf.sub includes the stdlib instead of using plucked.cf.sub from core which might get out of date and cause us to not test current code from the MPF.";
 }
 
@@ -20,6 +21,13 @@ bundle agent test
   meta:
       "description" -> { "ENT-6117" }
         string => "Test that replace_uncommented_substrings behaves as expected";
+
+  vars:
+
+      "test_soft_fail"
+        string => "cfengine_3_7",
+        comment => "The agent is not able to find the bundle",
+        meta => { "ENT-6117" };
 
   files:
       "$(this.promise_filename).before"

--- a/tests/acceptance/lib/files/replace_uncommented_substrings.cf.after
+++ b/tests/acceptance/lib/files/replace_uncommented_substrings.cf.after
@@ -1,0 +1,5 @@
+# Don't replace ME please
+    # please don't  replace ME either
+You should replace YOU, and YOU though, and YOU also, and YOU, and YOU, and YOU, and YOU, # But, ME will not get replaced since it's after a comment
+And, also you should replace YOU too
+# Not ME

--- a/tests/acceptance/lib/files/replace_uncommented_substrings.cf.before
+++ b/tests/acceptance/lib/files/replace_uncommented_substrings.cf.before
@@ -1,0 +1,5 @@
+# Don't replace ME please
+    # please don't  replace ME either
+You should replace ME, and ME though, and ME also, and ME, and ME, and ME, and ME, # But, ME will not get replaced since it's after a comment
+And, also you should replace ME too
+# Not ME


### PR DESCRIPTION
This bundle and accompanying body aid in replacing all occurrences of a string
in a file that do not follow a comment character.

Ticket: ENT-6117
Changelog: Title
(cherry picked from commit d77f5de5a69f16e3e63feb94eb9447bc4f16a866)


----

#