### PR TITLE
CFE-3614: Fixed loading of platform specific inventory on AIX (master)

### DIFF
--- a/promises.cf.in
+++ b/promises.cf.in
@@ -138,7 +138,7 @@ bundle common inventory
 # Tested to work properly against 3.5.x
 {
   classes:
-      "other_unix_os" expression => "!windows.!macos.!linux.!freebsd";
+      "other_unix_os" expression => "!(windows|macos|linux|freebsd|aix)";
       "specific_linux_os" expression => "redhat|debian|suse|sles";
 
   vars:


### PR DESCRIPTION
inventory/aix.cf is never loaded because !aix is missing in the other_unix_os class