### PR TITLE
CFE-3569: Adopt use of sys.os_name_human & sys.os_version_major

### DIFF
--- a/inventory/os.cf
+++ b/inventory/os.cf
@@ -110,4 +110,12 @@ centos_6::
                   meta => { "inventory", "attribute_name=OS", "derived-from=centos_6" };
 
 @endif
+
+# TODO: Remove all of the logic above once 3.18 clients are expected everywhere
+@if minimum_version(3.18)
+any::
+  "description"
+    string => "$(sys.os_name_human) $(sys.os_name_major)",
+    meta => { "inventory", "attribute_name=OS" };
+@endif
 }


### PR DESCRIPTION
Adopt use of sys.os_name_human & sys.os_version_major for OS inventory
attribute

Ticket: CFE-3569
Changelog: None
Signed-off-by: larsewi <lars.erik.wik@northern.tech>