### PR TITLE
CFE-3715: Added separate classes for controlling autorun inputs and bundles (3.18)

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -627,8 +627,8 @@ The `inputs` key in augments can be used to add additional custom policy files.
 
 ### services\_autorun
 
-When the ```services_autorun``` class is defined bundles tagged with
-```autorun``` are actuated in lexical order.
+When the ```services_autorun``` class is defined ```.cf``` files located in `services/autorun/` are automatically
+included in inputs and bundles tagged with ```autorun``` are actuated in lexical order.
 
 Example definition of ```services_autorun``` using [Augments (def.json)][Augments]:
 
@@ -654,12 +654,11 @@ bundle agent example
 }
 ```
 
-**Note:** ```.cf``` files located in `services/autorun/` are automatically
-included in inputs even when the ```services_autorun``` class is **not**
-defined. Bundles tagged with ```autorun``` are **not required** to be placed in
-`services/autorun/` in order to be automatically actuated. If you have an
-automatically loaded policy file in `services/autorun` which loads additional
-policy dynamically, `cf-promises` may not be able to resolve syntax errors. Use
+**Note:** The `services_autorun_inputs` and `services_autorun_bundles` classes
+allow policy files to be dynamically loaded or tagged bundles to be run
+independently of each-other. If you have an automatically loaded policy file in
+`services/autorun` which loads additional policy dynamically, `cf-promises` may
+not be able to resolve syntax errors. Use
 [`mpf_extra_autorun_inputs`][mpf_extra_autorun_inputs]
 and or
 [`control_common_bundlesequence_classification`][Masterfiles Policy Framework#Classification bundles before autorun]
@@ -668,6 +667,43 @@ to work around this limitation.
 **History:**
 
 * Added in CFEngine 3.6.0
+
+#### Automatically add policy files to inputs
+
+When the ```services_autorun_inputs``` class is defined ```.cf``` files located
+in `services/autorun/` are automatically included in inputs.
+
+Example definition of ```services_autorun_inputs``` using [Augments (def.json)][Augments]:
+
+```json
+{
+  "classes": {
+    "services_autorun_inputs": [ "any::" ]
+  }
+}
+```
+
+**History:**
+
+* Added in CFEngine 3.19.0, 3.18.1
+
+#### Automatically run bundles tagged autorun
+
+When the ```services_autorun_bundles``` class is defined bundles tagged with ```autorun``` are actuated in lexical order.
+
+Example definition of ```services_autorun_bundles``` using [Augments (def.json)][Augments]:
+
+```json
+{
+  "classes": {
+    "services_autorun_bundles": [ "any::" ]
+  }
+}
+```
+
+**History:**
+
+* Added in CFEngine 3.19.0, 3.18.1
 
 #### Additional automatically loaded inputs
 

--- a/lib/autorun.cf
+++ b/lib/autorun.cf
@@ -7,7 +7,7 @@ body file control
 bundle agent autorun
 {
   vars:
-    services_autorun::
+    services_autorun|services_autorun_bundles::
       "bundles" slist => bundlesmatching(".*", "autorun");
 
       "sorted_bundles"

--- a/promises.cf.in
+++ b/promises.cf.in
@@ -339,7 +339,7 @@ bundle common services_autorun
 # added to inputs automatically.
 {
   vars:
-    services_autorun::
+    services_autorun|services_autorun_inputs::
       "inputs" slist => { "$(sys.local_libdir)/autorun.cf" };
 
       "_default_autorun_input_dir"
@@ -358,21 +358,31 @@ bundle common services_autorun
       "found_inputs" slist => { @(_default_autorun_inputs),
                                 sort( getvalues(_extra_autorun_inputs), "lex") };
 
-      "bundles" slist => { "autorun" }; # run loaded bundles
-
-    !services_autorun::
+    !(services_autorun|services_autorun_inputs|services_autorun_bundles)::
       # If services_autorun is not enabled, then we should not extend inputs
       # automatically.
       "inputs" slist => { };
       "found_inputs" slist => {};
       "bundles" slist => { "services_autorun" }; # run self
 
+    services_autorun|services_autorun_inputs|services_autorun_bundles::
+      "bundles" slist => { "autorun" }; # run loaded bundles
+
   reports:
     DEBUG|DEBUG_services_autorun::
       "DEBUG $(this.bundle): Services Autorun Disabled"
-        if => "!services_autorun";
+        if => "!(services_autorun|services_autorun_bundles|services_autorun_inputs)";
 
       "DEBUG $(this.bundle): Services Autorun Enabled"
+        if => "services_autorun";
+
+      "DEBUG $(this.bundle): Services Autorun Bundles Enabled"
+        if => "services_autorun_bundles";
+
+      "DEBUG $(this.bundle): Services Autorun Inputs Enabled"
+        if => "services_autorun_inputs";
+
+      "DEBUG $(this.bundle): Services Autorun (Bundles & Inputs) Enabled"
         if => "services_autorun";
 
       "DEBUG $(this.bundle): adding input='$(inputs)'"


### PR DESCRIPTION
The class services_autorun continues to enable both automatic inclusion of .cf
files in services/autorun and the running of bundles tagged with autorun.

This change adds the classes services_autorun_inputs and
services_autorun_bundles for independently enabling addition of .cf files in
services/autorun and automatic execution of bundles tagged with autorun
respectively.

Ticket: CFE-3715
Changelog: Commit
(cherry picked from commit 01850824a48c32ce43dce614ef4935b175f32f34)