### PR TITLE
ENT-6788/master: Made Enterprise CMDB data update after policy update

### DIFF
--- a/cfe_internal/update/update_policy.cf
+++ b/cfe_internal/update/update_policy.cf
@@ -61,6 +61,10 @@ bundle agent cfe_internal_update_policy
       "Stock policy update"
         usebundle => cfe_internal_update_policy_cpv;
 
+    enterprise_edition::
+      "CMDB data update" -> { "ENT-6788" }
+        usebundle => cfe_internal_update_cmdb;
+
   reports:
 
     inform_mode|verbose_mode|DEBUG|DEBUG_cfe_internal_update_policy::
@@ -308,9 +312,33 @@ bundle agent cfe_internal_update_policy_cpv
         usebundle => cfe_internal_setup_python_symlink("$(python_symlink)");
 }
 
+bundle agent cfe_internal_update_cmdb
+# @brief Ensure local cache of CMDB data is up to date
+{
+  files:
+      "$(sys.workdir)/data/." create => "true";
+
+      "$(sys.workdir)/data/." -> { "ENT-6788" }
+        depth_search => u_recurse( inf ),
+        file_select => u_all,
+        copy_from => u_cmdb_data;
+}
 #########################################################
 # Self-contained bodies from the lib to avoid dependencies
 #########################################################
+
+body copy_from u_cmdb_data
+# @brief Sync CMDB data from policy server
+# Note: Not all hosts necessarily have CMDB data
+{
+        copy_backup => "false";
+        trustkey => "false";
+        compare => "digest";
+        source  => "hub_cmdb";
+        servers => { "$(sys.policy_hub)" };
+        purge => "true";
+        missing_ok => "true";
+}
 
 body perms u_m(p)
 # @brief Ensure file mode is `p`
@@ -342,6 +370,13 @@ body perms u_shared_lib_perms
 }
 
 #########################################################
+
+body file_select u_all
+# @brief Select all file system entries
+{
+        leaf_name => { ".*" };
+        file_result => "leaf_name";
+}
 
 body file_select u_cf3_files
 # @brief Select files starting with `cf-` (cfengine binaries)

--- a/controls/cf_serverd.cf
+++ b/controls/cf_serverd.cf
@@ -136,10 +136,16 @@ bundle server mpf_default_access_rules()
         if => isdir( "$(sys.workdir)/master_software_updates" ),
         admit => { @(def.acl) };
 
-      enterprise_edition.policy_server::
-        "collect_calls"
-          resource_type => "query",
-          admit_ips => { @(def.mpf_access_rules_collect_calls_admit_ips) };
+    enterprise_edition.policy_server::
+      "collect_calls"
+        resource_type => "query",
+        admit_ips => { @(def.mpf_access_rules_collect_calls_admit_ips) };
+
+      "$(sys.workdir)/cmdb/$(connection.key)/" -> { "ENT-6788" }
+        handle => "server_access_grant_access_cmdb",
+        comment => "Grant access to host specific CMDB data",
+        shortcut => "hub_mdr",
+        admit_keys => { $(connection.key) };
 
     !windows::
       "$(def.cf_runagent_shell)" -> { "ENT-6673" }


### PR DESCRIPTION
This change makes sure that hosts update their local cache of CMDB data from an
Enterprise hub.

Ticket: ENT-6788
Changelog: Title