### PR TITLE
ENT-7051: Removed codecov.io

### DIFF
--- a/travis-scripts/before_install.sh
+++ b/travis-scripts/before_install.sh
@@ -26,7 +26,7 @@ else
     sudo apt-get install -y fakeroot
     # Optional
     sudo apt-get install -y libxml2-dev libacl1-dev
-    # codecov.io dependency
+    # Code coverage dependency:
     sudo apt-get install -y lcov
     # Ensure traditional yacc compatibility
     sudo apt-get purge      -y bison


### PR DESCRIPTION
No real change in this repo, just updating the comment.

Kept lcov dependency because:
* Not a quick thing to remove, shows up in many places
* Probably necessary if we add some code coverage again