### PR TITLE
ENT-8294 Only run clean_when_off FR bundle when needed (master)

### DIFF
--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -316,6 +316,10 @@ bundle agent clean_when_off
   vars:
     "user" string => "$(cfengine_enterprise_federation:transport_user.user)";
     "home" string => "$(cfengine_enterprise_federation:transport_user.home)";
+@if minimum_version(3.15)
+    "remote_hubs_row_count" string => execresult(`$(sys.bindir)/psql cfsettings --quiet --tuples-only --command "SELECT COUNT(*) FROM remote_hubs" 2>/dev/null`, useshell);
+    "federated_reporting_settings_row_count" string => execresult(`$(sys.bindir)/psql cfsettings --quiet --tuples-only --command "SELECT COUNT(*) FROM federated_reporting_settings" 2>/dev/null`, useshell);
+@endif
 
   users:
     "$(user)"
@@ -335,14 +339,15 @@ bundle agent clean_when_off
     "remote_hubs_table_empty" expression => returnszero(`[ $(const.dollar)($(sys.bindir)/psql cfsettings --quiet --tuples-only --command "SELECT COUNT(*) FROM remote_hubs") -eq "0"]`, "useshell");
     "federated_reporting_settings_table_empty" expression => returnszero(`[ $(const.dollar)($(sys.bindir)/psql cfsettings --quiet --tuples-only --command "SELECT COUNT(*) FROM federated_reporting_settings") -eq "0"]`, "useshell");
 
+
   commands:
       # Oh, the humanity! Where for art thou databases: promises for psql!
-      !remote_hubs_table_empty::
-        `$(sys.bindir)/psql cfsettings --quiet --command "TRUNCATE TABLE remote_hubs"` -> { "ENT-7233" };
-      !federated_reporting_settings_table_empty::
-        `$(sys.bindir)/psql cfsettings --quiet --command "TRUNCATE TABLE federated_reporting_settings"` -> { "ENT-7233" };
+      `$(sys.bindir)/psql cfsettings --quiet --command "TRUNCATE TABLE remote_hubs"` -> { "ENT-7233" }
+        if => isgreaterthan( "$(remote_hubs_table_row_count)", "0" );
+      `$(sys.bindir)/psql cfsettings --quiet --command "TRUNCATE TABLE federated_reporting_settings"` -> { "ENT-7233" }
+        if => isgreaterthan( "$(federated_reporting_settings_table_row_count)", "0" );
 
-      # _stdlib_path_exists_<command> and paths.<command> are defined is masterfiles/lib/paths.cf
+      # _stdlib_path_exists_<command> and paths.<command> are defined in masterfiles/lib/paths.cf
     selinux_enabled.default:_stdlib_path_exists_semanage.has_cftransport_fcontext::
       "$(paths.semanage) fcontext -d '$(home)/.ssh(/.*)?'";
 


### PR DESCRIPTION
Only on 3.15 and newer hubs when the remote_hubs and
federated_reporting_settings tables have rows in them.

Ticket: ENT-8294
Changelog: title
(cherry picked from commit 85bdb768206a4a378889ffeb132e1a0cab8a6fda)

 Conflicts:
	cfe_internal/enterprise/federation/federation.cf