### PR TITLE
[3.18.x] Revert "apt_get package module now uses apt-get for file based instal…

### DIFF
--- a/modules/packages/vendored/apt_get.mustache
+++ b/modules/packages/vendored/apt_get.mustache
@@ -349,7 +349,7 @@ def remove():
     return ret
 
 def file_install():
-    cmd_line = [apt_get_cmd] + apt_get_options + ["install"]
+    cmd_line = [dpkg_cmd] + dpkg_options + ["-i"]
 
     found = False
     for line in sys.stdin:

--- a/tests/unit/test_package_module_apt_get
+++ b/tests/unit/test_package_module_apt_get
@@ -93,10 +93,10 @@ assert check("supports-api-version", [], 1, ["1"], 1, ["apt-get -v"])
 
 assert check("file-install", ["File=/path/to/pkg"], 0, [], 3, ["""apt-get -v
 apt-get -v
-apt-get -o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-confdef -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install /path/to/pkg"""])
+dpkg --force-confold --force-confdef -i /path/to/pkg"""])
 assert check("file-install", ["File=/path/to/pkg","File=/path/to/pkg2"], 0, [], 3, ["""apt-get -v
 apt-get -v
-apt-get -o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-confdef -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install /path/to/pkg /path/to/pkg2"""])
+dpkg --force-confold --force-confdef -i /path/to/pkg /path/to/pkg2"""])
 
 assert check("repo-install", ["Name=a\nVersion=1\nArchitecture=x",
                               "Name=b\nArchitecture=y",


### PR DESCRIPTION
…ls instead of dpkg"

Unfortunately, there seems to be a race condition between apt-get
and dpkg and in some cases (incl. out test cases), apt-get thinks
different packages (or versions) are installed.

Ticket: ENT-7508
Ticket: CFE-3724

This reverts commit e5e7e524f211babd0a2fbcc1761817c6d9d3fecd.
This reverts commit 60b6a8f2ca650d13b8bde00b20dfddf9e2c4eef1.
This reverts commit fb147024136eb16bc8eac209e1dae2121a4123c3.

(cherry picked from commit 39b417ae2c52ae90be2940ce788b37d515af15df)