### PR TITLE
Fix monitoring_include sample values

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -1176,7 +1176,7 @@ memory related probes on policy servers:
 {
   "vars": {
     "default_data_select_host_monitoring_include": [ ".*" ],
-    "default_data_select_policy_hub_monitoring_include": [ "mem_.*", "cpu_.*" ]
+    "default_data_select_policy_hub_monitoring_include": [ "mem_.*", "cpu.*" ]
   }
 }
 ```


### PR DESCRIPTION
There are no "cpu_.*" measurements: https://docs.cfengine.com/docs/3.18/reference-special-variables-mon.html