### PR TITLE
 ENT-6563/3.15.x: Suppressed inform output from Enterprise Hub database maintenance operations

### DIFF
--- a/cfe_internal/enterprise/CFE_hub_specific.cf
+++ b/cfe_internal/enterprise/CFE_hub_specific.cf
@@ -596,7 +596,10 @@ bundle agent cfe_internal_refresh_inventory_view
       "$(sys.workdir)/httpd/php/bin/php"
         args => "$(cfe_internal_hub_vars.docroot)/index.php cli_tasks $(cfe_internal_refresh_inventory_args.args)",
         contain => silent,
-        comment => "This refreshes the inventory view. If the inventory view is not refreshed then it will contain stale data.",
+@if minimum_version(3.15.0)
+        inform => "false",
+@endif
+        comment => "This refreshes the variables shown in the Mission Portal Inventory.",
         handle  => "mpf_fresh_inventory_view",
         if => isdir( "$(cfe_internal_hub_vars.docroot)/api/modules/inventory" );
 }
@@ -617,6 +620,9 @@ bundle agent cfe_internal_refresh_hosts_view
       "$(sys.workdir)/httpd/php/bin/php" -> { "ENT-3482" }
         args => "$(cfe_internal_hub_vars.docroot)/index.php cli_tasks materialized_hosts_view_refresh",
         contain => silent,
+@if minimum_version(3.15.0)
+        inform => "false",
+@endif
         comment => "This refreshes the hosts view. If the hosts view is not refreshed then it will contain stale data.",
         handle  => "mpf_fresh_hosts_view",
         if => isgreaterthan(countlinesmatching(".*materialized_hosts_view_refresh.*", "$(cfe_internal_hub_vars.docroot)/application/controllers/Cli_tasks.php"), 0);
@@ -661,6 +667,9 @@ bundle agent cfe_internal_refresh_events_table
       "$(sys.workdir)/httpd/php/bin/php"
         args => "$(cfe_internal_hub_vars.docroot)/index.php cli_tasks process_api_events",
         contain => silent,
+@if minimum_version(3.15.0)
+        inform => "false",
+@endif
         comment => "This refreshes the events table. If the events table is not refreshed then it will contain stale data.",
         handle  => "mpf_fresh_events_table",
         if => fileexists( "$(cfe_internal_hub_vars.docroot)/api/resource-v1/Event.php" );


### PR DESCRIPTION
The inform output generated by these commands is distracting for new users.
Already the promises were set to be contained in a silent body, this just
extends that silence to suppress from inform. The command results are still
interpreted the same, and if one of these commands is not kept, they will still
emit an error.

Ticket: ENT-6563
Changelog: Title