### PR TITLE
CFE-3615: add /usr/bin/yum to paths.cf for aix (3.15.x)

### DIFF
--- a/lib/paths.cf
+++ b/lib/paths.cf
@@ -202,6 +202,7 @@ bundle common paths
       "path[sed]"      string => "/usr/bin/sed";
       "path[sort]"     string => "/usr/bin/sort";
       "path[tr]"       string => "/usr/bin/tr";
+      "path[yum]"      string => "/usr/bin/yum";
 
     archlinux::
 


### PR DESCRIPTION
(cherry picked from commit a139956ca32f378976f0a8ef538d96a1740f1a4e)