### PR TITLE
Fixed mock test for apt_get package module

### DIFF
--- a/tests/unit/test_package_module_apt_get
+++ b/tests/unit/test_package_module_apt_get
@@ -96,7 +96,7 @@ apt-get -v
 apt-get -o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-confdef -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install /path/to/pkg"""])
 assert check("file-install", ["File=/path/to/pkg","File=/path/to/pkg2"], 0, [], 3, ["""apt-get -v
 apt-get -v
-dpkg --force-confold --force-confdef -i /path/to/pkg /path/to/pkg2"""])
+apt-get -o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-confdef -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install /path/to/pkg /path/to/pkg2"""])
 
 assert check("repo-install", ["Name=a\nVersion=1\nArchitecture=x",
                               "Name=b\nArchitecture=y",

--- a/tests/unit/test_package_module_apt_get
+++ b/tests/unit/test_package_module_apt_get
@@ -93,7 +93,7 @@ assert check("supports-api-version", [], 1, ["1"], 1, ["apt-get -v"])
 
 assert check("file-install", ["File=/path/to/pkg"], 0, [], 3, ["""apt-get -v
 apt-get -v
-dpkg --force-confold --force-confdef -i /path/to/pkg"""])
+apt-get -o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-confdef -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install /path/to/pkg"""])
 assert check("file-install", ["File=/path/to/pkg","File=/path/to/pkg2"], 0, [], 3, ["""apt-get -v
 apt-get -v
 dpkg --force-confold --force-confdef -i /path/to/pkg /path/to/pkg2"""])


### PR DESCRIPTION
Recently switched to using apt_get instead of dpkg for local file installs so
that dependencies would be resolved automatically, and so that the behavior was
more in line with user expectations without having to read something.