### PR TITLE
ENT-7442: Fixup zypper package module script to work properly with interpreter attribute (3.18)

### DIFF
--- a/modules/packages/vendored/zypper.mustache
+++ b/modules/packages/vendored/zypper.mustache
@@ -69,7 +69,7 @@ def redirection_is_broken():
     # and that's good, because it would have been much more tricky to solve.
     global redirection_is_broken_cached
     if redirection_is_broken_cached == -1:
-        cmd_line = [sys.argv[0], "internal-test-stderr"]
+        cmd_line = [sys.executable, sys.argv[0], "internal-test-stderr"]
         if subprocess.call(cmd_line, stdout=sys.stderr) == 0:
             redirection_is_broken_cached = 0
         else:


### PR DESCRIPTION
Same change as included in masterfiles commit

ef02bcb265b7a285b280efddb87413f68372ba2e

which covered apt_get and yum but missed zypper.

Ticket: ENT-7442
Changelog: title
(cherry picked from commit 684ec90b028360a63726ce5fce37629682668c00)