### PR TITLE
ENT-7870 Remove inaccurate build badges (3.18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,3 @@
-| Version | Core                                                                                                               | MPF                                                                                                                             |
-|---------|--------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
-|  master | [![Core Build Status](https://travis-ci.com/cfengine/core.svg?branch=master)](https://travis-ci.com/cfengine/core) | [![MPF Build Status](https://travis-ci.com/cfengine/masterfiles.svg?branch=master)](https://travis-ci.com/cfengine/masterfiles) |
-|  3.15.x | [![Core Build Status](https://travis-ci.com/cfengine/core.svg?branch=3.15.x)](https://travis-ci.com/cfengine/core) | [![MPF Build Status](https://travis-ci.com/cfengine/masterfiles.svg?branch=3.15.x)](https://travis-ci.com/cfengine/masterfiles) |
-|  3.12.x | [![Core Build Status](https://travis-ci.com/cfengine/core.svg?branch=3.12.x)](https://travis-ci.com/cfengine/core) | [![MPF Build Status](https://travis-ci.com/cfengine/masterfiles.svg?branch=3.12.x)](https://travis-ci.com/cfengine/masterfiles) |
-|  3.10.x | [![Core Build Status](https://travis-ci.com/cfengine/core.svg?branch=3.10.x)](https://travis-ci.com/cfengine/core) | [![MPF Build Status](https://travis-ci.com/cfengine/masterfiles.svg?branch=3.10.x)](https://travis-ci.com/cfengine/masterfiles) |
-
 Looking for help?
 [![Gitter chat](https://badges.gitter.im/cfengine/core.png)](https://gitter.im/cfengine/core) | [![IRC channel](https://kiwiirc.com/buttons/irc.cfengine.com/cfengine.png)](https://web.libera.chat?channel=#cfengine)
 


### PR DESCRIPTION
Travis badges are for any PRs on the branches so not what we want.
Jenkins badges aren't accurate either due to lack of known
issue exceptions.

Ticket: ENT-7870
Changelog: none
(cherry picked from commit 0a4cffa32ddc2f0fbf844bf6aced62784a79d5d6)