### PR TITLE
ENT-6219 Added default cf_version_release of 1 when sys var missing

### DIFF
--- a/cfe_internal/update/windows_unattended_upgrade.cf
+++ b/cfe_internal/update/windows_unattended_upgrade.cf
@@ -68,16 +68,16 @@ exit 0
         template_method => "inline_mustache",
         template_data => '{}',
         create => "true",
-        ifvarclass => not( "_expected_version_installed" );
+        if => not( "_expected_version_installed" );
 
       "$(_scripts)"
         delete => windows_unattended_upgrade_tidy,
-        ifvarclass => "_expected_version_installed";
+        if => "_expected_version_installed";
 
   commands:
     windows::
       '$(_schedule_upgrade_script)'
-         ifvarclass => not( "_expected_version_installed" ),
+         if => not( "_expected_version_installed" ),
          contain => windows_unattended_upgrade:powershell;
 }
 

--- a/standalone_self_upgrade.cf.in
+++ b/standalone_self_upgrade.cf.in
@@ -235,7 +235,7 @@ bundle agent cfengine_software_version
       "pkg_release" string => "$(cfengine_software.pkg_release)";
       "_cf_version_release" string => ifelse( isvariable( "sys.cf_version_release" ), "$(sys.cf_version_release)", "1" );
       "pkg_arch" string => "$(cfengine_software.pkg_arch)";
-      "package_dir" string => "$(cfengine_software.pkg_dir)";
+      "package_dir" string => "$(cfengine_software.package_dir)";
       "local_software_dir" string => "$(cfengine_software.local_software_dir)";
 
   methods:
@@ -272,7 +272,7 @@ bundle agent cfengine_software_version_packages2
       "pkg_version" string => "$(cfengine_software.pkg_version)";
       "pkg_release" string => "$(cfengine_software.pkg_release)";
       "pkg_arch" string => "$(cfengine_software.pkg_arch)";
-      "package_dir" string => "$(cfengine_software.pkg_dir)";
+      "package_dir" string => "$(cfengine_software.package_dir)";
       "local_software_dir" string => "$(cfengine_software.local_software_dir)";
 
   packages:
@@ -505,7 +505,7 @@ bundle agent cfengine_master_software_content
       "pkg_version" string => "$(cfengine_software.pkg_version)";
       "pkg_release" string => "$(cfengine_software.pkg_release)";
       "pkg_arch" string => "$(cfengine_software.pkg_arch)";
-      "package_dir" string => "$(cfengine_software.pkg_dir)";
+      "package_dir" string => "$(cfengine_software.package_dir)";
       "base_url" string => "https://cfengine-package-repos.s3.amazonaws.com/enterprise/Enterprise-$(pkg_version)/agent";
 
       # Map platform/directory identifier to upstream package URLs

--- a/standalone_self_upgrade.cf.in
+++ b/standalone_self_upgrade.cf.in
@@ -233,6 +233,7 @@ bundle agent cfengine_software_version
       "pkg_name" string => "$(cfengine_software.pkg_name)";
       "pkg_version" string => "$(cfengine_software.pkg_version)";
       "pkg_release" string => "$(cfengine_software.pkg_release)";
+      "_cf_version_release" string => ifelse( isvariable( "sys.cf_version_release" ), "$(sys.cf_version_release)", "1" );
       "pkg_arch" string => "$(cfengine_software.pkg_arch)";
       "package_dir" string => "$(cfengine_software.pkg_dir)";
       "local_software_dir" string => "$(cfengine_software.local_software_dir)";
@@ -254,7 +255,7 @@ bundle agent cfengine_software_version
           "windows",
           or(
               not(strcmp("$(cfengine_software.pkg_version)", "$(sys.cf_version)")),
-              not(strcmp("$(cfengine_software.pkg_release)", "$(sys.cf_version_release)"))
+              not(strcmp("$(cfengine_software.pkg_release)", "$(_cf_version_release)"))
             )
         );
 

--- a/standalone_self_upgrade.cf.in
+++ b/standalone_self_upgrade.cf.in
@@ -251,7 +251,7 @@ bundle agent cfengine_software_version
       # when ENT-6823 allows us to use msiexec.bat packages module.
       "Windows Unattended Upgrade Workaround"
         usebundle => windows_unattended_upgrade,
-        ifvarclass => and(
+        if => and(
           "windows",
           or(
               not(strcmp("$(cfengine_software.pkg_version)", "$(sys.cf_version)")),


### PR DESCRIPTION
In versions before 3.12.7 sys.cf_version_release is not present so default to 1.
This will handle most cases well and enable upgrades from <3.12.7 to >=3.12.7.

Ticket: ENT-6219
Changelog: title
(cherry picked from commit 2edd756bc6a9ba769e1912bdb56cc0339a7c9b9c)