### PR TITLE
CFE-3724: apt_get package module fails to fully install packages from local files

### DIFF
--- a/modules/packages/vendored/apt_get.mustache
+++ b/modules/packages/vendored/apt_get.mustache
@@ -349,7 +349,7 @@ def remove():
     return ret
 
 def file_install():
-    cmd_line = [dpkg_cmd] + dpkg_options + ["-i"]
+    cmd_line = [apt_get_cmd] + apt_get_options + ["install"]
 
     found = False
     for line in sys.stdin:


### PR DESCRIPTION
Prior to this change packages promises using the apt_get package module would
use dpkg to handle the case when the path to a package was the promiser. dpkg
does not resolve dependencies, so the result could be a half installed package,
or a package installed with unmet dependencies leaving it in a nonfunctional
state.

This change switches to using apt-get to install the package from a local file,
with apt-get, dependencies are automatically resolved and would be installed
from repositories if available.

Ticket: CFE-3724
Changelog: Title