### PR TITLE
CFE-3724: apt_get package module now uses apt-get for file based installs instead of dpkg (3.15)

### DIFF
--- a/modules/packages/vendored/apt_get.mustache
+++ b/modules/packages/vendored/apt_get.mustache
@@ -345,7 +345,7 @@ def remove():
     return ret
 
 def file_install():
-    cmd_line = [dpkg_cmd] + dpkg_options + ["-i"]
+    cmd_line = [apt_get_cmd] + apt_get_options + ["install"]
 
     found = False
     for line in sys.stdin:

--- a/tests/unit/test_package_module_apt_get
+++ b/tests/unit/test_package_module_apt_get
@@ -93,10 +93,10 @@ assert check("supports-api-version", [], 1, ["1"], 1, ["apt-get -v"])
 
 assert check("file-install", ["File=/path/to/pkg"], 0, [], 3, ["""apt-get -v
 apt-get -v
-dpkg --force-confold --force-confdef -i /path/to/pkg"""])
+apt-get -o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-confdef -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install /path/to/pkg"""])
 assert check("file-install", ["File=/path/to/pkg","File=/path/to/pkg2"], 0, [], 3, ["""apt-get -v
 apt-get -v
-dpkg --force-confold --force-confdef -i /path/to/pkg /path/to/pkg2"""])
+apt-get -o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-confdef -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install /path/to/pkg /path/to/pkg2"""])
 
 assert check("repo-install", ["Name=a\nVersion=1\nArchitecture=x",
                               "Name=b\nArchitecture=y",


### PR DESCRIPTION
Prior to this change packages promises using the apt_get package module would
use dpkg to handle the case when the path to a package was the promiser. dpkg
does not resolve dependencies, so the result could be a half installed package,
or a package installed with unmet dependencies leaving it in a nonfunctional
state.

This change switches to using apt-get to install the package from a local file,
with apt-get, dependencies are automatically resolved and would be installed
from repositories if available.

Ticket: CFE-3724
Changelog: Title
(cherry picked from commit fb147024136eb16bc8eac209e1dae2121a4123c3)