### PR TITLE
ENT-6814 Added missing packages modules scripts in makefile (3.15.x)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -221,7 +221,7 @@ do
 done
 for i in templates cfe_internal
 do
-    for j in `find "$srcdir/$i" -name '*.mustache' -o -name '*.sh' -o -name '*.awk' -o -name '*.sed'`
+    for j in `find "$srcdir/$i" -name '*.mustache' -o -name '*.sh' -o -name '*.awk' -o -name '*.sed' -o -name '*.ps1'`
     do
         MASTERFILES_INSTALL_TARGETS="$MASTERFILES_INSTALL_TARGETS $j"
     done

--- a/modules/packages/Makefile.am
+++ b/modules/packages/Makefile.am
@@ -1,3 +1,3 @@
 package_modulesdir = $(prefix)/modules/packages
 
-dist_package_modules_SCRIPTS = apt_get yum pkg nimclient pkgsrc freebsd_ports zypper slackpkg msiexec.bat WiRunSQL.vbs
+dist_package_modules_SCRIPTS = apt_get yum pkg nimclient pkgsrc freebsd_ports zypper slackpkg msiexec.bat WiRunSQL.vbs apk msiexec-list.vbs snap


### PR DESCRIPTION
apk, snap and msiexec-list.vbs were missing from modules/packages/Makefile.am
and so would be missing from packaging.

Ticket: ENT-6814
Changelog: title