### PR TITLE
ENT-6783/3.15.x: Disabled TLSv1 by default for Mission Portal's web server

### DIFF
--- a/cfe_internal/enterprise/templates/httpd.conf.mustache
+++ b/cfe_internal/enterprise/templates/httpd.conf.mustache
@@ -181,8 +181,8 @@ LogLevel warn
   # A more secure setting might be:
   # SSLCipherSuite EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH
 
-  # Some versions of SSL are known to be insecure
-  SSLProtocol all -SSLv2 -SSLv3
+  # Some versions of SSL and TLS are known to be insecure, so we disable them by default
+  SSLProtocol all -SSLv2 -SSLv3 -TLSv1
 
   SSLRandomSeed startup builtin
   SSLRandomSeed connect builtin


### PR DESCRIPTION
Merge together: https://github.com/cfengine/buildscripts/pull/800

Ticket: ENT-6783
Changelog: Title
(cherry picked from commit 00396d3ebcbfccb1ff1eb995c4562f70232bd67f)