### PR TITLE
ENT-6603/master: Added ability to specify a list of bundles to run before autorun (for classification)

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -1079,7 +1079,27 @@ Primarily for developer conveniance, this setting allows you to easily disable t
 }
 ```
 
-### Append to the main bundlesequence
+### Bundlesequence
+
+#### Classification bundles before autorun
+
+You can specify a list of bundles which should be run before autorun policies (if enabled).
+
+```json
+{
+  "vars":{
+    "control_common_bundlesequence_classification": [ "classification_one", "classification_two" ]
+  },
+
+  "inputs": [ "services/my_classificaton.cf" ]
+}
+```
+
+**History:**
+
+* Added in CFEngine 3.18.0
+
+#### Append to the main bundlesequence
 
 You can specify bundles which should be run at the end of the default
 bundlesequence by defining ```control_common_bundlesequence_end``` in the vars

--- a/controls/def.cf
+++ b/controls/def.cf
@@ -160,6 +160,9 @@ bundle common def
       "tbse" data => mergedata( "def.control_common_bundlesequence_end" );
       "bundlesequence_end" slist => getvalues( tbse );
 
+      "tbse" data => mergedata( "def.control_common_bundlesequence_classification" );
+      "bundlesequence_classification" slist => getvalues( tbse );
+
       "control_common_ignore_missing_bundles" -> { "CFE-2773" }
         string => ifelse( strcmp( $(control_common_ignore_missing_bundles), "true" ),
                           "true",

--- a/promises.cf.in
+++ b/promises.cf.in
@@ -47,6 +47,9 @@ body common control
                           def,
                           @(cfengine_enterprise_hub_ha.classification_bundles),
 
+                          # Custom classification
+                          @(def.bundlesequence_classification),
+
                           # autorun system
                           services_autorun,
                           @(services_autorun.bundles),


### PR DESCRIPTION
With this change, you can specify a list of bundles to run before autorun
polices. This can be useful if you want to have autorun policies execute based
on soft classes that are not persistent. E.g. prod hosts.

Ticket: ENT-6603
Changelog: Title