### PR TITLE
ENT-6824 Changed msiexec package module install logs to be unique for each msi file (3.12.x)

### DIFF
--- a/controls/def.cf
+++ b/controls/def.cf
@@ -384,6 +384,10 @@ bundle common def
       "log_dir[outputs]" string => "$(sys.workdir)/outputs";
       "log_dir[reports]" string => "$(sys.workdir)/reports";
 
+    # TODO ENT-6845 - move package module logs to $(sys.workdir)/log/something
+    windows::
+      "log_dir[package_logs]" string => "$(const.dirsep)cfengine_package_logs";
+
     enterprise.am_policy_hub::
       "log_dir[application]" string => "$(sys.workdir)/httpd/htdocs/application/logs";
 

--- a/modules/packages/msiexec.bat
+++ b/modules/packages/msiexec.bat
@@ -106,11 +106,16 @@ rem Install this file if it exists
     goto :EOF
   )
 
-  REM TODO: ENT-6824 save this logfile based on msi filename
-  set logfile="\cfengine_package_install.log"
-  %MSIEXEC% /quiet /passive /qn /norestart /l*vx %logfile% /i %1
+  set log_dir="\cfengine_package_logs\"
+  if not exist %log_dir% (
+    mkdir %log_dir%
+  )
+  for /F "delims=" %%i in (%1) do @set basename="%%~ni"
+  REM %log_dir:"=% replaces quotes with nothing, otherwise you get two double-quotes which causes failures
+  set log_file="%log_dir:"=%%basename:"=%_install.log"
+  %MSIEXEC% /quiet /passive /qn /norestart /l*vx %log_file% /i %1
   if not errorlevel 0 (
-    echo ErrorMessage=msiexec.exe ErrorLevel was %ErrorLevel% for file %1 logfile at %logfile%
+    echo ErrorMessage=msiexec.exe ErrorLevel was %ErrorLevel% for file %1 log at %log_file%
   )
 goto :EOF
 


### PR DESCRIPTION
Logs are now placed in a unique "basename"_install.log file in\cfengine_package_logs.
That dir is also added in controls/def.cf to cfe_log_dirs to be
pruned by cfe_internal/core/log_rotation.cf policy every $(def.mpf_log_dir_retention) days.

Ticket: ENT-6824
Changelog: title
(cherry picked from commit c77d06a348a90034d5aeb21dde655f807ec69659)