### PR TITLE
ENT-6375/master: Removed unnecessary packages promises

### DIFF
--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -1020,6 +1020,11 @@ bundle agent cfe_autorun_inventory_packages
                                 fileexists("$(sys.workdir)/state/software_packages.csv"),
       };
 
+      "use_package_module_for_inventory" or => { "redhat", "debian", "suse", "sles", "alpinelinux" };
+      "use_package_method_for_inventory" or => { "gentoo", "aix" };
+      "use_package_method_generic_for_inventory"
+        not => "use_package_module_for_inventory|use_package_method_for_inventory";
+
   vars:
       # if we have the patches, 7 days; otherwise keep trying
       "refresh" string => ifelse("have_inventory", "10080",
@@ -1033,12 +1038,6 @@ bundle agent cfe_autorun_inventory_packages
     # exists. As package modules become available the package_methods should be
     # removed.
 
-    suse|sles::
-      "cfe_internal_non_existing_package"
-      package_policy => "add",
-      package_method => inventory_zypper($(refresh)),
-      action => if_elapsed_day;
-
     aix::
       "cfe_internal_non_existing_package"
       package_policy => "add",
@@ -1051,7 +1050,7 @@ bundle agent cfe_autorun_inventory_packages
       package_method => emerge,
       action => if_elapsed_day;
 
-    !redhat.!debian.!gentoo.!(suse|sles).!aix::
+    use_package_method_generic_for_inventory::
       "cfe_internal_non_existing_package"
       package_policy => "add",
       package_method => generic,
@@ -1089,40 +1088,6 @@ body package_method inventory_lslpp(update_interval)
       package_patch_command  => "/usr/bin/true";
       package_delete_command => "/usr/bin/true";
       package_verify_command => "/usr/bin/true";
-}
-
-body package_method inventory_zypper(update_interval)
-# @depends common_knowledge rpm_knowledge suse_knowledge
-# @brief SUSE zypper installation method for inventory purposes only
-# @param update_interval how often to update the package and patch list
-#
-# This package method is a copy of the SUSE zypper method just for
-# inventory purposes.
-{
-      package_changes => "bulk";
-
-      package_list_command => "$(paths.path[rpm]) -qa --queryformat \"i | repos | %{name} | %{version}-%{release} | %{arch}\n\"";
-
-      # set it to "0" to avoid caching of list during upgrade
-      package_list_update_command => "$(suse_knowledge.call_zypper) list-updates";
-      package_list_update_ifelapsed => $(update_interval);
-
-      package_patch_list_command => "$(suse_knowledge.call_zypper) patches";
-      package_installed_regex => "i.*";
-      package_list_name_regex    => "$(rpm_knowledge.rpm_name_regex)";
-      package_list_version_regex => "$(rpm_knowledge.rpm_version_regex)";
-      package_list_arch_regex    => "$(rpm_knowledge.rpm_arch_regex)";
-
-      package_patch_installed_regex => ".*Installed.*|.*Not Applicable.*";
-      package_patch_name_regex    => "[^|]+\|\s+([^\s]+).*";
-      package_patch_version_regex => "[^|]+\|[^|]+\|\s+([^\s]+).*";
-
-      package_name_convention => "$(name)";
-      package_add_command => "$(suse_knowledge.call_zypper) --help >/dev/null 2>&1 ; /bin/true";
-      package_delete_command => "$(suse_knowledge.call_zypper) --non-interactive remove --force-resolution";
-      package_update_command => "$(suse_knowledge.call_zypper) --non-interactive update";
-      package_patch_command => "$(suse_knowledge.call_zypper) --non-interactive patch$"; # $ means no args
-      package_verify_command => "$(suse_knowledge.call_zypper) --non-interactive verify$";
 }
 
 bundle agent cfe_autorun_inventory_cmdb


### PR DESCRIPTION
This packages promise was in place to provide package inventory used by
packagematching() and packageupdatesmatching() out of the box. This is not
needed since ENT-5480 introduced the zypper package module.

Ticket: ENT-6375
Changelog: Title