### PR TITLE
ENT-7733: Removed promise of perms on modules in inputs (3.18)

### DIFF
--- a/cfe_internal/update/update_policy.cf
+++ b/cfe_internal/update/update_policy.cf
@@ -260,7 +260,6 @@ bundle agent cfe_internal_update_policy_cpv
       handle => "cfe_internal_update_policy_files_modules_dir",
       copy_from => u_rcp("$(modules_dir_source)", @(update_def.policy_servers)),
       depth_search => u_recurse("inf"),
-      perms => u_m("755"),
       action => u_immediate;
 
     update_inputs_not_kept::


### PR DESCRIPTION
This change removes explicit enforcement of permissions for modules in inputs.
Instead of explicitly enforcing permissions in inputs, we rely on the default
permissions (600). The previous explicit permissions (755) are un-necessary as
modules are not executed from within the inputs directory and have resulted in
permission flip-flopping in some environments. Permissions on modules in the
modules dir (sys.workdir)/modules are still enforced.

Ticket: ENT-7733
Changelog: Title
