### PR TITLE
ENT-7360: Reduced scope of report informing of missing systemd service

### DIFF
--- a/lib/services.cf
+++ b/lib/services.cf
@@ -411,7 +411,7 @@ bundle agent systemd_services(service,state)
         if => "action_custom";
 
   reports:
-    systemd.service_notfound.(inform_mode|verbose_mode)::
+    systemd.service_notfound.(start|restart|reload).(inform_mode|verbose_mode)::
       "$(this.bundle): Could not find service: $(service)";
 }
 


### PR DESCRIPTION
This change restores 71cb6946b2e45c3466f45c0be29cd377508b22ec from CFE-290 which
limits the scope of the report to cases when the desire is to have the service
functioning. When the desire is to have a service not function, a missing
service fufills this desire. Only in the case of desiring a functional service
does is a missing service problematic.

Ticket: ENT-7360
Changelog: Title