### PR TITLE
ENT-6992: Switched Travis to using cf-remote for getting master packages (3.12)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,14 +58,20 @@ matrix:
 
     # JOB 5
     - env: CF_VERSION=3.7.x
-      addons:
-        apt:
-          sources:
-            - sourceline: "deb https://cfengine-package-repos.s3.amazonaws.com/pub/apt/packages stable main"
-              key_url: https://cfengine-package-repos.s3.amazonaws.com/pub/gpg.key
-          packages:
-            - cfengine-community=3.7.*
-
+      install:
+        - sudo apt install -y software-properties-common
+        - sudo add-apt-repository -y ppa:deadsnakes/ppa
+        - sudo apt update
+        - sudo apt -y install python3.6
+        - sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1
+        - sudo curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py"
+        - sudo python3 get-pip.py
+        - sudo rm get-pip.py
+        - sudo pip3 install cf-remote
+        - BRANCH=$CF_VERSION
+        - PKG_URL=`cf-remote --version $BRANCH list deb x86_64 agent | tail -n 1`
+        - wget $PKG_URL
+        - sudo dpkg -i ./$(basename ${PKG_URL})
 
 script:
 - sudo apt-get install -y fakeroot
@@ -97,8 +103,9 @@ script:
   fi;
   export IS_PRERELEASE
 - cd $TRAVIS_BUILD_DIR/..
-- export RELEASE_TAG=$(/var/cfengine/bin/cf-agent --version | awk '{print $3}')
+- export RELEASE_TAG=$(/var/cfengine/bin/cf-agent --version | awk '/Core/{print $3}')
 - export BRANCH="$RELEASE_TAG"
+- echo BRANCH=$BRANCH
 - if [ "$CF_VERSION" = "master" ]; then
     export BRANCH="master";
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,19 @@ matrix:
     # JOB 1
     - env: CF_VERSION=master
       install:
+        - sudo apt install -y software-properties-common
+        - sudo add-apt-repository -y ppa:deadsnakes/ppa
+        - sudo apt update
+        - sudo apt -y install python3.6
+        - sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1
+        - sudo curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py"
+        - sudo python3 get-pip.py
+        - sudo rm get-pip.py
+        - sudo pip3 install cf-remote
         - BRANCH=$CF_VERSION
-        - DATE=`wget -qO- https://builds.cfengine.com/pub/nightly/$BRANCH/FOOTER.html --no-check-certificate | grep -o 'latest.>[^<]*'`
-        - DATE="${DATE#*>}"
-        - DIR_URL="https://builds.cfengine.com/pub/nightly/master/$DATE/output/PACKAGES_x86_64_linux_debian_7"
-        - FILE=`wget --no-check-certificate -qO- "$DIR_URL" | grep -o '[^>]*\.deb<'`
-        - FILE="${FILE%%<*}"
-        - wget --no-check-certificate $DIR_URL/$FILE
-        - sudo dpkg -i $FILE
+        - PKG_URL=`cf-remote --version $BRANCH list ubuntu16 agent | tail -n 1`
+        - wget $PKG_URL
+        - sudo dpkg -i ./$(basename ${PKG_URL})
 
     # JOB 2
     - env: CF_VERSION=3.15.x

--- a/controls/def.cf
+++ b/controls/def.cf
@@ -233,7 +233,7 @@ bundle common def
                           "false");
 
       # Agent controls
-@if minimum_version(3.18.0)
+@if minimum_version(3.18)
       # TODO When 3.18 is the oldest supported LTS, redact this macro and associated protections
       "control_agent_files_single_copy" -> { "CFE-3622" }
         slist => { },


### PR DESCRIPTION
Prior to this change, Travis was fetching packages from builds.cfengine.com
which was previously co-located with cfengine.com. However, this broke when we
deployed the new cfengine.com website into different infrastructure. Instead of
restoring functionality to builds.cfengine.com, I thought it better to use our
shiny new tooling and switched to cf-remote. The Travis build host is Ubuntu
16.04, so, in order to facilitate the change I had to install python 3.6 from
the deadsnakes personal package archive as it is required for both pip3 and cf-remote.

Ticket: ENT-6992
Changelog: None
(cherry picked from commit 1f841f0f1bf894f64c2042ca4b8910f9ea470d83)