### PR TITLE
CFE-3512/master: Renamed python symlink to cfengine-selected-python

### DIFF
--- a/cfe_internal/update/update_policy.cf
+++ b/cfe_internal/update/update_policy.cf
@@ -133,6 +133,14 @@ bundle agent cfe_internal_setup_python_symlink(symlink_path)
         link_from => u_ln_s("$(python)"),
         move_obstructions => "true",
         if => isvariable("python");
+
+      "$(sys.bindir)/python" -> { "CFE-3512" }
+        delete => u_tidy,
+        if => islink( $(this.promiser) ),
+        comment => concat( "We don't want to leave a python that is potentially in $PATH ",
+                           "after having re-named our python symlink that is used for various ",
+                           "modules");
+
 }
 
 bundle agent cfe_internal_update_policy_cpv
@@ -195,7 +203,8 @@ bundle agent cfe_internal_update_policy_cpv
       comment => "File where Postgres database files will be logging -",
         handle => "cfe_internal_update_policy_postgresdb_log_file";
 
-      "python_symlink"        string => "$(sys.bindir)/python",
+      "python_symlink" -> { "CFE-2602", "CFE-3512" }
+        string => "$(sys.bindir)/cfengine-selected-python",
         comment => "Symlink to Python we found (if any)",
         handle => "cfe_internal_update_policy_python_symlink";
 
@@ -295,7 +304,8 @@ bundle agent cfe_internal_update_policy_cpv
   methods:
     debian|redhat|amazon_linux|suse|sles|opensuse::
       # Only needed on distros with Python-based package modules
-      "setup_python_symlink" usebundle => cfe_internal_setup_python_symlink("$(python_symlink)");
+      "setup_python_symlink" -> { "CFE-2602" }
+        usebundle => cfe_internal_setup_python_symlink("$(python_symlink)");
 }
 
 #########################################################

--- a/cfe_internal/update/update_policy.cf
+++ b/cfe_internal/update/update_policy.cf
@@ -136,7 +136,7 @@ bundle agent cfe_internal_setup_python_symlink(symlink_path)
 
       "$(sys.bindir)/python" -> { "CFE-3512" }
         delete => u_tidy,
-        if => islink( $(this.promiser) ),
+        if => islink( "$(sys.bindir)/python" ),
         comment => concat( "We don't want to leave a python that is potentially in $PATH ",
                            "after having re-named our python symlink that is used for various ",
                            "modules");

--- a/inventory/redhat.cf
+++ b/inventory/redhat.cf
@@ -12,13 +12,13 @@ bundle common inventory_redhat
       comment => "derived from Red Hat",
       meta => { "inventory", "attribute_name=none" };
 
-      "inventory_redhat_have_python_symlink" expression => fileexists("$(sys.bindir)/python");
+      "inventory_redhat_have_python_symlink" expression => fileexists("$(sys.bindir)/cfengine-selected-python");
 
     inventory_redhat_have_python_symlink::
-      "cfe_yum_package_module_supported" -> { "CFE-2602" }
+      "cfe_yum_package_module_supported" -> { "CFE-2602", "CFE-3512" }
         comment => "Here we see if the version of python found is acceptable for
                     the yum package module. We use this guard to prevent errors
                     related to missing python modules.",
-        expression => returnszero("$(sys.bindir)/python -V 2>&1 | grep ^Python | cut -d' ' -f 2 | ( IFS=. read v1 v2 v3 ; [ $v1 -ge 3 ] || [ $v1 -eq 2 -a $v2 -ge 4 ] )",
+        expression => returnszero("$(sys.bindir)/cfengine-selected-python -V 2>&1 | grep ^Python | cut -d' ' -f 2 | ( IFS=. read v1 v2 v3 ; [ $v1 -ge 3 ] || [ $v1 -eq 2 -a $v2 -ge 4 ] )",
                                   useshell);
 }

--- a/modules/packages/apt_get.in
+++ b/modules/packages/apt_get.in
@@ -1,4 +1,4 @@
-#!@bindir@/python
+#!@bindir@/cfengine-selected-python
 
 import sys
 import os

--- a/modules/packages/yum.in
+++ b/modules/packages/yum.in
@@ -1,4 +1,4 @@
-#!@bindir@/python
+#!@bindir@/cfengine-selected-python
 
 import sys
 import os

--- a/modules/packages/zypper.in
+++ b/modules/packages/zypper.in
@@ -1,4 +1,4 @@
-#!@bindir@/python
+#!@bindir@/cfengine-selected-python
 
 #####################################################################################
 # Copyright 2016 Normation SAS


### PR DESCRIPTION
Package modules that rely on python can be run with either python2 or python3.
We maintain a symlink pointing to a version of python found on the system that
is appropriate. In order to avoid confusion, since CFEngine's bin directory is
commonly found in $PATH we have renamed the symlink so that the symlink is not
used when a user types python on the console.