### PR TITLE
ENT-7356 Fixed package module augments settings usage for pre 3.15.3 binaries

### DIFF
--- a/lib/packages.cf
+++ b/lib/packages.cf
@@ -10,13 +10,13 @@ bundle common package_module_knowledge
 
       # Package inventory refresh
       "query_installed_ifelapsed" -> { "CFE-2771", "CFE-3504" }
-        string => ifelse( isvariable( "def.package_module_$(this.promiser)" ),
-                          "$(def.package_module_$(this.promiser))",
+        string => ifelse( isvariable( "def.package_module_query_installed_ifelapsed" ),
+                          "$(def.package_module_query_installed_ifelapsed)",
                           "0"); # Always refresh local package inventory
 
       "query_updates_ifelapsed" -> { "CFE-2771", "CFE-3504" }
-        string => ifelse( isvariable( "def.package_module_$(this.promiser)" ),
-                          "$(def.package_module_$(this.promiser))",
+        string => ifelse( isvariable( "def.package_module_query_updates_ifelapsed" ),
+                          "$(def.package_module_query_updates_ifelapsed)",
                           "1440"); # Refresh software updates available once a day
 
     debian::


### PR DESCRIPTION
A bug in ifelse in pre 3.15.3 binaries coupled with
a bug regarding evaluation of $(this.promiser) in doubly-referenced
values (https://tracker.mender.io/browse/ENT-7358) causes
package_module_query_installed_ifelapsed and
package_module_query_updates_ifelapsed to be undefined
(-678 value) when newer policy is run with pre
3.15.3 binaries.

Ticket: ENT-7356
Changelog: title