### PR TITLE
[3.18.x] Comment-out the default bindtointerface specification

### DIFF
--- a/controls/cf_serverd.cf
+++ b/controls/cf_serverd.cf
@@ -70,12 +70,11 @@ body server control
                            $(sys.cf_agent) -I -D cf_runagent_initiated -f $(sys.update_policy_path)  ;
                            $(sys.cf_agent) -I -D cf_runagent_initiated";
 
-    !windows.!(redhat_5|centos_5)::
-      # Bind to all interfaces including ipv6
-      # Adding this on windows will force ipv6 only, so limit to non-windows
-      # On RHEL/CentOS 5 binding to interface "::" fails.
-      bindtointerface => "::";
-
+    # Use bindtointerface to specify interface to bind to, the default is :: +
+    # 0.0.0.0/0 if IPV6 is supported or 0.0.0.0/0 if IPV6 is not supported. On
+    # Windows, binding to :: means only IPV6 connections will be accepted.
+    # !windows::
+    #   bindtointerface => "::";
 }
 
 ###############################################################################


### PR DESCRIPTION
With cfengine/core@4d67db312b1b9 the default is ::/0.0.0.0
instead of just 0.0.0.0 so the explicit value of :: is not needed
and can be dropped to resolve issues on hosts that don't have
working IPV6 and only try to bind to :: if that's the explicit
value.

Ticket: ENT-7362
Changelog: controls/cf_serverd.cf no longer specifies explicit
           default for bindtointerface and relies on the default
           binding to both :: and 0.0.0.0 on IPV6-enabled hosts
(cherry picked from commit 60f92f7ed441e4123f03d44b5d6e7fcbfb2e872d)


Merge together:
https://github.com/cfengine/core/pull/4756
https://github.com/cfengine/masterfiles/pull/2046