### PR TITLE
ENT-4628 Guard again enforcing root ownership for CFEngine files on Windows (3.15.x)

### DIFF
--- a/cfe_internal/enterprise/CFE_knowledge.cf
+++ b/cfe_internal/enterprise/CFE_knowledge.cf
@@ -368,7 +368,8 @@ body depth_search cfe_internal_docroot_application_perms
 body perms state_dir_system_owned
 {
       mode   => "0600";
-      owners => { "root" };
+      !windows::
+        owners => { "root" };
 
       freebsd|openbsd|netbsd|darwin::
         groups => { "wheel" };

--- a/cfe_internal/update/update_policy.cf
+++ b/cfe_internal/update/update_policy.cf
@@ -315,7 +315,8 @@ body perms u_mo(p,o)
 # @param p Desired file owner (username or uid)
 {
       mode   => "$(p)";
-      owners => {"$(o)"};
+      !windows::
+        owners => {"$(o)"};
 }
 
 #########################################################


### PR DESCRIPTION
Trying to enforce user root ownership on $(sys.statedir) and
$(sys.workdir)/modules was causing many errors to be reported:

error: Could not look up name 'root'. (LookupAccountName)

Changelog: title
Ticket: ENT-4628
(cherry picked from commit d6ae4b084610bfd91ac3c20b5fd5b0cf987a0e19)