### PR TITLE
ENT-7714: Physical Memory (MB) inventory now handles dmidecode MB or GB units

### DIFF
--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -983,7 +983,7 @@ bundle agent cfe_autorun_inventory_dmidecode
 
     have_dmidecode::
 
-      "$(decoder) -t 17 | $(paths.awk) '/Size.*MB/ {s+=$2} END {print s}' > '$(sys.statedir)/inventory-$(this.bundle)-total-physical-memory-MB.txt'" -> { "CFE-2896" }
+      "$(decoder) -t 17 | $(paths.awk) '/^\tSize:.*MB/ {a+=$2} /^\tSize:.*GB/ {b+=$2*1024} END {print a+b}' > '$(sys.statedir)/inventory-$(this.bundle)-total-physical-memory-MB.txt'" -> { "CFE-2896", "ENT-7714" }
         contain => in_shell,
         if => not( fileexists( "$(sys.statedir)/inventory-$(this.bundle)-total-physical-memory-MB.txt") );
 


### PR DESCRIPTION
In dmidecode 2.11 larger memory devices started being reported in GB units
instead of only MB. This change handles that case by converting GB to MB when
found.

Ticket: ENT-7714
Changelog: Title