### PR TITLE
ENT-6124: Fixed space before version number for RHEL 5 / 6

### DIFF
--- a/inventory/os.cf
+++ b/inventory/os.cf
@@ -22,7 +22,7 @@ _inventory_lsb_found::
 # Hard coded values for exceptions / platforms without os-release:
 
 (redhat_5|redhat_6).redhat_pure::
-  "description" string => regex_replace("$(inventory_lsb.description)", " release ", "", "g"),
+  "description" string => regex_replace("$(inventory_lsb.description)", " release ", " ", "g"),
                     if => isvariable("inventory_lsb.description"),
                   meta => { "inventory", "attribute_name=OS", "derived-from=inventory_lsb.description" };
 


### PR DESCRIPTION
Oopsie in previous commit:
cfengine/masterfiles@8c959b62655c0ae40dcb7b1f675ac64a25c98f36