### PR TITLE
CFE-1962: Added note about limitations of syntax checking dynamically loaded policy files (master)

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -650,7 +650,13 @@ bundle agent example
 **Note:** ```.cf``` files located in `services/autorun/` are automatically
 included in inputs even when the ```services_autorun``` class is **not**
 defined. Bundles tagged with ```autorun``` are **not required** to be placed in
-`services/autorun/` in order to be automatically actuated.
+`services/autorun/` in order to be automatically actuated. If you have an
+automatically loaded policy file in `services/autorun` which loads additional
+policy dynamically, `cf-promises` may not be able to resolve syntax errors. Use
+[`mpf_extra_autorun_inputs`][Masterfiles Policy Framework#Additional automatically loaded inputs]
+and or
+[`control_common_bundlesequence_classification`][Masterfiles Policy Framework#Classification bundles before autorun]
+to work around this limitation.
 
 **History:**
 


### PR DESCRIPTION
Currently (as of 3.17.0), cf-promises is not capable of detecting syntax errors
in policy files that are dynamically loaded by other dynamically loaded policy
files. This limitation can be worked around by leveraging loading from other
places in policy and this change references those other configuration options.

Ticket: CFE-1962
Changelog: None