### PR TITLE
ENT-6082 disable *-list-cached tests on deb7 and solaris11 - 3.15.x

### DIFF
--- a/tests/acceptance/17_packages/12_new/timed/local-updates-list-cached.cf
+++ b/tests/acceptance/17_packages/12_new/timed/local-updates-list-cached.cf
@@ -10,7 +10,9 @@ body common control
 bundle agent init
 {
   meta:
-    "test_skip_needs_work" string => "!linux";
+    # Test package module implemented only on Linux.
+    # On Debian 7 and Solaris 11 this test fails too often.
+    "test_skip_needs_work" string => "!linux|debian_7|sunos_5_11";
 
   files:
     test_pass_1::

--- a/tests/acceptance/17_packages/12_new/timed/updates-list-cached.cf
+++ b/tests/acceptance/17_packages/12_new/timed/updates-list-cached.cf
@@ -9,7 +9,9 @@ body common control
 bundle agent init
 {
   meta:
-    "test_skip_needs_work" string => "!linux";
+    # Test package module implemented only on Linux.
+    # On Debian 7 and Solaris 11 this test fails too often.
+    "test_skip_needs_work" string => "!linux|debian_7|sunos_5_11";
 
   files:
     test_pass_1::


### PR DESCRIPTION
(cherry picked from commit c4ced8e23bc55722b252def2233bbdd6d1df60e0)


----

#