### PR TITLE
ENT-7573: Corrected link target for Promise Types documentation (3.15)

### DIFF
--- a/inventory/README.md
+++ b/inventory/README.md
@@ -70,7 +70,7 @@ bundle agent cfe_autorun_inventory_listening_ports
 
 Well, the slist copy is a CFEngine detail (we get the listening ports from the
 monitoring daemon), so just assume that the data is correct. What's important is
-the second line that starts with [`meta`][Promise Types and Attributes#meta].
+the second line that starts with [`meta`][Promise Types#meta].
 That defines metadata for the promise that CFEngine will use to determine that
 this data is indeed inventory data and should be reported to the CFEngine
 Enterprise Hub.


### PR DESCRIPTION
Ticket: ENT-7573
Changelog: None
(cherry picked from commit b4c42afdffb1849cdfe110826adde60f1357c24f)