### PR TITLE
CFE-3776: Added test for bundle edit_line append_user_field

### DIFF
--- a/tests/acceptance/lib/files/append_user_field.cf
+++ b/tests/acceptance/lib/files/append_user_field.cf
@@ -1,0 +1,56 @@
+body common control
+{
+      inputs => { '../../default.cf.sub' };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+#######################################################
+
+bundle agent init
+{
+  files:
+
+      # The tested file "actual" is copied from our seeded starting position.
+      "$(G.testfile)"
+      copy_from => local_cp("$(this.promise_filename).start");
+
+     # Next we place the file which we will compare the final result with.
+     "$(G.testfile).expected"
+      copy_from => local_cp("$(this.promise_filename).finish");
+}
+
+#######################################################
+
+bundle agent test
+{
+  meta:
+      "description" -> { "CFE-3776" }
+        string => "Test that append_user_field works as expected";
+
+  vars:
+      "users" slist => { "ZAP", "one", "ZOINK", "two", "three" };
+
+  files:
+
+      "$(G.testfile)"
+        edit_line => append_user_field("root","4", @(users) );
+}
+
+#######################################################
+
+bundle agent check
+{
+  methods:
+      "check"
+      usebundle => dcs_if_diff( "$(G.testfile)", "$(G.testfile).expected",
+                                "pass", "_fail");
+      # Fail the test if any of the files fail.
+
+      "fail"
+        usebundle => dcs_fail( $(this.promise_filename) ),
+        ifvarclass => "_fail";
+
+    pass::
+      "pass"
+        usebundle => dcs_pass( $(this.promise_filename) );
+}

--- a/tests/acceptance/lib/files/append_user_field.cf.finish
+++ b/tests/acceptance/lib/files/append_user_field.cf.finish
@@ -1,0 +1,1 @@
+root:x:0:ZAP,ZOINK,one,pre-existing,three,two

--- a/tests/acceptance/lib/files/append_user_field.cf.start
+++ b/tests/acceptance/lib/files/append_user_field.cf.start
@@ -1,0 +1,1 @@
+root:x:0:pre-existing


### PR DESCRIPTION
The implementation in this bundle from the standard library triggers a bug that
prevents datastate() from being reported. We should have a test before we go
changing the implementation of the standard library, so here it is.

Ticket: CFE-3776
Changelog: None