### PR TITLE
CFE-3607 Adjust modules/packages/Makefile.am for lack of msiexec packages module (3.12.x)

### DIFF
--- a/modules/packages/Makefile.am
+++ b/modules/packages/Makefile.am
@@ -1,3 +1,3 @@
 package_modulesdir = $(prefix)/modules/packages
 
-dist_package_modules_SCRIPTS = apt_get yum pkg nimclient pkgsrc freebsd_ports zypper slackpkg msiexec.bat WiRunSQL.vbs apk msiexec-list.vbs snap
+dist_package_modules_SCRIPTS = apt_get yum pkg nimclient pkgsrc freebsd_ports zypper slackpkg msiexec.bat WiRunSQL.vbs apk snap


### PR DESCRIPTION
Commit a139ce9 improperly added reference
to msiexec-list.vbs.

Ticket: CFE-3607
Changelog: title