### PR TITLE
ENT-8065: Gave cfapache group full access to docroot (3.15)

### DIFF
--- a/cfe_internal/enterprise/CFE_knowledge.cf
+++ b/cfe_internal/enterprise/CFE_knowledge.cf
@@ -52,10 +52,10 @@ bundle agent cfe_internal_setup_knowledge
         perms => mog("0600", "root", "root" );
 
       "$(cfe_internal_hub_vars.docroot)"
-      comment => "All files in there should be at least 0644",
+      comment => "All files in there should be at least 0460. Giving cfapache group full access",
       handle => "cfe_internal_setup_knowledge_files_doc_root_2",
       file_select => cfe_internal_docroot_perms,
-      perms => mog("0440", "root", $(def.cf_apache_group) ),
+      perms => mog("0460", "root", $(def.cf_apache_group) ),
       depth_search => recurse_exclude("inf");   # see exclude dirs in recurse_exclude() body
 
       "$(cfe_internal_hub_vars.docroot)/.htaccess"


### PR DESCRIPTION
Policy Analyzer was not able to be enabled because
the flagfile could not be written due to policy which
prohibited write access to /var/cfengine/httpd/htdocs
for cfapache user/group.

Ticket: ENT-8065
Changelog: title
(cherry picked from commit a8e59558d9432a0608b5b1f9530728e193deffb1)