### PR TITLE
Fix converge bug with anchoring and add converge_prepend

### DIFF
--- a/lib/files.cf
+++ b/lib/files.cf
@@ -1077,10 +1077,18 @@ bundle edit_line converge(marker, lines)
 }
 
 bundle edit_line converge_prepend(marker, lines)
-# @brief Converge `lines` marked with `marker` to start of content
+# @brief Converge `lines` marked with `marker` to start of content.
 #
 # Any content marked with `marker` is removed, then `lines` are
 # inserted at *start* of content.  Every `line` should contain `marker`.
+#
+# This is helpful for files where order matters, like `pam.d/common-auth`,
+# and you want the content at the top. If you want to maintain the order
+# of multiple lines, pass one item with a newline in it like this:
+# ```
+# "" usebundle => converge_prepend("covfefe", "first line of covfefe
+# second line of covfefe");
+# ```
 #
 # @param marker The marker (not a regular expression; will be escaped)
 # @param lines The lines to insert; all must contain `marker`

--- a/lib/files.cf
+++ b/lib/files.cf
@@ -1071,10 +1071,29 @@ bundle edit_line converge(marker, lines)
       "regex" string => escape($(marker));
 
   delete_lines:
-      "$(regex)" comment => "Delete lines matching the marker";
+      ".*$(regex).*" comment => "Delete lines matching the marker";
   insert_lines:
       "$(lines)" comment => "Insert the given lines";
 }
+
+bundle edit_line converge_prepend(marker, lines)
+# @brief Converge `lines` marked with `marker` to start of content
+#
+# Any content marked with `marker` is removed, then `lines` are
+# inserted at *start* of content.  Every `line` should contain `marker`.
+#
+# @param marker The marker (not a regular expression; will be escaped)
+# @param lines The lines to insert; all must contain `marker`
+{
+  vars:
+      "regex" string => escape($(marker));
+
+  delete_lines:
+      ".*$(regex).*" comment => "Delete lines matching the marker";
+  insert_lines:
+      "$(lines)" location => start, comment => "Insert the given lines";
+}
+
 
 bundle edit_line fstab_option_editor(method, mount, option)
 # @brief Add or remove `/etc/fstab` options for a mount


### PR DESCRIPTION
In my testing with 3.16, the deletion doesn't work today, so `converge` is not functioning properly.

Add `converge_prepend` with same behavior and bugfix, but inserting at start of content.