### PR TITLE
ENT-6673/master: Added vars.mpf_admit_cf_runagent_shell to control admission for cf-runagent requests

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -786,6 +786,35 @@ This example allows the users `hubmanager` and  `cfoperator` to request unschedu
 - Added in 3.13.0, 3.12.1
 - Added `vars.control_server_allowusers` in 3.18.0
 
+**See Also:** [Configure hosts allowed to initate execution via cf-runagent][Configure hosts allowed to initate execution via cf-runagent]
+
+### Configure hosts allowed to initate execution via cf-runagent
+
+cf-serverd only allows specified hosts to request unscheduled execution remotely via `cf-runagent`.
+
+By default the MPF allows policy servers (as defined by `def.policy-servers`) to initiate agent runs via `cf-runagent`.
+
+
+To configure the list of hosts allowed to request unscheduled execution define `vars.mpf_admit_cf_runagnet_shell`. This example allows the IPv4 address `192.168.42.10`, the host `bastion.example.com`, and the host with identity `SHA=43c979e264924d0b4a2d3b568d71ab8c768ef63487670f2c51cd85e8cec63834` and policy servers the ability to initiate agent runs via `cf-runagent`.
+
+```json
+{
+    "vars": {
+        "mpf_admit_cf_runagent_shell": [ "192.168.42.10",
+                                         "bastion.example.com",
+                                         "SHA=43c979e264924d0b4a2d3b568d71ab8c768ef63487670f2c51cd85e8cec63834",
+                                         "@(def.policy_servers)"
+                                       ]
+    }
+}
+```
+
+**See Also:** [Configure users allowed to initate execution via cf-runagent][Configure users allowed to initate execution via cf-runagent]
+
+**History:**
+
+- Added in CFEngine 3.18.0
+
 ### Configure retention for files in log directories
 
 By default the MPF rotates managed log files when they reach 1M in size. To configure this limit via augments define `vars.mpf_log_file_max_size`.

--- a/controls/cf_serverd.cf
+++ b/controls/cf_serverd.cf
@@ -142,10 +142,10 @@ bundle server mpf_default_access_rules()
           admit_ips => { @(def.mpf_access_rules_collect_calls_admit_ips) };
 
     !windows::
-      "$(def.cf_runagent_shell)"
+      "$(def.cf_runagent_shell)" -> { "ENT-6673" }
       handle => "server_access_grant_access_shell_cmd",
       comment => "Grant access to shell for cfruncommand",
-      admit => { @(def.policy_servers) };
+      admit => { @(def.mpf_admit_cf_runagent_shell_selected) };
 
     policy_server.enable_cfengine_enterprise_hub_ha::
       "$(sys.workdir)/ppkeys/"

--- a/controls/def.cf
+++ b/controls/def.cf
@@ -106,6 +106,21 @@ bundle common def
 
     # Executor controls
     any::
+      "mpf_admit_cf_runagent_shell_selected" -> { "ENT-6673" }
+        handle => "mpf_admit_cf_runagent_shell_default",
+        if => not( isvariable( "mpf_admit_cf_runagent_shell" )),
+        slist => { @(def.policy_servers) },
+        comment => concat( "By default we admit our policy servers to initiate",
+                           "agent runs via cf-runagent");
+
+      "mpf_admit_cf_runagent_shell_selected" -> { "ENT-6673" }
+        handle => "mpf_admit_cf_runagent_shell_augments",
+        if => isvariable( "mpf_admit_cf_runagent_shell" ),
+        slist => { @(def.mpf_admit_cf_runagent_shell) },
+        comment => concat( "Users can override the default set of hosts that ",
+                           "can initiate agent runs via cf-runagent.");
+
+      # Executor Controls
 
       ## Default splaytime to 4 unless it's already defined (via augments)
       "control_executor_splaytime"


### PR DESCRIPTION
This change adds a new augmentable variable to control hosts that should be
allowed to initiate agent runs via cf-runagent.

Ticket: ENT-6673
Changelog: Title