### PR TITLE
CFE-3712: Removed stale CMDB inventory policy (master)

### DIFF
--- a/controls/def.cf
+++ b/controls/def.cf
@@ -645,10 +645,6 @@ bundle common inventory_control
       "disable_inventory_proc" expression => "disable_inventory|freebsd";
       "disable_inventory_proc" not => isdir($(proc));
 
-      # by default don't run the CMDB integration every time, even if
-      # disable_inventory is not set
-      "disable_inventory_cmdb" expression => "any";
-
   reports:
     verbose_mode.disable_inventory::
       "$(this.bundle): All inventory modules disabled";
@@ -666,8 +662,6 @@ bundle common inventory_control
       "$(this.bundle): proc module enabled";
     verbose_mode.!disable_inventory_package_refresh::
       "$(this.bundle): package_refresh module enabled";
-    verbose_mode.!disable_inventory_cmdb::
-      "$(this.bundle): CMDB module enabled";
 
     DEBUG|DEBUG_def::
 

--- a/inventory/README.md
+++ b/inventory/README.md
@@ -218,13 +218,6 @@ R: cfe_autorun_inventory_fstab: we have a cifs fstab entry under /backups/load
 R: cfe_autorun_inventory_fstab: we have a auto fstab entry under /mnt/cdrom
 ```
 
-## CMDB
-
-* lives in: `any.cf`
-* parses: `me.json` (which is copied from the policy server; see implementation)
-* provides classes: `CLASS` for each CLASS found under the ```classes``` key in the JSON data
-* provides variables: `inventory_cmdb_load.VARNAME` for each VARNAME found under the `vars` key in the JSON data
-
 ## DMI decoding
 
 * lives in: `any.cf`

--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -29,10 +29,6 @@ bundle agent inventory_autorun
 # earlier are no longer supported.
 {
   methods:
-    !disable_inventory_cmdb::
-      "cmdb" usebundle => cfe_autorun_inventory_cmdb(),
-      handle => "cfe_internal_autorun_inventory_cmdb";
-
     !disable_inventory_LLDP::
       "LLDP" usebundle => cfe_autorun_inventory_LLDP(),
       handle => "cfe_internal_autorun_inventory_LLDP";
@@ -1132,84 +1128,6 @@ body package_method inventory_lslpp(update_interval)
       package_patch_command  => "/usr/bin/true";
       package_delete_command => "/usr/bin/true";
       package_verify_command => "/usr/bin/true";
-}
-
-bundle agent cfe_autorun_inventory_cmdb
-# @brief Copy and load the CMDB inventory
-#
-# This bundle is for refreshing the CMDB inventory.  It copies the
-# file me.json from the server, then loads it to create variables and
-# classes.
-{
-  vars:
-      "cmdb_dir" string => "$(sys.workdir)/cmdb",
-      comment => "CMDB directory location",
-      meta => { "cmdb" };
-
-      "cmdb_file" string => "$(cmdb_dir)/me.json",
-      comment => "CMDB file location",
-      meta => { "cmdb" };
-
-  files:
-      "$(cmdb_file)"
-      copy_from => inventory_cmdb_copy_from,
-      classes => inventory_scoped_classes_generic("bundle", "cmdb_file");
-
-  methods:
-    cmdb_file_ok::
-      "load CMDB file" usebundle => inventory_cmdb_load($(cmdb_file));
-}
-
-bundle agent inventory_cmdb_load(file)
-# @brief Load the CMDB inventory
-# @param file Load the CMDB inventory
-#
-# This bundle is for loading the CMDB inventory.
-{
-  classes:
-      "have_cmdb_data" expression => isvariable("cmdb");
-
-      "$(ckeys)" expression => "any", scope => "namespace";
-
-  vars:
-      "cmdb"
-        data => readjson($(file), "999999"),
-        if => fileexists( $(file) );
-
-      "cmdb_string"
-      string => format("%S", cmdb),
-        if => isvariable( cmdb );
-
-      "bkeys" slist => getindices("cmdb[vars]");
-      "vkeys_$(bkeys)" slist => getindices("cmdb[vars][$(bkeys)]");
-      "$(vkeys_$(bkeys))" string => nth("cmdb[vars][$(bkeys)]", $(vkeys));
-
-      "ckeys" slist => getindices("cmdb[classes]");
-
-  reports:
-    DEBUG|DEBUG_inventory_cmdb_load::
-      "DEBUG $(this.bundle): Got CMDB data from $(file): $(cmdb_string)"
-        if => "have_cmdb_data";
-      "DEBUG $(this.bundle): Got CMDB key = $(vkeys_$(bkeys)), CMDB value = $((vkeys_$(bkeys)))"
-        if => "have_cmdb_data";
-      "DEBUG $(this.bundle): Got CMDB class = $(ckeys)"
-        if => "have_cmdb_data";
-      "DEBUG $(this.bundle): Could not read the CMDB data from $(file)"
-        if => "!have_cmdb_data";
-}
-
-body copy_from inventory_cmdb_copy_from
-# @brief Copy from the CMDB source
-{
-    !cfe_inventory_cmdb_override_file::
-      source      => "me.json";
-      servers     => { "$(sys.policy_hub)" };
-    cfe_inventory_cmdb_override_file::
-      source      => "$(sys.inputdir)/me.json";
-    any::
-      compare     => "digest";
-      encrypt     => "true";
-      verify      => "true";
 }
 
 body classes inventory_scoped_classes_generic(scope, x)


### PR DESCRIPTION
This policy was originally introduced for CFEngine 3.6.0 as an easy way to
provide information from an external system via a data interface. Since then new
functionality has been introduced, especially Augments and the new host specific
data which implement this from core.

It's always been disabled by default, and now there has been a report of it
causing errors, so I think it's perfectly safe to remove.