### PR TITLE
CFE-3790: Added lsmod to well known paths (3.15)

### DIFF
--- a/lib/paths.cf
+++ b/lib/paths.cf
@@ -170,6 +170,7 @@ bundle common paths
 
     linux::
       "path[lsattr]"        string => "/usr/bin/lsattr";
+      "path[lsmod]"         string => "/sbin/lsmod";
       "path[tar]"           string => "/bin/tar";
       "path[true]"          string => "/bin/true";
       "path[false]"         string => "/bin/false";


### PR DESCRIPTION
Ticket: CFE-3790
Changelog: Title
(cherry picked from commit d8b41ddf7d0279c2db8815548b0774ad456e45ef)