### PR TITLE
ENT-7628: Improved detection of pure Red Hat

### DIFF
--- a/inventory/redhat.cf
+++ b/inventory/redhat.cf
@@ -4,9 +4,11 @@ bundle common inventory_redhat
 # This common bundle is for Red Hat Linux inventory work.
 {
   classes:
-      "redhat_pure" expression => "redhat.!(centos|oracle|fedora)",
-      comment => "pure Red Hat",
-      meta => { "inventory", "attribute_name=none" };
+      "redhat_pure" or => { strcmp( "$(sys.os_release[ID])" , "rhel" ),  # Red Hat > 7 have /etc/os-release and the ID field is set to rhel
+                            and( "redhat.!(centos|oracle|fedora|rocky)", # Red Hat < 7 does not have /etc/os-release, and is pure if we don't find another known derivative
+                                 not( isvariable( "sys.os_release" )))},
+        comment => "pure Red Hat",
+        meta => { "inventory", "attribute_name=none" };
 
       "redhat_derived" expression => "redhat.!redhat_pure",
       comment => "derived from Red Hat",

--- a/inventory/redhat.cf
+++ b/inventory/redhat.cf
@@ -5,7 +5,7 @@ bundle common inventory_redhat
 {
   classes:
       "redhat_pure" or => { strcmp( "$(sys.os_release[ID])" , "rhel" ),  # Red Hat > 7 have /etc/os-release and the ID field is set to rhel
-                            and( "redhat.!(centos|oracle|fedora|rocky)", # Red Hat < 7 does not have /etc/os-release, and is pure if we don't find another known derivative
+                            and( "redhat.!(centos|oracle|fedora|rocky|almalinux)", # Red Hat < 7 does not have /etc/os-release, and is pure if we don't find another known derivative
                                  not( isvariable( "sys.os_release" )))},
         comment => "pure Red Hat",
         meta => { "inventory", "attribute_name=none" };


### PR DESCRIPTION
This change improves the reliability when detecting a Red Hat system.

- Now if the ID field in `/etc/os-release` is set to `rhel`, the `redhat_pure` class
will be defined.
- If the variable `sys.os_release` does not exist, `redhat_pure` is defined if we have already
defined `redhat` and we do not find classes for well known derivatives
- rocky, a class defined on Rocky Linux was added to the list of well known derivatives
- `almalinux`, a class defined on AlmaLinux was added to the list of well known derivatives

Tickets: ENT-7628, ENT7644
Changelog: Ticket