### PR TITLE
CFE-3775: Added cross reference to packagesmatching functions from MPF tunables (3.18)

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -1328,6 +1328,8 @@ pick up changes made outside packages promises.
 WARNING: Be ware of setting `package_module_query_update_ifelapsed` too low,
 especially with public repositories or you may be banned for abuse.
 
+**See also:** `packagesmatching()`, `packageupdatesmatching()`
+
 **History**:
 
 * Added in 3.15.0, 3.12.3


### PR DESCRIPTION
Ticket: CFE-3775
Changelog: None
(cherry picked from commit 67a8bf15da8d217fbfc1545b46eed83b10251348)