### PR TITLE
ENT-7544: Added class to prevent hub from seeding binary packages for use in self upgrade

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -367,6 +367,27 @@ For example:
 **History:**
 - Introduced 3.15.0, 3.12.3, 3.10.8
 
+#### Disable seeding binaries on hub
+
+By default when `trigger_upgrade` is defined on a hub, the hub will download
+packages for agents to use during self upgrade. This automatic download behavior
+is disabled when the class `mpf_disable_hub_masterfiles_software_update_seed` is
+defined.
+
+For example:
+
+```json
+{
+   "classes": {
+     "mpf_disable_hub_masterfiles_software_update_seed": [ "policy_server::" ]
+   }
+}
+```
+
+**History:**
+
+- Introduced 3.19.0, 3.18.1
+
 ### Files considered for copy during policy updates
 
 The default update policy only copies files that match regular expressions

--- a/standalone_self_upgrade.cf.in
+++ b/standalone_self_upgrade.cf.in
@@ -38,7 +38,7 @@ bundle agent main
 
       "cfengine_software";
 
-    am_policy_hub|policy_server::
+    (am_policy_hub|policy_server).!mpf_disable_hub_masterfiles_software_update_seed::
 
       "Master Software Repository Data"
         usebundle => cfengine_master_software_content;


### PR DESCRIPTION
Sometimes (especially in testing environments) it's desirable to avoid
downloading packages to master_software_updates on the hub. This can already be
avoided by carefully defining the trigger_upgrade class so that it is not
defined on the hub, but it's helpful to have an explicit way of disabling this
functionality.

Ticket: ENT-7544
Changelog: Title