### PR TITLE
ENT-6563/master: Suppressed inform output from Enterprise Hub database maintenance operations

### DIFF
--- a/cfe_internal/enterprise/CFE_hub_specific.cf
+++ b/cfe_internal/enterprise/CFE_hub_specific.cf
@@ -580,6 +580,9 @@ bundle agent cfe_internal_refresh_inventory_view
       "$(sys.workdir)/httpd/php/bin/php"
         args => "$(cfe_internal_hub_vars.public_docroot)/index.php cli_tasks inventory_refresh",
         contain => silent,
+@if minimum_version(3.15.0)
+        inform => "false",
+@endif
         comment => "This refreshes the variables shown in the Mission Portal Inventory.",
         handle  => "mpf_fresh_inventory_view",
         if => isdir( "$(cfe_internal_hub_vars.docroot)/api/modules/inventory" );
@@ -601,6 +604,9 @@ bundle agent cfe_internal_refresh_hosts_view
       "$(sys.workdir)/httpd/php/bin/php" -> { "ENT-3482" }
         args => "$(cfe_internal_hub_vars.public_docroot)/index.php cli_tasks materialized_hosts_view_refresh",
         contain => silent,
+@if minimum_version(3.15.0)
+        inform => "false",
+@endif
         comment => "This refreshes the hosts view. If the hosts view is not refreshed then it will contain stale data.",
         handle  => "mpf_fresh_hosts_view",
         if => isgreaterthan(countlinesmatching(".*materialized_hosts_view_refresh.*", "$(cfe_internal_hub_vars.docroot)/application/controllers/Cli_tasks.php"), 0);
@@ -645,6 +651,9 @@ bundle agent cfe_internal_refresh_events_table
       "$(sys.workdir)/httpd/php/bin/php"
         args => "$(cfe_internal_hub_vars.public_docroot)/index.php cli_tasks process_api_events",
         contain => silent,
+@if minimum_version(3.15.0)
+        inform => "false",
+@endif
         comment => "This refreshes the events table. If the events table is not refreshed then it will contain stale data.",
         handle  => "mpf_fresh_events_table",
         if => fileexists( "$(cfe_internal_hub_vars.docroot)/api/resource-v1/Event.php" );
@@ -666,6 +675,9 @@ bundle agent cfe_internal_update_health_failures
       "$(sys.workdir)/httpd/php/bin/php" -> { "ENT-6228" }
         args => "$(cfe_internal_hub_vars.public_docroot)/index.php cli_tasks update_health_failures",
         contain => silent,
+@if minimum_version(3.15.0)
+        inform => "false",
+@endif
         comment => "This updates health diagnostics failures table. If the table is not updated then it will contain stale data.",
         handle  => "mpf_update_health_failures",
         if => isgreaterthan(countlinesmatching(".*update_health_failures.*", "$(cfe_internal_hub_vars.docroot)/application/controllers/Cli_tasks.php"), 0);


### PR DESCRIPTION
The inform output generated by these commands is distracting for new users.
Already the promises were set to be contained in a silent body, this just
extends that silence to suppress from inform. The command results are still
interpreted the same, and if one of these commands is not kept, they will still
emit an error.

Ticket: ENT-6563
Changelog: Title

-----
Before:

```
[root@hub ~]# cf-agent -KI
    info: Executing 'no timeout' ... '/var/cfengine/httpd/php/bin/php /var/cfengine/httpd/htdocs/index.php cli_tasks process_api_events'
    info: Completed execution of '/var/cfengine/httpd/php/bin/php /var/cfengine/httpd/htdocs/index.php cli_tasks process_api_events'
    info: Executing 'no timeout' ... '/var/cfengine/httpd/php/bin/php /var/cfengine/httpd/htdocs/index.php cli_tasks materialized_hosts_view_refresh'
    info: Completed execution of '/var/cfengine/httpd/php/bin/php /var/cfengine/httpd/htdocs/index.php cli_tasks materialized_hosts_view_refresh'
    info: Executing 'no timeout' ... '/var/cfengine/httpd/php/bin/php /var/cfengine/httpd/htdocs/index.php cli_tasks inventory_refresh'
    info: Completed execution of '/var/cfengine/httpd/php/bin/php /var/cfengine/httpd/htdocs/index.php cli_tasks inventory_refresh'
[root@hub ~]# 
```

After

```
[root@hub ~]# cf-agent -KI
[root@hub ~]# 
```