### PR TITLE
Updated stale copyright headers to 2021

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -4,7 +4,7 @@ under the following license.
 MIT Public License
 http://www.opensource.org/licenses/MIT
 
-Copyright 2017 Northern.tech AS
+Copyright 2021 Northern.tech AS
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/m4/cf3_platforms.m4
+++ b/m4/cf3_platforms.m4
@@ -1,5 +1,5 @@
 #
-#  Copyright 2017 Northern.tech AS
+#  Copyright 2021 Northern.tech AS
 #
 #  This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 #

--- a/modules/packages/zypper.in
+++ b/modules/packages/zypper.in
@@ -23,7 +23,7 @@
 
 # Licensed under:
 # MIT Public License
-# Copyright 2017 Northern.tech AS
+# Copyright 2021 Northern.tech AS
 
 import sys
 import os

--- a/tests/acceptance/testall
+++ b/tests/acceptance/testall
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-#  Copyright 2017 Northern.tech AS
+#  Copyright 2021 Northern.tech AS
 #
 #  This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 #


### PR DESCRIPTION
There were a few stale copyright headers from 2017 that weren't updated with the
change from 2020 -> 2021.

Ticket: None
Changelog: None