### PR TITLE
ENT-2589: Switched from using package_method generic to default package_module for windows software inventory

### DIFF
--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -1043,7 +1043,7 @@ bundle agent cfe_autorun_inventory_packages
                                 fileexists("$(sys.workdir)/state/software_packages.csv"),
       };
 
-      "use_package_module_for_inventory" or => { "redhat", "debian", "suse", "sles", "alpinelinux" };
+      "use_package_module_for_inventory" or => { "redhat", "debian", "suse", "sles", "alpinelinux", "windows" };
       "use_package_method_for_inventory" or => { "gentoo", "aix" };
       "use_package_method_generic_for_inventory"
         not => "use_package_module_for_inventory|use_package_method_for_inventory";


### PR DESCRIPTION
Now that the windows package module is used by default we can stop using the
legacy packages promise to generate software inventory. Furthermore, this change
should prevent log spam generated by MsiInstaller in the default policy which
was generated for each piece of software found as a result of the use of the
Win32_Product class.

Ticket: ENT-2589
Changelog: Title