### PR TITLE
ENT-5538/3.15.x: Added watchdog for Windows

### DIFF
--- a/cfe_internal/core/watchdog/README.md
+++ b/cfe_internal/core/watchdog/README.md
@@ -50,6 +50,20 @@ If there is less than 500MB of free space, the watchdog will clean up old archiv
 - Introduced check for too many concurrent cf-agent processes (3.15.0)
 - Introduced check for integrity issues identified by cf-check (3.15.0)
 
+## Windows Watchdog
+
+The Windows watchdog is implemented as a powershell script rendered via mustache template.
+
+When **enabled** the policy ensures that the watchdog script is scheduled for execution via the windows task scheduler.
+
+When **disabled** the policy ensures that the there it no scheduled task named `CFEngine-watchdog`.
+
+The watchdog logs to `$(sys.workdir)/watchdog.log` (`C:\Program Files\Cfengine\watchdog.log`). Note, this log file is **not** automatically rotated or purged.
+
+**History:**
+
+- Initially introduced with check to terminate any cf-agent processes that have been running for longer than 5 minutes. (3.17.0, 3.15.3)
+
 ### Symptoms of pathology
 
 The following conditions are included in the watchdog checks:

--- a/cfe_internal/core/watchdog/templates/watchdog-windows.ps1.mustache
+++ b/cfe_internal/core/watchdog/templates/watchdog-windows.ps1.mustache
@@ -1,0 +1,22 @@
+$LOGFILE="{{{logfile}}}"
+
+$long_running_cf_agent_threshold_min = 5
+$long_running_cf_agent_count = @(Get-Process cf-agent -erroraction "silentlycontinue" | Where { $_.StartTime -lt (Get-Date).AddMinutes(-$long_running_cf_agent_threshold_min) }).count
+$long_running_cf_agent_count_threshold = 1
+
+If ($long_running_cf_agent_count -ge $long_running_cf_agent_count_threshold) {
+    $DATESTAMP=Get-Date -Format "yyyy-MM-dd HH:mm"
+
+    Write-Output "${DATESTAMP}: Count of long running cf-agent ($long_running_cf_agent_count) has met the threshold ($long_running_cf_agent_count_threshold) of long running agents, remediation triggered." | Tee-Object -FilePath "$LOGFILE" -Append
+    Write-Output "${DATESTAMP}: Before remediation" | Tee-Object -FilePath "$LOGFILE" -Append
+    Get-Process cf-agent -erroraction "silentlycontinue" | ft -erroraction "silentlycontinue" Name,CommandLine,StartTime,@{label="Elapsed Minutes";expression={[System.Math]::Round(((Get-Date)-$_.StartTime).totalminutes)}} | Tee-Object -FilePath "$LOGFILE" -Append
+
+    Get-Process cf-agent -erroraction "silentlycontinue" | Where { $_.StartTime -lt (Get-Date).AddMinutes(-$long_running_cf_agent_threshold_min) } | Stop-Process -Force
+    # Give the system a bit of time to kill all the processes
+    sleep 1
+
+    $DATESTAMP=Get-Date -Format "yyyy-MM-dd HH:mm"
+    $running_cf_agent_count = @(Get-Process cf-agent -erroraction "silentlycontinue").count
+    Write-Output "${DATESTAMP}: Observed $running_cf_agent_count cf-agent processes after remediation" | Tee-Object -FilePath "$LOGFILE" -Append
+    Get-Process cf-agent -erroraction "silentlycontinue" | ft -erroraction "silentlycontinue" Name,CommandLine,StartTime,@{label="Elapsed Minutes";expression={[System.Math]::Round(((Get-Date)-$_.StartTime).totalminutes)}} | Tee-Object -FilePath "$LOGFILE" -Append
+}

--- a/cfe_internal/core/watchdog/watchdog.cf
+++ b/cfe_internal/core/watchdog/watchdog.cf
@@ -6,6 +6,9 @@ bundle agent cfe_internal_core_watchdog(state)
     "description"
       string => "Configure external watchdog processes (like cron, or monit) to
                  make sure that cf-execd is always running";
+  vars:
+
+      "_logfile" string => "$(sys.workdir)/watchdog.log";
 
   classes:
       "invalid_state"
@@ -23,6 +26,9 @@ bundle agent cfe_internal_core_watchdog(state)
       "use_cfe_internal_core_watchdog_aix"
         expression => "!use_cfe_internal_core_watchdog_cron_d.aix";
 
+      "use_cfe_internal_core_watchdog_windows"
+        expression => "windows";
+
   methods:
     use_cfe_internal_core_watchdog_cron_d::
       "any" usebundle => cfe_internal_core_watchdog_cron_d( $(state) );
@@ -30,14 +36,100 @@ bundle agent cfe_internal_core_watchdog(state)
     use_cfe_internal_core_watchdog_aix::
       "any" usebundle => cfe_internal_core_watchdog_aix( $(state) );
 
+    use_cfe_internal_core_watchdog_windows::
+      "any" usebundle => cfe_internal_core_watchdog_windows( $(state) );
+
   reports:
     DEBUG|DEBUG_cfe_internal_core_watchdog::
       "DEBUG $(this.bundle): Watchdog '$(state)'";
       "DEBUG $(this.bundle): Invalid state '$(state)' only enabled|disabled allowed"
         ifvarclass => "invalid_state";
 
