### PR TITLE
CFE-3618: Removed unused plugins directory (master)

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -137,8 +137,8 @@ For example:
 
 ### Specify the agent bundle used for policy update
 
-The MPF uses `cfe_internal_update_policy_cpv` to update inputs, modules, and
-plugins on remote agents. When new policy is verified by the agent
+The MPF uses `cfe_internal_update_policy_cpv` to update inputs and modules on
+remote agents. When new policy is verified by the agent
 `/var/cfengine/masterfiles/cf_promises_validated` is updated with the current
 timestamp. This file is used by remote agents to avoid unnecessary inspection of
 all files each time the update policy is triggered.

--- a/cfe_internal/update/update_policy.cf
+++ b/cfe_internal/update/update_policy.cf
@@ -152,14 +152,14 @@ bundle agent cfe_internal_setup_python_symlink(symlink_path)
 bundle agent cfe_internal_update_policy_cpv
 # @brief Update inputs from masterfiles when cf_promises_validated changes
 #
-# @description This bundle updates inputdir, modules, and plugins. It uses the
+# @description This bundle updates inputdir, and modules. It uses the
 #              cf_promises_validated file as a gating mechanism to prevent
 #              unnecessary burden on the server from remote agents checking to
 #              see if each individual file needs an update.
 # - The class `validated_updates_ready` is defined when `cf_promises_validated` is repaired
 # - Executing `cf-agent -KIf update.cf --define validated_updates_ready` will
-#   cause the update policy to scan all files in masterfiles, modules, and
-#   plugins to be scanned for update.
+#   cause the update policy to scan all files in masterfiles and modules to be
+#   scanned for update.
 {
   vars:
       "inputs_dir"         string => translatepath("$(sys.inputdir)"),
@@ -177,19 +177,11 @@ bundle agent cfe_internal_update_policy_cpv
       comment => "Directory containing CFEngine modules",
       handle => "cfe_internal_update_policy_vars_modules_dir_windows";
 
-      "plugins_dir_source"        string => "/var/cfengine/plugins",
-      comment => "Directory containing CFEngine plugins",
-      handle => "cfe_internal_update_policy_vars_plugins_dir_windows";
-
     !windows::
 
       "modules_dir_source"        string => translatepath("$(master_location)/modules"),
       comment => "Directory containing CFEngine modules",
       handle => "cfe_internal_update_policy_vars_modules_dir";
-
-      "plugins_dir_source"        string => translatepath("$(sys.workdir)/plugins"),
-      comment => "Directory containing CFEngine plugins",
-      handle => "cfe_internal_update_policy_vars_plugins_dir";
 
     any::
 
@@ -257,16 +249,6 @@ bundle agent cfe_internal_update_policy_cpv
       comment => "Always update modules files on client side",
       handle => "cfe_internal_update_policy_files_update_modules",
       copy_from => u_rcp("$(modules_dir_source)", @(update_def.policy_servers)),
-      depth_search => u_recurse("inf"),
-      perms => u_m("755"),
-      action => u_immediate;
-
-    !am_policy_hub::
-
-      "$(sys.workdir)$(const.dirsep)plugins"
-      comment => "Always update plugins files on client side",
-      handle => "cfe_internal_update_policy_files_update_plugins",
-      copy_from => u_rcp("$(plugins_dir_source)", @(update_def.policy_servers)),
       depth_search => u_recurse("inf"),
       perms => u_m("755"),
       action => u_immediate;

--- a/controls/cf_serverd.cf
+++ b/controls/cf_serverd.cf
@@ -114,7 +114,8 @@ bundle server mpf_default_access_rules()
       if => isdir( "$(def.dir_modules)/" ),
       admit => { @(def.acl) };
 
-      "$(def.dir_plugins)/"
+      # TODO: Remove after 3.15 is no longer supported (December 18th 2022)
+      "$(def.dir_plugins)/" -> { "CFE-3618" }
       handle => "server_access_grant_access_plugins",
       comment => "Grant access to plugins directory",
       if => isdir( "$(def.dir_plugins)/" ),

--- a/controls/def.cf
+++ b/controls/def.cf
@@ -261,6 +261,12 @@ bundle common def
       comment => "Define modules path",
       handle => "common_def_vars_dir_modules";
 
+      # TODO: Remove after 3.15 is no longer supported (December 18th 2022)
+      "dir_plugins" -> { "CFE-3618" }
+      string => translatepath("$(sys.workdir)/plugins"),
+      comment => "Define plugins path",
+      handle => "common_def_vars_dir_plugins";
+
       "dir_templates"
         string => ifelse( isvariable( "def.dir_templates"),
                           $(def.dir_templates),

--- a/controls/def.cf
+++ b/controls/def.cf
@@ -261,10 +261,6 @@ bundle common def
       comment => "Define modules path",
       handle => "common_def_vars_dir_modules";
 
-      "dir_plugins"     string => translatepath("$(sys.workdir)/plugins"),
-      comment => "Define plugins path",
-      handle => "common_def_vars_dir_plugins";
-
       "dir_templates"
         string => ifelse( isvariable( "def.dir_templates"),
                           $(def.dir_templates),


### PR DESCRIPTION
merge together: https://github.com/cfengine/buildscripts/pull/814 https://github.com/cfengine/core/pull/4577

The plugins directory has seemingly gone unused since it was introduced to the
MPF in 2013, this change simply removes this directory from being considered for
sharing and updating.

Ticket: CFE-3618
Changelog: Title