### PR TITLE
ENT-7056 nightly maintenance tasks were silenced - 3.15.x

### DIFF
--- a/lib/cfe_internal_hub.cf
+++ b/lib/cfe_internal_hub.cf
@@ -189,6 +189,10 @@ AND    t.$(settings[$(index)][time_key]) <= (z.latest - '$(settings[$(index)][hi
 
   commands:
       "$(sys.bindir)/psql cfdb -c \"$(remove_query_$(settings[$(index)][report]))\""
+@if minimum_version(3.15.0)
+        inform => "false",
+@endif
+        contain => silent,
         handle => "cf_database_maintain_report_$(settings[$(index)][report])";
 }
 
@@ -237,9 +241,17 @@ bundle agent cfe_internal_database_cleanup_consumer_status (row_count)
 
   commands:
       "$(sys.bindir)/psql cfdb -c \"$(remove_query)\""
-      handle => "cf_database_maintain_consumer_status";
+@if minimum_version(3.15.0)
+        inform => "false",
+@endif
+        contain => silent,
+        handle => "cf_database_maintain_consumer_status";
 
       "$(sys.bindir)/psql cfdb -c \"$(delete_future_ts_query)\"" -> { "ENT-4362" }
+@if minimum_version(3.15.0)
+        inform => "false",
+@endif
+        contain => silent,
         handle => "cf_database_maintain_consumer_status_no_future_timestamps";
 
 }
@@ -254,7 +266,11 @@ bundle agent cfe_internal_database_cleanup_diagnostics (settings)
 
   commands:
       "$(sys.bindir)/psql cfdb -c \"$(remove_query_$(settings[$(index)][report]))\""
-      handle => "cf_database_maintain_diagnostics_$(settings[$(index)][report])";
+@if minimum_version(3.15.0)
+        inform => "false",
+@endif
+        contain => silent,
+        handle => "cf_database_maintain_diagnostics_$(settings[$(index)][report])";
 }
 
 bundle agent cfe_internal_database_cleanup_promise_log (history_length_days)
@@ -270,10 +286,18 @@ bundle agent cfe_internal_database_cleanup_promise_log (history_length_days)
 
   commands:
       "$(sys.bindir)/psql cfdb -c \"$(cleanup_query_repaired)\""
-      handle => "cf_database_maintain_promise_log_repaired";
+@if minimum_version(3.15.0)
+        inform => "false",
+@endif
+        contain => silent,
+        handle => "cf_database_maintain_promise_log_repaired";
 
       "$(sys.bindir)/psql cfdb -c \"$(cleanup_query_notkept)\""
-      handle => "cf_database_maintain_promise_log_notkept";
+@if minimum_version(3.15.0)
+        inform => "false",
+@endif
+        contain => silent,
+        handle => "cf_database_maintain_promise_log_notkept";
 }
 
 bundle agent cfe_internal_database_partitioning()
@@ -288,7 +312,11 @@ bundle agent cfe_internal_database_partitioning()
 
   commands:
       "$(sys.bindir)/psql cfdb -c \"$(query_create_promise_log_$(promise_outcome))\""
-      handle => "cf_database_create_partition_promise_log_$(promise_outcome)";
+@if minimum_version(3.15.0)
+        inform => "false",
+@endif
+        contain => silent,
+        handle => "cf_database_create_partition_promise_log_$(promise_outcome)";
 }
 
 bundle agent cfe_internal_postgresql_maintenance


### PR DESCRIPTION
Issue was that these tasks broke no-noise deployment test, if it was
started at Hr00.

Changelog: none
(cherry picked from commit 478db759fe80e3c6cab9a883e3c41cf5e5b5759a)