### PR TITLE
CFE-3510/3.15.x: services/init.cf will be loaded automatically by promises.cf if it's present

### DIFF
--- a/promises.cf.in
+++ b/promises.cf.in
@@ -247,6 +247,11 @@ bundle common cfengine_controls
                  },
         comment => "We strictly order the def inputs because they should be parsed first";
 
+      "input[custom_promise_types]" -> { "CFE-3510" }
+        string => "services/init.cf",
+        if => fileexists( "$(this.promise_dirname)/services/init.cf"),
+        comment => "Users should use this file to define custom promise types. The file is only added to inputs if it is present. The file is not vendored as part of the Masterfiles Policy Framework";
+
 
       "input[cf_agent]"
         string => "controls/cf_agent.cf",


### PR DESCRIPTION
services/init.cf provides a location for users to define custom promise types.
It will be loaded very early (with controls) if found.

Ticket: CFE-3510
Changelog: Title
(cherry picked from commit f8c6d2f32bf4615942b76adfec8698016d3da89b)