### PR TITLE
ENT-8294 Remove version condition on FR clean_when_off bundle

### DIFF
--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -676,8 +676,7 @@ bundle agent entry
     am_policy_hub.(am_off|config_not_exists)::
       "CFEngine Enterprise Federation Transport Off"
         handle => "clean_when_off",
-        usebundle => clean_when_off,
-        if => cf_version_minimum("3.15");
+        usebundle => clean_when_off;
     enabled.am_on::
       "CFEngine Enterprise Federation Transport User"
         handle => "transport_user",


### PR DESCRIPTION
It is no longer needed now that we check for the existence
of the FR tables to truncate.
cf_version_minimum is not even support until 3.16 so can't
really be used to check for 3.15 and newer.

Ticket: ENT-8294
Changelog: title