### PR TITLE
CFE-3703: Add interpreter attribute to standalone self upgrade package_module bodies (3.18)

### DIFF
--- a/standalone_self_upgrade.cf.in
+++ b/standalone_self_upgrade.cf.in
@@ -953,6 +953,9 @@ body package_module yum
 {
       query_installed_ifelapsed => "10";
       query_updates_ifelapsed => "30";
+@if minimum_version(3.12.2)
+      interpreter => "$(sys.bindir)/cfengine-selected-python";
+@endif
 }
 
 body package_module apt_get
@@ -960,6 +963,9 @@ body package_module apt_get
 {
       query_installed_ifelapsed => "10";
       query_updates_ifelapsed => "30";
+@if minimum_version(3.12.2)
+      interpreter => "$(sys.bindir)/cfengine-selected-python";
+@endif
 }
 
 body package_module msiexec
@@ -967,7 +973,9 @@ body package_module msiexec
 {
       query_installed_ifelapsed => "10";
       query_updates_ifelapsed => "30";
+@if minimum_version(3.12.2)
       interpreter => "$(sys.winsysdir)$(const.dirsep)cmd.exe /c ";
+@endif
       module_path => "$(sys.workdir)$(const.dirsep)modules$(const.dirsep)packages$(const.dirsep)msiexec.bat";
 }
 body perms u_m(p)


### PR DESCRIPTION
This was missed in ENT-5752 work and will cause problems in self-upgrade.

Ticket: CFE-3703
Changelog: title
(cherry picked from commit 8d35228286c868c780a2daacfafbf0bce45a214c)