### PR TITLE
CFE-3799 Fixed services_autorun_bundles only case

### DIFF
--- a/lib/autorun.cf
+++ b/lib/autorun.cf
@@ -15,7 +15,7 @@ bundle agent autorun
         comment => "Lexicographically sorted bundles for predictable order";
 
   methods:
-    services_autorun::
+    services_autorun|services_autorun_bundles::
       "autorun" -> { "CFE-3795" }
         usebundle => $(sorted_bundles),
         action => immediate;

--- a/promises.cf.in
+++ b/promises.cf.in
@@ -340,8 +340,6 @@ bundle common services_autorun
 {
   vars:
     services_autorun|services_autorun_inputs::
-      "inputs" slist => { "$(sys.local_libdir)/autorun.cf" };
-
       "_default_autorun_input_dir"
         string => "$(this.promise_dirname)/services/autorun";
       "_default_autorun_inputs"
@@ -366,6 +364,7 @@ bundle common services_autorun
       "bundles" slist => { "services_autorun" }; # run self
 
     services_autorun|services_autorun_inputs|services_autorun_bundles::
+      "inputs" slist => { "$(sys.local_libdir)/autorun.cf" };
       "bundles" slist => { "autorun" }; # run loaded bundles
 
   reports:


### PR DESCRIPTION
If only this class is defined then services_autorun.inputs was undefined
and caused an error in promises.cf

Ticket: CFE-3799
Changelog: title