### PR TITLE
ENT-7087: Clarified inline docs for authorizing data for reporting (3.12)

### DIFF
--- a/controls/reports.cf
+++ b/controls/reports.cf
@@ -71,11 +71,11 @@ bundle server report_access_rules
 }
 
 body report_data_select default_data_select_host
-# @brief Data to collect from remote hosts by default
+# @brief Data authorized by non policy servers for collection by cf-hub
 #
 # By convention variables and classes known to be internal, (having no
-# reporting value) should be prefixed with an underscore. By default the policy
-# framework explicitly excludes these variables and classes from collection.
+# reporting value) should be prefixed with an underscore. By default cf-hub
+# explicitly excludes these variables and classes from collection.
 {
       metatags_include => { "inventory", "report" };
       metatags_exclude => { "noreport" };
@@ -84,11 +84,11 @@ body report_data_select default_data_select_host
 }
 
 body report_data_select default_data_select_policy_hub
-# @brief Data to collect from policy servers by default
+# @brief Data authorized by policy servers for collection by cf-hub
 #
 # By convention variables and classes known to be internal, (having no
-# reporting value) should be prefixed with an underscore. By default the policy
-# framework explicitly excludes these variables and classes from collection.
+# reporting value) should be prefixed with an underscore. By default cf-hub
+# explicitly excludes these variables and classes from collection.
 {
       metatags_include => { "inventory", "report" };
       metatags_exclude => { "noreport" };


### PR DESCRIPTION
This change clarifies the description of how the report_data_select bodies work.
The previous verbiage indicated that the bodies were used by the hub instead of
by the host being collected from.

Ticket: ENT-7087
Changelog: None
(cherry picked from commit 4f4bae3fdb442cf7462a4c5f2bb63960542753c5)