### PR TITLE
ENT-8274: Added support for Amazon Linux in standalone self upgrade (3.18)

### DIFF
--- a/standalone_self_upgrade.cf.in
+++ b/standalone_self_upgrade.cf.in
@@ -217,8 +217,9 @@ bundle agent cfengine_software_version
 # upgrading.
 {
   classes:
-      "__supported_platform" -> { "ENT-5045", "ENT-5152", "ENT-4094" }
+      "__supported_platform" -> { "ENT-5045", "ENT-5152", "ENT-4094", "ENT-8247" }
         or => {
+                "amazon_linux",
                 "redhat.!redhat_4",
                 "centos.!centos_4",
                 "debian",
@@ -231,7 +232,7 @@ bundle agent cfengine_software_version
 
       # Add "windows" to __new_implementation classes with ENT-6823
       "__new_implementation"
-        or => { "redhat", "centos", "ubuntu", "debian", "suse", "opensuse" };
+        or => { "amazon_linux", "redhat", "centos", "ubuntu", "debian", "suse", "opensuse" };
 
   vars:
       "pkg_name" string => "$(cfengine_software.pkg_name)";
@@ -281,7 +282,7 @@ bundle agent cfengine_software_version_packages2
 
   packages:
 
-    (redhat|centos)::
+    (amazon_linux|redhat|centos)::
       "$(local_software_dir)/$(cfengine_package_names.my_pkg)"
       policy => "present",
       package_module => yum,


### PR DESCRIPTION
Prior to this change Amazon Linux hosts (based on redhat|fedora) would not
attempt to upgrade themselves as they were not explicitly supported. With this
change hosts that have the amazon_linux class defined will use the same
methodology as redhat and centos hosts with respect to self upgrade.

Ticket: ENT-8274
Changelog: Title
(cherry picked from commit e4831d12046c5a9e470b2dce4612c34de3e1359d)