### PR TITLE
Added support for downloading community packages on hub in preparation for binary upgrades

### DIFF
--- a/standalone_self_upgrade.cf.in
+++ b/standalone_self_upgrade.cf.in
@@ -87,11 +87,11 @@ bundle agent cfengine_software
       "pkg_arch" string => ifelse( isvariable( "def.cfengine_software_pkg_arch" ), $(def.cfengine_software_pkg_arch), "x86_64");
       "package_dir" string => ifelse( isvariable( "def.cfengine_software_pkg_dir" ), $(def.cfengine_software_pkg_dir), "$(sys.flavour)_$(sys.arch)");
       "pkg_edition_path" string => ifelse( isvariable( "def.cfengine_software_pkg_edition_path" ), $(def.cfengine_software_pkg_edition_path), "enterprise/Enterprise-$(pkg_version)/agent");
-    
+
     community_edition::
       "pkg_name" string => "cfengine-community";
       "pkg_edition_path" string => "community_binaries/Community-$(pkg_version)";
-    
+
     aix::
       "pkg_name" string => "cfengine.cfengine-nova";
       "pkg_arch" string => "default";


### PR DESCRIPTION
Detects enterprise/community edition and selects correct package paths for standalone self upgrade.

(cherry picked from commit b99b510d5ff005c074f4cb07fb26e3415cedde53)