### PR TITLE
CFE-3662: Changed default behavior of policy update to keep inputs in sync with masterfiles (master)

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -255,21 +255,28 @@ If you want to periodically perform a full scan consider adding custom policy to
 simply remove ```$(sys.inputdir)/cf_promises_validated```. This will cause the
 file to be repaired during the next update run triggering a full scan.
 
-### Automatically remove files not present upstream (SYNC masterfiles)
+### Disable automatically removing files not present upstream (SYNC masterfiles)
 
-If the class ```cfengine_internal_purge_policies``` is defined the update
-behavior to change from only copying changed files down to performing a
-synchronization by purging files on the client that do not exist on the server.
+By default, the MPF will keep inputdir in sync with masterfiles on the hub. If
+the class ```cfengine_internal_purge_policies_disabled``` is defined the update
+behavior will only keep files that exist on the remote up to date locally, files
+that exist locally that do not exist upstream will be left behind. Note, if this
+is disabled and a policy file that is dynamically loaded based on it's presence
+is renamed, duplicate definition errors may occur, preventing policy execution.
 
 This [augments file][Augments] will enable this behavior for all clients.
 
 ```
 {
   "classes": {
-    "cfengine_internal_purge_policies": [ "any" ]
+    "cfengine_internal_purge_policies_disabled": [ "any" ]
   }
 }
 ```
+
+**History:**
+
+- Introduced in 3.18.0, previously, the default behavior was opposite and the class `cfengine_internal_purge_policies`  had to be enabled to keep inputs in sync with masterfiles.
 
 ### Disable limiting robot agents
 

--- a/cfe_internal/recommendations.cf
+++ b/cfe_internal/recommendations.cf
@@ -1,3 +1,15 @@
+bundle agent MPF_class_reccomendations
+{
+  meta:
+    (policy_server|am_policy_hub).enterprise_edition::
+      "tags" slist => { "cfengine_recommends" };
+
+  reports:
+      "`cfengine_internal_purge_polices` no longer has any effect. Please use `cfengine_internal_purge_policies_disabled` instead, to choose where you want to disable purging or remove the class completely if you want purging enabled everywhere (the new default in 3.18+)." -> { "CFE-3662" }
+        if => "cfengine_internal_purge_policies";
+}
+
+
 bundle agent postgresql_conf_reccomendations
 # @brief Recommendations about the configuration of postgresql.conf for CFEngine Enterprise Hubs
 {

--- a/cfe_internal/update/update_policy.cf
+++ b/cfe_internal/update/update_policy.cf
@@ -391,7 +391,7 @@ body copy_from u_rcp(from,server)
       source      => "$(from)";
       compare     => "digest";
       trustkey    => "false";
-
+      purge => "true"; # CFE-3662
 
       # CFE-2932 For testing, we want to be able to avoid this local copy optimiztion
     !am_policy_hub|mpf_skip_local_copy_optimizaton::
@@ -403,8 +403,8 @@ body copy_from u_rcp(from,server)
     cfengine_internal_encrypt_transfers::
       encrypt => "true";
 
-    cfengine_internal_purge_policies::
-      purge => "true";
+    cfengine_internal_purge_policies_disabled::
+      purge => "false";
 
     cfengine_internal_preserve_permissions::
       preserve => "true";

--- a/controls/def.cf
+++ b/controls/def.cf
@@ -511,13 +511,13 @@ bundle common def
 
       "cfengine_internal_encrypt_transfers" expression => "!any";
 
-      # Purge policies that don't exist on the server side.
+      # Do not purge policies that don't exist on the server side.
       # you can also request it from the command line with
-      # -Dcfengine_internal_purge_policies
+      # -Dcfengine_internal_purge_policies_disabled
 
       # NOTE THAT THIS CLASS ALSO NEEDS TO BE SET IN update.cf
 
-      "cfengine_internal_purge_policies" expression => "!any";
+      "cfengine_internal_purge_policies_disabled" expression => "!any";
 
       # Preserve permissions of the policy server's masterfiles.
       # you can also request it from the command line with

--- a/controls/update_def.cf.in
+++ b/controls/update_def.cf.in
@@ -157,13 +157,13 @@ bundle common update_def
 
       "cfengine_internal_encrypt_transfers" expression => "!any";
 
-      # Purge policies that don't exist on the server side.
+      # Do not purge policies that don't exist on the server side.
       # you can also request it from the command line with
-      # -Dcfengine_internal_purge_policies
+      # -Dcfengine_internal_purge_policies_disabled
 
       # NOTE THAT THIS CLASS ALSO NEEDS TO BE SET IN def.cf
 
-      "cfengine_internal_purge_policies" expression => "!any";
+      "cfengine_internal_purge_policies_disabled" expression => "!any";
 
       # Preserve permissions of the policy server's masterfiles.
       # you can also request it from the command line with


### PR DESCRIPTION
Prior to this change, the default behavior of the MPF was to only ensure that
files in masterfiles were up to date with the files in inputs. Files in inputs
that did not exist in masterfiles were left undisturbed. To enable sync
behavior (a common user expectation) you had to explicitly define
'cfengine_internal_purge_policies'. Now, if you wish to return to the previous
default behavior, define the class 'cfengine_internal_purge_policies_disabled'.

Ticket: CFE-3662
Changelog: Commit