### PR TITLE
CFE-3546/3.15.x: Fixed ability to define users authorized for using cf-runagent on policy servers

### DIFF
--- a/controls/def.cf
+++ b/controls/def.cf
@@ -141,7 +141,7 @@ bundle common def
 
       "control_server_allowusers_policy_server"
         slist => {},
-        ifvarclass => not( isvariable( "control_server_allowusers_non_policy_server" ) );
+        ifvarclass => not( isvariable( "control_server_allowusers_policy_server" ) );
 
       # Executor Controls
 


### PR DESCRIPTION
Ticket: CFE-3546
Changelog: Title
(cherry picked from commit 5558f11b4bfa043cbd03541abfca4e7d2fb26c43)