### PR TITLE
CFE-2984/master: Update policy now moves obstructions

### DIFF
--- a/cfe_internal/update/update_policy.cf
+++ b/cfe_internal/update/update_policy.cf
@@ -274,7 +274,8 @@ bundle agent cfe_internal_update_policy_cpv
       depth_search => u_recurse("inf"),
       file_select  => u_input_files,
       action => u_immediate,
-      classes => u_results("bundle", "update_inputs");
+      classes => u_results("bundle", "update_inputs"),
+      move_obstructions => "true";
 
     update_inputs_not_kept::
 


### PR DESCRIPTION
Prior to this change, if a file were changed into a directory or vice versa,
policy update would fail, e.g.

   error: The object '/var/cfengine/inputs/testme' is not a directory. Cannot make a new directory without deleting it.
   error: Errors encountered when actuating files promise '/var/cfengine/inputs'
   error: Method 'cfe_internal_update_policy_cpv' failed in some repairs

This change results in files or directories being moved out of the way so that
policy update will complete and properly transform files into directory or vice
versa.

    info: Moved obstructing file/link '/var/cfengine/inputs/testme' to '/var/cfengine/inputs/testme.cf-moved' to make directories for '/var/cfengine/inputs/testme/dummy'
    info: Created parent directory for '/var/cfengine/inputs/testme'
    info: Copied file '/var/cfengine/masterfiles/testme/fine.cf' to '/var/cfengine/inputs/testme/fine.cf.cfnew' (mode '600')
    info: Moved '/var/cfengine/inputs/testme/fine.cf.cfnew' to '/var/cfengine/inputs/testme/fine.cf'
    info: Updated file '/var/cfengine/inputs/testme/fine.cf' from 'localhost:/var/cfengine/masterfiles/testme/fine.cf'
    info: files promise '/var/cfengine/inputs' repaired

Ticket: CFE-2984
Changelog: Title