### PR TITLE
CFE-3544/master: Added new interface for controlling users allowed to initiate cf-agent via cf-runagent

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -758,7 +758,19 @@ cf-serverd only allows specified users to request unscheduled execution remotely
 
 By default the MPF allows `root` to request unscheduled execution of non policy servers and does not allow any users to request unscheduled execution from policy servers.
 
-To configure the list of users allowed to request unscheduled execution from non policy servers define `vars.control_server_allowusers_non_policy_server`. This example allows the users `hubmanager` and  `cfoperator` to request unscheduled execution from policy servers and no users are allowed to request unscheduled runs from non policy servers.
+To configure the list of users allowed to request unscheduled execution define `vars.control_server_allowusers`.
+
+```
+{
+  "vars": {
+    "control_server_allowusers": [ "root", "nickanderson", "cfapache" ],
+  }
+}
+```
+
+It's possible to configure different users that are allowed for policy servers versus non policy servers via `vars.control_server_allowusers_non_policy_server` and `vars.control_server_allowusers_policy_server`. However, if  `vars.control_server_allowusers` is defined, it has precedence.
+
+This example allows the users `hubmanager` and  `cfoperator` to request unscheduled execution from policy servers and no users are allowed to request unscheduled runs from non policy servers.
 
 ```
 {
@@ -772,6 +784,7 @@ To configure the list of users allowed to request unscheduled execution from non
 **History:**
 
 - Added in 3.13.0, 3.12.1
+- Added `vars.control_server_allowusers` in 3.18.0
 
 ### Configure retention for files in log directories
 

--- a/controls/cf_serverd.cf
+++ b/controls/cf_serverd.cf
@@ -50,13 +50,11 @@ body server control
       # to complete report transfer.
         collect_window => "$(def.control_server_collect_window)";
 
-    # The MPF provides different variables for configuring which users are
-    # allowed to initiate execution via cf-runagent.
-    !policy_server::
-      allowusers => { @(def.control_server_allowusers_non_policy_server) };
+    any::
+      # The remote user accounts which are allowed to initiate cf-agent via
+      # cf-runagent.
 
-    policy_server::
-        allowusers => { @(def.control_server_allowusers_policy_server) };
+      allowusers => { @(def.control_server_allowusers) };
 
     windows::
       cfruncommand => "$(sys.cf_agent) -I -D cf_runagent_initiated -f \"$(sys.update_policy_path)\"  &

--- a/controls/def.cf
+++ b/controls/def.cf
@@ -92,7 +92,20 @@ bundle common def
         slist => {},
         if => not( isvariable( "control_server_allowusers_policy_server" ) );
 
-      # Executor Controls
+    policy_server::
+      "control_server_allowusers" -> { "CFE-3544" }
+        handle => "def_control_server_allowusers_policy_server",
+        slist => { @(control_server_allowusers_policy_server) },
+        if => not(isvariable("control_server_allowusers"));
+
+    !policy_server::
+      "control_server_allowusers" -> { "CFE-3544" }
+        handle => "def_control_server_allowusers_non_policy_server",
+        slist => { @(control_server_allowusers_non_policy_server) },
+        if => not(isvariable("control_server_allowusers"));
+
+    # Executor controls
+    any::
 
       ## Default splaytime to 4 unless it's already defined (via augments)
       "control_executor_splaytime"


### PR DESCRIPTION
This change makes def.control_server_allowusers the singular variable used to
control the list of users allowed to execute policy via cf-runagent. It
supersedes def.control_server_allowusers_policy_server and
def.control_server_allowusers_non_policy_server which are still used to set the
default value for def.control_server_allowusers. If
vars.control_server_allowusers is defined via Augments (def.json) that setting
will be used for both policy servers and non policy servers.

If further segmentation is desired, multiple augments can be used.

Ticket: CFE-3544
Changelog: Title