### PR TITLE
ENT-7501: Added fallback logic for determining installed software version on Windows (3.15.x)

### DIFF
--- a/modules/packages/vendored/msiexec-list.vbs.mustache
+++ b/modules/packages/vendored/msiexec-list.vbs.mustache
@@ -32,13 +32,28 @@ For Each strKey in strKeys
       ' Read the InstallDate
       objReg.GetStringValue HKLM, strKey & strSubkey, strInstallDateEntry, strInstallDateValue
       ' Read the DisplayVersion
-      objReg.GetStringValue HKLM, strKey & strSubkey, strDisplayVersionEntry, strDisplayVersionValue
+      intRet2 = objReg.GetStringValue( HKLM, strKey & strSubkey, strDisplayVersionEntry, strDisplayVersionValue )
+      If intRet2 <> 0 Then
+        ' DisplayVersion is missing, so try to fall back InstalledVersion
+        intRet2 = objReg.GetStringValue( HKLM, strKey & strSubKey, "InstalledVersion", strDisplayVersionValue )
+      End If
+      If intRet2 <> 0 Then
+        ' DisplayVersion and InstalledVersion are missing, so try to fall back to a key of the same name as the node, i.e. AOMEI Backupper Server.
+        intRet2 = objReg.GetStringValue( HKLM, strKey & strDisplayNameValue, strDisplayNameValue, strDisplayVersionValue )
+      End If
       ' Replace whitespace with dashes for CFEngine
       ' strDisplayNameValue = Replace(strDisplayNameValue, " ", "-")
       ' Print out the DisplayName
       WScript.Echo "Name=" & LCase(strDisplayNameValue)
       ' Print out the DisplayVersion
-      WScript.Echo "Version=" & LCase(strDisplayVersionValue)
+      ' Ensure that Version is set to something, else it can't be inserted into the database.
+      If intRet2 <> 0 Then
+        ' Unable to find a version, set it to "unknown" so that it can be inserted into the database and not result in patch failure
+        WScript.Echo "Version=unknown"
+      Else
+        ' Must have a legit version
+        WScript.Echo "Version=" & LCase(strDisplayVersionValue)
+      End If
       ' Print out the Architecture
       If InStr(strKey, "6432") = 0 Then
         WScript.Echo "Architecture=amd64"


### PR DESCRIPTION
Windows software is like the wild west. This change tries to fall back to
InstalledVersion if DisplayVersion is not defined in the registry, if that
fails, it falls back trying to look for keys named the same as the software
itself which while not correct, was seen in the wild for at least one piece of
software.

Ticket: ENT-7501
Changelog: Title
(cherry picked from commit 6140be60a049d5ba762bbf4ea3fb2b135d4dd9f0)