### PR TITLE
CFE-3427/master: Changed bundle server access_rules to mpf_default_access_rules

### DIFF
--- a/controls/cf_serverd.cf
+++ b/controls/cf_serverd.cf
@@ -82,7 +82,7 @@ body server control
 
 ###############################################################################
 
-bundle server access_rules()
+bundle server mpf_default_access_rules()
 # @brief Defines access to common resources
 {
   access:


### PR DESCRIPTION
This is an attempt to clarify a common misconception that `bundle server
access_rules` is somehow special. There is no need to modify this file in the
MPF in order to define custom access promises. Instead, simply define a custom
server bundle, e.g. bundle server my_access_rules.

Merge with: https://github.com/cfengine/documentation/pull/2369