### PR TITLE
Removed delay in refreshing software installed inventory

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -1210,8 +1210,8 @@ For example:
 ### Configure periodic package inventory refresh interval
 
 CFEngine refreshes software inventory when it makes changes via packages
-promises. Additionally, by default, CFEngine periodically refreshes it's
-internal cache of packages installed (every 60 minutes) and package updates that
+promises. Additionally, by default, CFEngine refreshes it's
+internal cache of packages installed (during each agent run) and package updates that
 are available (once a day) according to the default package manager in order to
 pick up changes made outside packages promises.
 
@@ -1227,7 +1227,10 @@ pick up changes made outside packages promises.
 WARNING: Be ware of setting `package_module_query_update_ifelapsed` too low,
 especially with public repositories or you may be banned for abuse.
 
-**History**: Added in 3.15.0, 3.12.3
+**History**:
+
+* Added in 3.15.0, 3.12.3
+* 3.17.0 decreased `package_module_query_installed_ifelapsed` from `60` to `0`
 
 ### Enable logging of Enterprise License utilization
 

--- a/controls/def.cf
+++ b/controls/def.cf
@@ -185,7 +185,7 @@ bundle common def
 
       # Package inventory refresh
       "package_module_query_installed_ifelapsed" -> { "CFE-2771" }
-        string => "60", # 1 hour
+        string => "0", # Always refresh local package inventory
         if => not( isvariable( $(this.promiser) ));
 
       "package_module_query_updates_ifelapsed" -> { "CFE-2771" }


### PR DESCRIPTION
This change sets the delay for updating the inventory of currently installed
packages to 0, effectively disabling any delay. This inventory affects
packagesmatching() as well as inventory collected by an Enterprise hub. Without
this change, changes to software made outside CFEngine may not be realized for
up to 60 minutes.

Ticket: ENT-6154
Changelog: Title