### PR TITLE
CFE-3513/master: query service status on FreeBSD using onestatus

### DIFF
--- a/lib/services.cf
+++ b/lib/services.cf
@@ -171,7 +171,10 @@ bundle agent standard_services(service,state)
 
       "have_init" expression => fileexists($(init));
 
-    chkconfig.have_init::
+    chkconfig.have_init.freebsd::
+      "running" expression => returnszero("$(init) onestatus > /dev/null", "useshell");
+      
+    chkconfig.have_init.!freebsd::
       "running" expression => returnszero("$(init) status > /dev/null", "useshell");
 
     sysvservice.have_init::


### PR DESCRIPTION
If a service is not enabled in rc.conf on FreeBSD, trying to get the status always results in something like:

```
# /etc/rc.d/ntpd status
Cannot 'status' ntpd. Set ntpd_enable to YES in /etc/rc.conf or use 'onestatus' instead of 'status'.
# echo $?
0
```

As the exit code is zero, cf-agent would try to stop this service. Using onestatus always returns the wanted exit code, regardless if the service is enabled or not. 

```
# /etc/rc.d/ntpd onestatus
ntpd is not running.
# echo $?
1
```