-    !(use_cfe_internal_core_watchdog_cron_d|aix)::
-      "WARNING $(this.bundle): Currently only supports /etc/cron.d on systems that have pgrep in the the stdlib paths bundle and AIX hosts.";
+    !(use_cfe_internal_core_watchdog_cron_d|use_cfe_internal_core_watchdog_aix|use_cfe_internal_core_watchdog_windows)::
+      "WARNING $(this.bundle): Currently only supports /etc/cron.d on systems that have pgrep in the the stdlib paths bundle, AIX and Windows hosts.";
+}
+
+bundle agent cfe_internal_core_watchdog_windows(state)
+# @brief Manage watchdog state on windows
+# @param state enabled|disabled
+# - When enabled a scheduled task "CFEngine-watchdog" will be present and enabled
+# - When disabled a scheduled task named "CFEngine-watchdog" will be absent.
+{
+
+  vars:
+    windows::
+      "_requested_state" string => ifelse( regcmp( "enabled|disabled", $(state) ), "$(state)", "invalid");
+      "_taskname" string => "CFEngine-watchdog";
+      "_taskfreq" string => "1";
+      "_taskscript" string => "$(sys.bindir)$(const.dirsep)watchdog.ps1";
+      "_taskrun" string => "PowerShell";
+      "_taskrun_args" string => "-NoProfile -ExecutionPolicy bypass -File";
+      "_logfile" string => "$(cfe_internal_core_watchdog._logfile)";
+      # -NonInteractive?
+
+      "_cmd_task_schedule"
+        string => `$(sys.winsysdir)$(const.dirsep)schtasks.exe /create /tn "$(_taskname)" /tr "$(_taskrun) $(_taskrun_args) '$(_taskscript)'" /ru "System" /sc minute /mo $(_taskfreq) /rl highest /f`;
+
+      # We use XML output because it's the most portable output considering localization etc ...
+      "_cmd_task_query"
+        string => `schtasks /QUERY /TN "$(_taskname)" /XML 2> $(const.dollar)null`;
+
+      "_cmd_task_query_result"
+        string => execresult( $(_cmd_task_query), powershell);
+
+      # This regular expression is used to match against the XML output querying the task
+      # We escape _taskscript with \Q \E since it contains backslashes which we don't want to be expanded
+      "_scheduled_task_regex"
+        string => concat(".*Interval.PT$(_taskfreq)M..Interval",
+                         ".*Command.$(_taskrun)..Command",
+                         ".*Arguments.$(_taskrun_args) .\Q$(_taskscript)\E...Arguments",
+                         ".*");
+  classes:
+    windows::
+      "_requested_state_$(_requested_state)";
+
+    _requested_state_enabled::
+      "_watchdog_present_correct"
+        expression => regcmp( $(_scheduled_task_regex), $(_cmd_task_query_result) );
+
+    _requested_state_disabled::
+      "_watchdog_absent_correct"
+        expression => not( returnszero( 'schtasks /QUERY /TN "$(_taskname)" 2> $(const.dollar)null', powershell ));
+
+  files:
+      "$(_taskscript)"
+        create => "true",
+        template_method => "mustache",
+        edit_template => "$(this.promise_dirname)/templates/watchdog-windows.ps1.mustache",
+        template_data => parsejson( '{"logfile": "$(_logfile)" }' );
+
+  commands:
+
+    _requested_state_disabled.!_watchdog_absent_correct::
+      `schtasks /DELETE /TN "$(_taskname)" /F`
+        action => immediate,
+        contain => powershell,
+        classes => results( "bundle", "win_watchdog_script");
+
+    _requested_state_enabled.!_watchdog_present_correct::
+      `$(_cmd_task_schedule)`
+        action => immediate,
+        contain => in_shell,
+        classes => results( "bundle", "win_watchdog_script");
+
+  reports:
+    verbose_mode::
+      "CFEngine-watchdog desired state '$(_requested_state)'";
+
+      "CFEngine-watchdog scheduled task state '$(_requested_state)' correct"
+        if => "_watchdog_present_correct|_watchdog_absent_correct";
+
+    verbose_mode.(!_watchdog_present_correct._requested_state_enabled)::
+      "CFEngine-watchdog scheduled task state incorrect";
+      `Should: $(_cmd_task_schedule)`;
+
+    (inform_mode|verbose_mode).win_watchdog_script_repaired::
+      "CFEngine-watchdog scheduled task repaired";
 }
 
 bundle agent cfe_internal_core_watchdog_aix(state)

--- a/lib/commands.cf
+++ b/lib/commands.cf
@@ -74,6 +74,25 @@ bundle agent daemonize(command)
 ## contain
 ##-------------------------------------------------------
 
+body contain powershell
+# @brief Run command with powershell (windows only)
+#
+# **Example:**
+#
+# ```cf3
+#  commands:
+#    windows::
+#      'schtasks /DELETE /TN "$(_taskname)" /F'
+#        contain => powershell;
+# ```
+#
+# **History:**
+#
+# * Introduced in 3.17.0, 3.15.3
+{
+        useshell => "powershell";
+}
+
 body contain silent
 # @brief suppress command output
 {


### PR DESCRIPTION
This change adds an external watchdog for windows. When enabled, any cf-agent
processes found running longer than 5 minutes are terminated.

Ticket: ENT-5538
Changelog: Title
(cherry picked from commit 6bdc03df8d3c1a74c72442800e3f6ff79f86cca2)