### PR TITLE
Protect inputs for autorun.cf so cf-promises can parse it

### DIFF
--- a/lib/autorun.cf
+++ b/lib/autorun.cf
@@ -1,5 +1,6 @@
 body file control
 {
+    services_autorun::
       inputs => { @(services_autorun.found_inputs) };
 }
 


### PR DESCRIPTION
Without the `services_autorun::` guard you get

```shell
% cf-promises -p json autorun.cf
  error: Unresolved variable '@(services_autorun.found_inputs)' in input list, cannot parse
...
```