### PR TITLE
Sort output from ssh-keyscan in FR policy

### DIFF
--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -737,7 +737,7 @@ bundle agent setup_status
     "ssh_server_fingerprint"
       # ssh-keyscan is used because it's more reliable/easy than trying to
       # parse sshd config to find the file and then readfile():
-      string => execresult("ssh-keyscan localhost 2>/dev/null | sed 's/localhost //g'", useshell);
+      string => execresult("ssh-keyscan localhost 2>/dev/null | sed 's/localhost //g' | sort", useshell);
   classes:
     "superhub_setup_status_complete"
       expression => "any",


### PR DESCRIPTION
So that we get consistent data and avoid repairing a config JSON
just because the keys are in a different order.

Ticket: ENT-7967
Changelog: setup-status.json is no longer being repaired over and over on FR feeder hubs