### PR TITLE
Fixed new OS inventory string based on new vars

### DIFF
--- a/inventory/os.cf
+++ b/inventory/os.cf
@@ -115,7 +115,7 @@ centos_6::
 @if minimum_version(3.18)
 any::
   "description"
-    string => "$(sys.os_name_human) $(sys.os_name_major)",
+    string => "$(sys.os_name_human) $(sys.os_version_major)",
     meta => { "inventory", "attribute_name=OS" };
 @endif
 }


### PR DESCRIPTION
Changed sys.os_name_major -> sys.os_version_major

One is correct, the other one isn't.