### PR TITLE
CFE-3614: Fixed loading of platform specific inventory on AIX (3.12)

### DIFF
--- a/promises.cf.in
+++ b/promises.cf.in
@@ -105,7 +105,7 @@ bundle common inventory
 # Tested to work properly against 3.5.x
 {
   classes:
-      "other_unix_os" expression => "!windows.!macos.!linux.!freebsd";
+      "other_unix_os" expression => "!(windows|macos|linux|freebsd|aix)";
       "specific_linux_os" expression => "redhat|debian|suse|sles";
 
   vars:


### PR DESCRIPTION
AIX was not considered in the expression that determined which set of
inventory policy files to load resulting in only generic inventory
policy being loaded. This change corrects the expression so that AIX
loads the AIX specific inventory.

Ticket: CFE-3614
Changelog: Title
(cherry picked from commit ea1b1e5a9ade42d8b49885307bd23330f22f23c6)