### PR TITLE
ENT-7359 Removed build dir from install/dist targets

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -30,17 +30,5 @@ tar-package:
 	)  ;  \
 	[ x$$pkgdir != x ]  &&  rm -rf $$pkgdir
 
-# copy package modules for tests to build directory
-vendored := modules/packages/vendored
-modules := $(patsubst $(vendored)/%.mustache,build/modules/packages/%,$(wildcard $(vendored)/*.mustache))
-
-all-local: $(modules)
-
-build/modules/packages/%:
-	mkdir -p build/modules/packages
-	TEMPLATE=$$(echo $@ | sed 's,build/modules/packages,modules/packages/vendored,'); \
-	cp $$TEMPLATE.mustache $@
-	chmod +x $@
-
 clean-local:
 	rm -rf build

--- a/configure.ac
+++ b/configure.ac
@@ -227,11 +227,6 @@ do
     done
 done
 
-for i in `find "$srcdir/modules/packages/vendored" -type f`
-do
-    # add .mustache files, but from build dir instead to support ci/tests
-    MASTERFILES_INSTALL_TARGETS="$MASTERFILES_INSTALL_TARGETS `echo $i | sed -e 's,vendored/,,' -e 's,modules,build/modules,' -e 's,.mustache,,'`"
-done
 
 AC_SUBST(MASTERFILES_INSTALL_TARGETS)
 

--- a/tests/acceptance/17_packages/10_new/unsafe/the_great_package_test.cf
+++ b/tests/acceptance/17_packages/10_new/unsafe/the_great_package_test.cf
@@ -50,6 +50,16 @@ bundle agent init
     debian|redhat::
       "setup_python_symlink" usebundle => cfe_internal_setup_python_symlink("$(python_path)");
 
+  files:
+    "${sys.workdir}/modules/packages/."
+      create => "true";
+
+    debian::
+      "${sys.workdir}/modules/packages/apt_get"
+        copy_from => local_cp("${sys.workdir}/modules/packages/vendored/apt_get.mustache");
+    redhat::
+      "${sys.workdir}/modules/packages/yum"
+        copy_from => local_cp("${sys.workdir}/modules/packages/vendored/yum.mustache");
 }
 
 bundle agent log_test_case(msg)

--- a/tests/acceptance/17_packages/10_new/unsafe/the_great_package_test_generator.py
+++ b/tests/acceptance/17_packages/10_new/unsafe/the_great_package_test_generator.py
@@ -133,6 +133,16 @@ bundle agent init
     debian|redhat::
       "setup_python_symlink" usebundle => cfe_internal_setup_python_symlink("$(python_path)");
 
+  files:
+    "${sys.workdir}/modules/packages/."
+      create => "true";
+
+    debian::
+      "${sys.workdir}/modules/packages/apt_get"
+        copy_from => local_cp("${sys.workdir}/modules/packages/vendored/apt_get.mustache");
+    redhat::
+      "${sys.workdir}/modules/packages/yum"
+        copy_from => local_cp("${sys.workdir}/modules/packages/vendored/yum.mustache");
 }
 
 bundle agent log_test_case(msg)

--- a/tests/acceptance/testall
+++ b/tests/acceptance/testall
@@ -74,7 +74,7 @@ fi
 # where the binaries are.
 
 # Common flags
-FLAGS="--include=$TEST_DIR/../../build/modules --baseclasses=AUTO,DEBUG,EXTRA,testing_masterfiles_policy_framework"
+FLAGS="--include=$TEST_DIR/../../modules --baseclasses=AUTO,DEBUG,EXTRA,testing_masterfiles_policy_framework"
 
 
 # Was --bindir in the arguments?

--- a/tests/unit/test_package_module_apt_get
+++ b/tests/unit/test_package_module_apt_get
@@ -1,7 +1,9 @@
 #!/usr/bin/python
 
-import sys
 import os
+import shutil
+import sys
+import tempfile
 
 try:
     import subprocess
@@ -9,7 +11,11 @@ except ImportError:
     # Redhat 4 doesn't have subprocess. 77 means "skip test"
     sys.exit(77)
 
-apt_get_module = "../../build/modules/packages/apt_get"
+# if an exception occurs, this tmpdir won't be cleaned up, this is desired to aid in debugging
+tmpdir = tempfile.mkdtemp()
+mustache_file = os.path.realpath("../../modules/packages/vendored/apt_get.mustache")
+apt_get_module = os.path.join(tmpdir, "apt_get")
+shutil.copy(mustache_file, apt_get_module)
 
 cwd = os.getcwd()
 # Will cause the package module to call these instead.
@@ -239,3 +245,4 @@ assert check("get-package-data", ["File=repo/pkg"], 2,
              ["""PackageType=repo
 Name=repo/pkg"""],
              1, ["apt-get -v"])
+shutil.rmtree(tmpdir)

--- a/tests/unit/test_package_module_yum
+++ b/tests/unit/test_package_module_yum
@@ -1,7 +1,9 @@
 #!/usr/bin/python
 
-import sys
 import os
+import shutil
+import sys
+import tempfile
 
 try:
     import subprocess
@@ -9,7 +11,11 @@ except ImportError:
     # Redhat 4 doesn't have subprocess. 77 means "skip test"
     sys.exit(77)
 
-yum_module = "../../build/modules/packages/yum"
+# if an exception occurs, this tmpdir won't be cleaned up, this is desired to aid in debugging
+tmpdir = tempfile.mkdtemp()
+mustache_file = os.path.realpath("../../modules/packages/vendored/yum.mustache")
+yum_module = os.path.join(tmpdir, "yum")
+shutil.copy(mustache_file, yum_module)
 
 cwd = os.getcwd()
 # Will cause the package module to call these instead.
@@ -156,3 +162,4 @@ assert check("get-package-data", ["File=repo_pkg"], 2,
 assert check("get-package-data", ["File=repo/pkg"], 2,
              ["PackageType=repo\nName=repo/pkg"],
              0, [])
+shutil.rmtree(tmpdir)


### PR DESCRIPTION
Instead of creating files from .mustache templates
just copy them over in the tests where they are needed:

tests/unit/test_package_module_apt_get
tests/unit/test_package_module_yum

Ticket: ENT-7359
Changelog: title