### PR TITLE
CFE-3617: Remove stale unused copy of u_kept_successful_command body (master)

### DIFF
--- a/lib/common.cf
+++ b/lib/common.cf
@@ -371,13 +371,6 @@ body classes scoped_classes_generic(scope, x)
       promise_kept => { "promise_kept_$(x)", "$(x)_kept", "$(x)_ok", "$(x)_reached" };
 }
 
-# special body for update/*.cf compatibility
-body classes u_kept_successful_command
-# @brief Set command to "kept" instead of "repaired" if it returns 0
-{
-      kept_returncodes => { "0" };
-}
-
 ##-------------------------------------------------------
 ## Persistent classes
 ##-------------------------------------------------------


### PR DESCRIPTION
In <https://gitlab.com/vsa-cfengine/policy-channels/-/issues/4>,
it came up that we have an extra, out-of-date copy of
`body classes u_kept_successful_command body` (from the
update policy) in lib/common.cf (which is part of the CFEngine
Standard Library).

Remember that the update policy doesn't use the CFEngine Standard Library.

In the aforelinked issue @nickanderson stated it was probably some artifact 
left in promises.cf from some time when update.cf was included in the main policy.

Remove it so that it doesn't confuse us.  (It's confusing to have two copies of the same
classes body THAT ARE DIFFERENT.)  See <https://gitlab.com/vsa-cfengine/policy-channels/-/issues/4> for the full discussion on this.

If someone is using `u_kept_successful_command` outside the update policy, that is to so in their main policy (loaded from promises.cf), this will be a breaking change. They shouldn't be; they should be using `kept_successful_command` in lib/common.cf.

I appreciate this might be a breaking change for anybody (ab)using `u_kept_successful_command` from promises.cf; putting it in the changelog would mitigate the risk.

Having two different copies of the same body is _definitely_ broken.