### PR TITLE
ENT-6117/3.15.x: Added history for backport of replace_uncommented_substrings

### DIFF
--- a/lib/files.cf
+++ b/lib/files.cf
@@ -316,7 +316,7 @@ bundle edit_line replace_uncommented_substrings( _comment, _find, _replace )
 #
 # **History:**
 #
-# * Introduced 3.17.0
+# * Introduced 3.17.0, 3.15.3
 {
   vars:
       "_reg_match_uncommented_lines_containing_find"


### PR DESCRIPTION
Ticket: ENT-6117
Changelog: None
(cherry picked from commit 58dcce6babb93e5a8ed1b54248b7bedd2263a37f)