### PR TITLE
ENT-8079: Plumbing in support of distributing compliance reports from cfbs modules

### DIFF
--- a/.no-distrib/README.md
+++ b/.no-distrib/README.md
@@ -1,0 +1,3 @@
+This directory is *excluded* from policy updates.
+
+Place things here that are primarily useful on your policy distribution servers or that your policy will explicitly copy from.

--- a/MPF.md
+++ b/MPF.md
@@ -14,6 +14,7 @@ various aspects of the system.
 * `services/main.cf` - Contains an empty bundle agent main where custom policy
   can be integrated.
 * `services/autorun/` - Automatically included policy files.
+* `.no-distrib/` - A directory that is excluded from policy updates from remote agents.
 
 The MPF is continually updated. You can track its development
 on [github](https://github.com/cfengine/masterfiles/).

--- a/cfe_internal/update/update_policy.cf
+++ b/cfe_internal/update/update_policy.cf
@@ -247,7 +247,7 @@ bundle agent cfe_internal_update_policy_cpv
       comment => "Copy policy updates from master source on policy server if a new validation was acquired",
       handle => "cfe_internal_update_policy_files_inputs_dir",
       copy_from => u_rcp("$(master_location)", @(update_def.policy_servers)),
-      depth_search => u_infinate_client_policy,
+      depth_search => u_infinite_client_policy,
       file_select  => u_input_files,
       action => u_immediate,
       classes => u_results("bundle", "update_inputs"),
@@ -572,7 +572,7 @@ body depth_search u_recurse(d)
 
 #########################################################
 
-body depth_search u_infinate_client_policy
+body depth_search u_infinite_client_policy
 # @brief Search recursively for files excluding vcs related files and .no-distrib directories
 # @param d Maximum depth to search recursively
 # Duplicated in embedded bootstrap/failsafe

--- a/cfe_internal/update/update_policy.cf
+++ b/cfe_internal/update/update_policy.cf
@@ -247,7 +247,7 @@ bundle agent cfe_internal_update_policy_cpv
       comment => "Copy policy updates from master source on policy server if a new validation was acquired",
       handle => "cfe_internal_update_policy_files_inputs_dir",
       copy_from => u_rcp("$(master_location)", @(update_def.policy_servers)),
-      depth_search => u_recurse("inf"),
+      depth_search => u_infinate_client_policy,
       file_select  => u_input_files,
       action => u_immediate,
       classes => u_results("bundle", "update_inputs"),
@@ -570,6 +570,16 @@ body depth_search u_recurse(d)
       exclude_dirs => { "\.svn", "\.git", "git-core" };
 }
 
+#########################################################
+
+body depth_search u_infinate_client_policy
+# @brief Search recursively for files excluding vcs related files and .no-distrib directories
+# @param d Maximum depth to search recursively
+# Duplicated in embedded bootstrap/failsafe
+{
+        depth => "inf";
+        exclude_dirs => { "\.svn", "\.git", "git-core", "\.no-distrib" };
+}
 #########################################################
 
 body depth_search u_recurse_basedir(d)

--- a/controls/cf_serverd.cf
+++ b/controls/cf_serverd.cf
@@ -93,6 +93,10 @@ bundle server mpf_default_access_rules()
       if => isdir( "$(def.dir_masterfiles)/" ),
       admit => { @(def.acl) };
 
+      "$(def.dir_masterfiles)/.no-distrib" -> { "ENT-8079" }
+      handle => "prevent_distribution_of_top_level_dot_no_distrib",
+      deny => { "0.0.0.0/0" };
+
       "$(def.dir_bin)/"
       handle => "server_access_grant_access_binary",
       comment => "Grant access to binary for cf-runagent",


### PR DESCRIPTION
Merge together:
- https://github.com/cfengine/core/pull/4882
- https://github.com/cfengine/documentation/pull/2597

These changes to the MPF add .no-distrib as a directory that should not be copied as part of policy update so that cfbs modules could populate this directory with assets that should not be implicitly distributed but are not necessarily explicitly prohibited from distribution.