### PR TITLE
ENT-7573: Corrected link target for Promise Types documentation

### DIFF
--- a/inventory/README.md
+++ b/inventory/README.md
@@ -70,7 +70,7 @@ bundle agent cfe_autorun_inventory_listening_ports
 
 Well, the slist copy is a CFEngine detail (we get the listening ports from the
 monitoring daemon), so just assume that the data is correct. What's important is
-the second line that starts with [`meta`][Promise Types and Attributes#meta].
+the second line that starts with [`meta`][Promise Types#meta].
 That defines metadata for the promise that CFEngine will use to determine that
 this data is indeed inventory data and should be reported to the CFEngine
 Enterprise Hub.


### PR DESCRIPTION
Merge with:
- https://github.com/cfengine/documentation/pull/2530
Ticket: ENT-7573
Changelog: None