### PR TITLE
CFE-3622: Avoid setting files_single_copy in an erroneous way (master)

### DIFF
--- a/controls/cf_agent.cf
+++ b/controls/cf_agent.cf
@@ -35,6 +35,9 @@ body agent control
       # Maximum number of outgoing connections to a remote cf-serverd.
       maxconnections => "$(def.control_agent_maxconnections)";
 
+    _have_control_agent_files_single_copy::
+      # CFE-3622
+
       # File patterns which allow a file to be copied over only a single time
       # per agent run.
 

--- a/controls/def.cf
+++ b/controls/def.cf
@@ -215,7 +215,7 @@ bundle common def
 
       "control_agent_files_single_copy"
         slist => { },
-        if => not( some( ".*", "control_agent_files_single_copy") ),
+        if => not( isvariable( "control_agent_files_single_copy" ) ),
         comment => "Default files_single_copy to an empty list if it is not
                     defined. It is expected that users can override the default
                     by setting this value from the augments file (def.json).";

--- a/controls/def.cf
+++ b/controls/def.cf
@@ -212,13 +212,15 @@ bundle common def
                           "false");
 
       # Agent controls
-
-      "control_agent_files_single_copy"
+@if minimum_version(3.18.0)
+      # TODO When 3.18 is the oldest supported LTS, redact this macro and associated protections
+      "control_agent_files_single_copy" -> { "CFE-3622" }
         slist => { },
         if => not( isvariable( "control_agent_files_single_copy" ) ),
         comment => "Default files_single_copy to an empty list if it is not
                     defined. It is expected that users can override the default
                     by setting this value from the augments file (def.json).";
+@endif
 
       "control_server_maxconnections"
         int => "200",
@@ -464,6 +466,8 @@ bundle common def
 
   classes:
 
+      "_have_control_agent_files_single_copy" -> { "CFE-3622"}
+        expression => isvariable( "def.control_agent_files_single_copy" );
       "_have_control_executor_runagent_socket_allow_users"
         expression => isvariable( "def.control_executor_runagent_socket_allow_users" );
 


### PR DESCRIPTION

This pr builds on top of one from @vpodzime https://github.com/cfengine/masterfiles/pull/1960