### PR TITLE
ENT-6195: Adjust use of policy_servers for server failover case

### DIFF
--- a/controls/def.cf
+++ b/controls/def.cf
@@ -363,7 +363,12 @@ bundle common def
       "policy_servers" slist => { "$(sys.policy_hub)", "@(standby_servers)" };
 
     !enable_cfengine_enterprise_hub_ha::
-      "policy_servers" slist => {"$(sys.policy_hub)"};
+      # Since this is used in the default ACL, we need to have a variable defined, even if it is empty
+      "policy_servers"
+        slist => { $(sys.policy_hub) },
+        if => not( isvariable( "$(this.promiser)" )),
+        comment => "An ordered list of policy servers",
+        handle => "mpf_def_policy_servers";
 
     enterprise_edition.policy_server::
       "control_hub_exclude_hosts"


### PR DESCRIPTION
Allow augments `policy_servers` to specify a list of servers which are granted access.

This enables creating custom update policy which can auto-update a clients policy_server.dat to on the first available policy server in `policy_servers` list of IPs.

Ticket: ENT-6195
Changelog: title