### PR TITLE
CFE-3776: Dropped un-necessary local variable

### DIFF
--- a/lib/files.cf
+++ b/lib/files.cf
@@ -1005,16 +1005,12 @@ bundle edit_line append_user_field(group,field,allusers)
 # **Note:** To manage local users with CFEngine 3.6 and later,
 # consider making `users` promises instead of modifying system files.
 {
-  vars:
-
-      "val" slist => { @(allusers) };
-
   field_edits:
 
       "$(group):.*"
 
       comment => "Append users into a password file format",
-      edit_field => col(":","$(field)","$(val)","alphanum");
+      edit_field => col(":","$(field)","$(allusers)","alphanum");
 }
 
 ##


### PR DESCRIPTION
The use of this local variable triggers a bug that prevents datastate() from
printing. Since the variable is un-necessary, it's been removed and the
parameter is used directly.

Ticket: CFE-3776
Changelog: Commit