### PR TITLE
ENT-7627: Changed IRC channel reference from freenode to libera.chat (3.15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 |  3.10.x | [![Core Build Status](https://travis-ci.com/cfengine/core.svg?branch=3.10.x)](https://travis-ci.com/cfengine/core) | [![MPF Build Status](https://travis-ci.com/cfengine/masterfiles.svg?branch=3.10.x)](https://travis-ci.com/cfengine/masterfiles) |
 
 Looking for help?
-[![Gitter chat](https://badges.gitter.im/cfengine/core.png)](https://gitter.im/cfengine/core) | [![IRC channel](https://kiwiirc.com/buttons/irc.cfengine.com/cfengine.png)](https://kiwiirc.com/client/irc.cfengine.com/#cfengine)
+[![Gitter chat](https://badges.gitter.im/cfengine/core.png)](https://gitter.im/cfengine/core) | [![IRC channel](https://kiwiirc.com/buttons/irc.cfengine.com/cfengine.png)](https://web.libera.chat?channel=#cfengine)
 
 # CFEngine 3 masterfiles
 


### PR DESCRIPTION
Ticket: ENT-7627
Changelog: None
(cherry picked from commit b0ead81d95da3a1a4d60c4622abc36a447f61477)