### PR TITLE
CFE-3615: add /usr/bin/yum to paths.cf for aix

### DIFF
--- a/lib/paths.cf
+++ b/lib/paths.cf
@@ -171,6 +171,7 @@ bundle common paths
       "path[sed]"      string => "/usr/bin/sed";
       "path[sort]"     string => "/usr/bin/sort";
       "path[tr]"       string => "/usr/bin/tr";
+      "path[yum]"      string => "/usr/bin/yum";
 
     archlinux::
 


### PR DESCRIPTION
yum has become an integral part of aix and it is  commonly used, as ibm has put  ehanced effort into the aix toolbox for linux applications (gnu freeware rpm packages for aix). so yum should be considered in cfengine as a valid package manager. this PR is part of ongoing efforts to make cfengine more aix aware.