### PR TITLE
ENT-6220 Added verbose logfile for msiexec package module file installs

### DIFF
--- a/modules/packages/msiexec.bat
+++ b/modules/packages/msiexec.bat
@@ -96,8 +96,12 @@ rem Install this file if it exists
     goto :EOF
   )
 
-  %MSIEXEC% /quiet /passive /qn /norestart /i %1
-  rem TODO options, error checking
+  REM TODO: ENT-6824 save this logfile based on msi filename
+  set logfile="\cfengine_package_install.log"
+  %MSIEXEC% /quiet /passive /qn /norestart /l*vx %logfile% /i %1
+  if not errorlevel 0 (
+    echo ErrorMessage=msiexec.exe ErrorLevel was %ErrorLevel% for file %1 logfile at %logfile%
+  )
 goto :EOF
 
 


### PR DESCRIPTION
File is always \cfengine_package_install.log

See ENT-6824 TODO to save based on basename of msi file.

Ticket: ENT-6220
Changelog: Title