### PR TITLE
CFE-3612: enable yum package inventory in aix

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -1842,6 +1842,53 @@ For example:
 
 - Introduced in CFEngine 3.23.0
 
+### Configure default package manager
+
+The MPF specifies the package module to use for managing packages and collecting software inventory based on the detected platform. Define `default:def.default_package_module` as a data structure keyed with values matching the value of `sys.flavor` for the platforms you wish to target.
+
+**Example:**
+
+```json
+{
+  "variables": {
+    "default:def.default_package_module": {
+      "value": {
+        "ubuntu_20": "snap",
+        "aix_7": "yum"
+      },
+        "comment": "This variable provides the ability to override the default package manager to use for a platform. Keys are based on the value of $(sys.flavor) for the targeted platform."
+    }
+  }
+}
+```
+
+**History:**
+
+* Added in CFEngine 3.24.0
+
+### Configure additional package managers to inventory by default
+
+The MPF inventories software for the default package module in use. Define `default:def.additional_package_inventory_modules` as a data structure keyed with values matching the value of `sys.flavor` for any additional package modules you wish to inventory by default.
+
+
+```json
+{
+  "variables": {
+    "default:def.additional_package_inventory_modules": {
+        "value": {
+            "ubuntu_20": [ "snap", "flatpak" ],
+            "aix": [ "yum" ]
+        },
+        "comment": "This variable provides the ability to extend the default package managers to inventory for a platform. Keys are based on the value of $(sys.flavor) for the targeted platform."
+      }
+  }
+}
+```
+
+**History:**
+
+* Added in CFEngine 3.24.0
+
 ### Configure periodic package inventory refresh interval
 
 Note that there are currently two implementations of packages promises, package

--- a/lib/packages.cf
+++ b/lib/packages.cf
@@ -8,16 +8,8 @@ bundle common package_module_knowledge
 {
   vars:
 
-      # Package inventory refresh
-      "query_installed_ifelapsed" -> { "CFE-2771", "CFE-3504" }
-        string => ifelse( isvariable( "def.package_module_query_installed_ifelapsed" ),
-                          "$(def.package_module_query_installed_ifelapsed)",
-                          "0"); # Always refresh local package inventory
-
-      "query_updates_ifelapsed" -> { "CFE-2771", "CFE-3504" }
-        string => ifelse( isvariable( "def.package_module_query_updates_ifelapsed" ),
-                          "$(def.package_module_query_updates_ifelapsed)",
-                          "1440"); # Refresh software updates available once a day
+    # First we set the default package manager based on the platform:
+    # TODO Refactor to use ifelse()?
 
     debian::
       "platform_default" string => "apt_get";
@@ -45,6 +37,48 @@ bundle common package_module_knowledge
 
     termux::
       "platform_default" string => "apt_get";
+
+    any::
+
+      # By default, we don't want additional package managers inventoried, but
+      # we need the variable to be defined, so we initialize it to an empty
+      # list.
+
+      "additional_inventory" slist => {};
+
+      # We look to see if additional package inventory modules should be used.
+      # `default:def.additional_package_inventory_modules` is expected to be a data
+      # structure keyed with values expected to match the value of `sys.flavor`.
+
+      # For example: { "aix_7": [ "yum"], "ubuntu_20: [ "snap" ] }
+
+      # If there is additional inventory defined for the platform we want to use them
+      "additional_inventory" -> { "CFE-3612" }
+        slist => getvalues( "default:def.additional_package_inventory_modules[$(sys.flavor)]" ),
+        if => isvariable( "default:def.additional_package_inventory_modules[$(sys.flavor)]" );
+
+      # Package inventory refresh
+      "query_installed_ifelapsed" -> { "CFE-2771", "CFE-3504" }
+        string => ifelse( isvariable( "def.package_module_$(this.promiser)" ),
+                          "$(def.package_module_$(this.promiser))",
+                          "0"); # Always refresh local package inventory
+
+      "query_updates_ifelapsed" -> { "CFE-2771", "CFE-3504" }
+        string => ifelse( isvariable( "def.package_module_$(this.promiser)" ),
+                          "$(def.package_module_$(this.promiser))",
+                          "1440"); # Refresh software updates available once a day
+
+      # It's possible that a user wants to use a different default package
+      # manager. To support that we look at
+      # `default:def.default_package_module`, a data structure keyed
+      # with values expected to match the value of `sys.flavor`
+
+      "platform_default" -> { "CFE-3612" }
+        string => "$(default:def.default_package_module[$(sys.flavor)])",
+        if => isvariable( "default:def.default_package_module[$(sys.flavor)]"),
+        comment => concat( "default:def.default_package_module[$(sys.flavor)] has been defined.",
+                           "This overrides the default package manager.");
+
 }
 
 body package_module apk

--- a/promises.cf.in
+++ b/promises.cf.in
@@ -93,14 +93,26 @@ body common control
       # modules in which you MUST provide package modules used to generate
       # software inventory reports. You can also provide global default package module
       # instead of specifying it in all package promises.
-    (debian|redhat|centos|suse|sles|opensuse|amazon_linux).cfe_python_for_package_modules_supported.!disable_inventory_package_refresh::
-          package_inventory => { $(package_module_knowledge.platform_default) };
+    (debian).!disable_inventory_package_refresh::
+          package_inventory => { $(package_module_knowledge.platform_default), @(default:package_module_knowledge.additional_inventory) };
+
+      # We only define package_inventory on redhat like systems that have a
+      # python version that works with the package module.
+    (redhat|centos|suse|sles|opensuse|amazon_linux).cfe_yum_package_module_supported.!disable_inventory_package_refresh::
+        package_inventory => { $(package_module_knowledge.platform_default), @(default:package_module_knowledge.additional_inventory)};
+
+    aix.!disable_inventory_package_refresh::
+      package_inventory => { $(package_module_knowledge.platform_default), @(default:package_module_knowledge.additional_inventory) };
+
+    aix::
+      package_module => $(package_module_knowledge.platform_default);
+
 
     (debian|redhat|suse|sles|opensuse|amazon_linux)::
           package_module => $(package_module_knowledge.platform_default);
 
     windows::
-          package_inventory => { $(package_module_knowledge.platform_default) };
+          package_inventory => { $(package_module_knowledge.platform_default), @(default:package_module_knowledge.additional_inventory) };
           package_module => $(package_module_knowledge.platform_default);
 
     termux::


### PR DESCRIPTION
see discussion here -> https://groups.google.com/g/help-cfengine/c/jzDzekirYTY

the changes made here enables the package inventory for yum/rpm packages in aix through augments, but there are some unwanted inventory files beside the working ones created in the state directory. this needs to be reviewed by some cfengine expert, as i am unable to figure out whats the reason behind this.

files used for testing:
https://github.com/flynn1973/cfengine_aix_yum