### PR TITLE
ENT-7684: Added variable for excluding files from Policy Analyzer

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -309,6 +309,24 @@ directly in ```/opt/cfengine/dc-scripts```.
 will be deleted the first time this tooling runs. Be wary of local modifications
 before enabling.
 
+### Policy Analyzer Exclude Files
+
+When the policy analyzer is enabled, a copy of the policy is made available for viewing from Mission Portal. To exclude files from this view you can define ```def.cfengine_enterprise_policy_analyzer_exclude_files``` as a list of regular expressions matching files that you do not want to be viewable from Policy Analyzer.
+
+This [augments file][Augments] will prevent any files named `please-no-copy` and any file names that contain `no-copy-me` from being copied and visible from Policy Analyzer.
+
+```json
+{
+  "vars": {
+    "cfengine_enterprise_policy_analyzer_exclude_files": [ "please-no-copy", ".*no-copy-me.*" ]
+  },
+}
+```
+
+**History:**
+
+* Added in 3.19.0, 3.18.1
+
 ### Policy Permissions
 
 By default the policy enforces permissions of ```0600``` meaning that inputs are

--- a/cfe_internal/enterprise/CFE_hub_specific.cf
+++ b/cfe_internal/enterprise/CFE_hub_specific.cf
@@ -740,6 +740,18 @@ bundle agent cfe_internal_enterprise_policy_analyzer
       "analyzer_dir" string => "/opt/cfengine/analyzer/policy/masterfiles";
       "analyzer_source" string => "$(sys.masterdir)";
 
+      "exclude_files" -> { "ENT-7684" }
+        slist => { "" },
+        unless => isvariable( "def.cfengine_enterprise_policy_analyzer_exclude_files" ),
+        comment => concat( "By default policy analyzer will get access to all files, ",
+                           "that are part of the policy." );
+
+      "exclude_files" -> { "ENT-7684" }
+        slist => { "@(def.cfengine_enterprise_policy_analyzer_exclude_files)" },
+        if => isvariable( "def.cfengine_enterprise_policy_analyzer_exclude_files" ),
+        comment => concat( "A list of regular expressions matching file leaf names ",
+                           "that should not be copied for access by policy analyzer." );
+
   classes:
 
     enterprise_edition.policy_server::
@@ -756,7 +768,7 @@ bundle agent cfe_internal_enterprise_policy_analyzer
 
        "$(analyzer_dir)/."
          copy_from => analyzer_sync( $(analyzer_source) ),
-         file_select => all,
+         file_select => default:ex_list( @(exclude_files) ),
          depth_search => recurse_with_base( inf ),
          perms => mog( "400", $(def.cf_apache_user), $(def.cf_apache_group) );
 


### PR DESCRIPTION
This change adds `def.cfengine_enterprise_policy_analyzer_exclude_files` as a
list of regular expressions matching file leaf names that should not be copied
and available from Policy Analyzer.

For example, this def.json will prevent any files named `please-no-copy` and any
file names that contain `no-copy-me` from being copied and visible from Policy
Analyzer.

```
{
  "vars": {
    "cfengine_enterprise_policy_analyzer_exclude_files": [ "please-no-copy", ".*no-copy-me.*" ]
  },
}
```

Ticket: ENT-7684
Changelog: Title