### PR TITLE
CFE-3583 Fix pip package method if only pip3 command is available (alpine)

### DIFF
--- a/lib/paths.cf
+++ b/lib/paths.cf
@@ -104,7 +104,9 @@ bundle common paths
 
     !(freebsd|darwin|smartos)::
       "path[npm]"      string => "/usr/bin/npm";
-      "path[pip]"      string => "/usr/bin/pip";
+      "path[pip]"      string => ifelse(
+        fileexists("/usr/bin/pip3"), "/usr/bin/pip3",
+        "/usr/bin/pip");
       "path[virtualenv]" string => "/usr/bin/virtualenv";
 
     !(freebsd|darwin)::


### PR DESCRIPTION
On alpine lack of pip broke the pip package method.

Ticket: CFE-3583
Changelog: title