### PR TITLE
Make sure systemd service info is always fresh

### DIFF
--- a/lib/services.cf
+++ b/lib/services.cf
@@ -296,7 +296,21 @@ body action fresh_systemd_state
 # Although it's now the same as the 'immediate' action body, this may change in
 # the future.
 {
+    cfengine::
+      # ^Needed for versions 3.15.x and older that did not
+      # support empty bodies. When 3.15.x is no longer
+      # supported, this can be removed.
+
+@if minimum_version(3.18.1)
+      # Beginning with 3.18.1 ifelapsed being set to 0 results in bypassing of
+      # function caching. In versions prior to 3.18, if an action body with
+      # ifelapsed set to 0 was used in a vars type promise a warning was
+      # emitted. This is guarded to suppress that warning in older versions
+      # where this setting would not change the behavior.
+
     ifelapsed => "0";
+@endif
+
 }
 
 bundle agent systemd_services(service,state)
@@ -346,16 +360,10 @@ bundle agent systemd_services(service,state)
       "systemd_properties"
         string => "-pLoadState,CanStop,UnitFileState,ActiveState,LoadState,CanStart,CanReload";
 
-@if minimum_version(3.18.1)
       "systemd_service_info"
         slist => string_split(execresult("$(call_systemctl) $(systemd_properties) show $(service)",
                                          "noshell"), "\n", "10"),
         action => fresh_systemd_state;  # Ensure this info is always fresh and not cached [CFE-3753]
-@else
-      "systemd_service_info"
-        slist => string_split(execresult("$(call_systemctl) $(systemd_properties) show $(service)",
-                                         "noshell"), "\n", "10");
-@endif
 
   classes:
     systemd::

--- a/lib/services.cf
+++ b/lib/services.cf
@@ -287,6 +287,18 @@ bundle agent standard_services(service,state)
 
 }
 
+body action fresh_systemd_state
+# @brief An 'action' body ensuring the state information for a systemd service is always fresh
+#
+# This 'action' body disables caching for functions, in particular the
+# execresult*() family of functions.
+#
+# Although it's now the same as the 'immediate' action body, this may change in
+# the future.
+{
+    ifelapsed => "0";
+}
+
 bundle agent systemd_services(service,state)
 # @brief Manage systemd service state
 # @author Bryan Burke
@@ -334,9 +346,16 @@ bundle agent systemd_services(service,state)
       "systemd_properties"
         string => "-pLoadState,CanStop,UnitFileState,ActiveState,LoadState,CanStart,CanReload";
 
+@if minimum_version(3.18.1)
+      "systemd_service_info"
+        slist => string_split(execresult("$(call_systemctl) $(systemd_properties) show $(service)",
+                                         "noshell"), "\n", "10"),
+        action => fresh_systemd_state;  # Ensure this info is always fresh and not cached [CFE-3753]
+@else
       "systemd_service_info"
         slist => string_split(execresult("$(call_systemctl) $(systemd_properties) show $(service)",
                                          "noshell"), "\n", "10");
+@endif
 
   classes:
     systemd::


### PR DESCRIPTION
The state of a particular systemd service can change during the
agent run, either by external actions or even by actions done by
the agent itself. For this reason, the 'systemd_service_info'
variable holding the information about a state of a system
service needs to be refreshed for every 'services' promise.

Only versions of cf-agent greater than or equal to 3.18.1 support
'ifelapsed => "0"' disabling function caching, older versions
produce a warning for 'vars' promises using 'ifelapsed'.

Ticket: CFE-3753
Changelog: State changes of systemd services during agent run are now properly registered
