### PR TITLE
Sort output from ssh-keyscan in FR policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ Notable changes to the framework should be documented here
 	- controls/cf_serverd.cf no longer specifies explicit
 	  default for bindtointerface and relies on the default
 	  binding to both :: and 0.0.0.0 on IPV6-enabled hosts (ENT-7362)
+	- setup-status.json is no longer being repaired over and over on FR feeder hubs
+	  (ENT-7967)
 
 3.18.0:
 	- Added .ps1 to list of file patterns considered during policy update

--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -737,7 +737,7 @@ bundle agent setup_status
     "ssh_server_fingerprint"
       # ssh-keyscan is used because it's more reliable/easy than trying to
       # parse sshd config to find the file and then readfile():
-      string => execresult("ssh-keyscan localhost 2>/dev/null | sed 's/localhost //g'", useshell);
+      string => execresult("ssh-keyscan localhost 2>/dev/null | sed 's/localhost //g' | sort", useshell);
   classes:
     "superhub_setup_status_complete"
       expression => "any",


### PR DESCRIPTION
So that we get consistent data and avoid repairing a config JSON
just because the keys are in a different order.

Ticket: ENT-7967
Changelog: setup-status.json is no longer being repaired over and over on FR feeder hubs
(cherry picked from commit af872c3a700b6a0f3020e8a32db93114ddc1ebf0)