### PR TITLE
ENT-7730: Promised permissions for Mission Portal application and Apache log files (3.15.x)

### DIFF
--- a/cfe_internal/enterprise/CFE_knowledge.cf
+++ b/cfe_internal/enterprise/CFE_knowledge.cf
@@ -160,11 +160,25 @@ bundle agent cfe_internal_setup_knowledge
       create => "true",
       perms => mog("0640", $(def.cf_apache_user), $(def.cf_apache_group));
 
+      "$(sys.workdir)/httpd/logs/application/." -> { "ENT-7730" }
+        comment => "Ensure permissions for $(sys.workdir)/httpd/logs/application/.*",
+        handle => "cfe_internal_setup_knowledge_files_httpd_application_log_files",
+        file_select => plain,
+        depth_search => recurse( "inf" ),
+        perms => mog("0600", $(def.cf_apache_user), $(def.cf_apache_group));
+
       "$(sys.workdir)/httpd/logs/."
       comment => "Ensure permissions for $(sys.workdir)/httpd/logs",
-      handle => "cfe_internal_setup_knowledge_files_httpd_logs",
+      handle => "cfe_internal_setup_knowledge_files_httpd_logs_dir",
       create => "true",
       perms => mog("0640", $(def.cf_apache_user), $(def.cf_apache_group));
+
+      "$(sys.workdir)/httpd/logs/." -> { "ENT-7730" }
+        comment => "Ensure permissions for $(sys.workdir)/httpd/logs",
+        handle => "cfe_internal_setup_knowledge_files_httpd_log_files",
+        file_select => plain,
+        depth_search => recurse_with_base( "0" ),
+        perms => mog("0600", root, root);
 
       "$(cfe_internal_hub_vars.docroot)/../ssl/."
         perms => mog("0440", "root", "root" ),


### PR DESCRIPTION
This change ensures that both Mission Portal and Apache log files have
restrictive permissions. Previously this was un-managed.