### PR TITLE
CFE-3721 Skip ownership of package modules on termux (3.18.x)

### DIFF
--- a/cfe_internal/update/update_policy.cf
+++ b/cfe_internal/update/update_policy.cf
@@ -453,7 +453,7 @@ body perms u_mo(p,o)
 # @param p Desired file owner (username or uid)
 {
       mode   => "$(p)";
-      !windows::
+      !(windows|termux)::
         owners => {"$(o)"};
 }
 


### PR DESCRIPTION
Ticket: CFE-3721
Changelog: title
(cherry picked from commit e1117eb03d611b2335d4a398364dd249940c4aba)