### PR TITLE
ENT-6495/master: Added measurement of entropy available on linux systems

### DIFF
--- a/inventory/linux.cf
+++ b/inventory/linux.cf
@@ -90,3 +90,20 @@ bundle common inventory_linux
       "DEBUG $(this.bundle)";
       "$(const.t)OS release ID = $(os_release_id), OS release version = $(os_release_version)";
 }
+
+bundle monitor measure_entropy_available
+# @brief Measure amount of entropy available
+{
+  measurements:
+    linux::
+      # A lack of entropy can cause agents to hang
+      "/proc/sys/kernel/random/entropy_avail" -> { "ENT-6495", "ENT-6494" }
+        if => fileexists( "/proc/sys/kernel/random/entropy_avail" ),
+        handle => "entropy_avail",
+        stream_type => "file",
+        data_type => "int",
+        units => "bits",
+        history_type => "weekly",
+        match_value => single_value("\d+"),
+        comment => "Amount of entropy available";
+}


### PR DESCRIPTION
Low entropy can cause all kinds of issues, including hanging agents. Tracking
this over time can be useful for understanding and avoiding issues.

Ticket: ENT-6495
Changelog: Title