### PR TITLE
Allows overriding modules and plugins directories path on policy server

### DIFF
--- a/cfe_internal/update/update_policy.cf
+++ b/cfe_internal/update/update_policy.cf
@@ -171,27 +171,15 @@ bundle agent cfe_internal_update_policy_cpv
         comment => "The path to request updates from the policy server.",
         handle => "cfe_internal_update_policy_vars_master_location";
 
-    windows::
+      "modules_dir_source" -> { "CFE-3318" }
+        string => "$(update_def.mpf_update_modules_master_location)",
+        comment => "Directory containing CFEngine modules on the policy server.",
+        handle => "cfe_internal_update_policy_vars_modules_dir";
 
-      "modules_dir_source"        string => "/var/cfengine/masterfiles/modules",
-      comment => "Directory containing CFEngine modules",
-      handle => "cfe_internal_update_policy_vars_modules_dir_windows";
-
-      "plugins_dir_source"        string => "/var/cfengine/plugins",
-      comment => "Directory containing CFEngine plugins",
-      handle => "cfe_internal_update_policy_vars_plugins_dir_windows";
-
-    !windows::
-
-      "modules_dir_source"        string => translatepath("$(master_location)/modules"),
-      comment => "Directory containing CFEngine modules",
-      handle => "cfe_internal_update_policy_vars_modules_dir";
-
-      "plugins_dir_source"        string => translatepath("$(sys.workdir)/plugins"),
-      comment => "Directory containing CFEngine plugins",
-      handle => "cfe_internal_update_policy_vars_plugins_dir";
-
-    any::
+      "plugins_dir_source" -> { "CFE-3318" }
+        string => "$(update_def.mpf_update_plugins_master_location)",
+        comment => "Directory containing CFEngine plugins on the policy server.",
+        handle => "cfe_internal_update_policy_vars_plugins_dir";
 
       "file_check"         string => translatepath("$(inputs_dir)/promises.cf"),
       comment => "Path to a policy file",

--- a/controls/update_def.cf.in
+++ b/controls/update_def.cf.in
@@ -109,6 +109,18 @@ bundle common update_def
         string => "$(def.mpf_update_policy_master_location)",
         if => isvariable( "def.mpf_update_policy_master_location" );
 
+      "mpf_update_modules_master_location" -> { "CFE-3318" }
+        comment => "Directory where clients should get modules from.",
+        string => ifelse( isvariable("def.mpf_update_modules_master_location"),
+                          "$(def.mpf_update_modules_master_location)",
+                          "@prefix@/modules" );
+
+      "mpf_update_plugins_master_location" -> { "CFE-3318" }
+        comment => "Directory where clients should get plugins from.",
+        string => ifelse( isvariable("def.mpf_update_plugins_master_location"),
+                          "$(def.mpf_update_plugins_master_location)",
+                          "@prefix@/plugins" );
+
     # enable_cfengine_enterprise_hub_ha is defined below
     # Disabled by default
 


### PR DESCRIPTION
Introduces mpf_update_modules_master_location and
mpf_update_plugins_master_location variables (configurable via augments
file) for configuring where on the policy server the modules and plugins
directories reside. Do not rely on the client's operating system, as the
policy server can be installed on a different one.

This patch removes the
cfe_internal_update_policy_vars_modules_dir_windows and
cfe_internal_update_policy_vars_plugins_dir_windows handles, that
didn't seem to be referred anywhere.