### PR TITLE
CFE-3617: Removed stale unused copy of u_kept_successful_command body (master)

### DIFF
--- a/lib/common.cf
+++ b/lib/common.cf
@@ -371,13 +371,6 @@ body classes scoped_classes_generic(scope, x)
       promise_kept => { "promise_kept_$(x)", "$(x)_kept", "$(x)_ok", "$(x)_reached" };
 }
 
-# special body for update/*.cf compatibility
-body classes u_kept_successful_command
-# @brief Set command to "kept" instead of "repaired" if it returns 0
-{
-      kept_returncodes => { "0" };
-}
-
 ##-------------------------------------------------------
 ## Persistent classes
 ##-------------------------------------------------------


### PR DESCRIPTION
This PR supersedes #1932

This change removes body classes u_kept_successful_command from the standard
library. Note an identically named classes body still exists inside the
update.cf policy entry. This body that is being removed was only loaded by the
promises.cf entry and is believed to be some left over artifact from a time when
promises.cf loaded the update.cf policy. Another classes body,
kept_successful_command still remains in the standard library, and should be
used instead.

Ticket: CFE-3617
Changelog: Removed stale unused copy of u_kept_successful_command body. If you receive an error about undefined body, alter your policy to use kept_successful_command instead.