### PR TITLE
CFE-3795: Autorun bundles now run regardless of locks (3.18)

### DIFF
--- a/lib/autorun.cf
+++ b/lib/autorun.cf
@@ -16,7 +16,9 @@ bundle agent autorun
 
   methods:
     services_autorun::
-      "autorun" usebundle => $(sorted_bundles);
+      "autorun" -> { "CFE-3795" }
+        usebundle => $(sorted_bundles),
+        action => immediate;
 
   reports:
     DEBUG|DEBUG_autorun|DEBUG_services_autorun::


### PR DESCRIPTION
Previously, when the autorun feature was enabled to automatically run bundles
tagged with autorun the bundle actuation was affected by promise locking. The
effect of this is that agent runs that happen close together would skip running
bundles run within the last minute. Now autorun bundles no longer wait for a
lock to expire, they will be actuated each agent execution. Note, promises
within those bundles have their own locks which still apply.

Ticket: CFE-3795
Changelog: commit
(cherry picked from commit 58d8b14953ff0b3c0fcb3c778cf8a4cb2007bd23)