### PR TITLE
Auto-detect current release and add it to policy - 3.18.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ stamp-h1
 /ylwrap
 /test-driver
 CFVERSION
+CFRELEASE
 
 # Misc.
 /cf_promises_*

--- a/autogen.sh
+++ b/autogen.sh
@@ -11,6 +11,11 @@ rm -f CFVERSION
 misc/determine-version.sh .CFVERSION > CFVERSION \
     || echo "$0: Unable to auto-detect CFEngine version, continuing"
 
+echo "$0: Running determine-release.sh ..."
+rm -f CFRELEASE
+misc/determine-release.sh CFRELEASE \
+    || { echo "$0: Unable to auto-detect CFEngine release, continuing"; echo 1 >CFRELEASE; }
+
 echo "$0: Running autoreconf ..."
 [ ! -d m4 ] && mkdir m4
 autoreconf -Wno-portability --force --install -I m4  ||  exit $?

--- a/cfe_internal/update/update_bins.cf
+++ b/cfe_internal/update/update_bins.cf
@@ -160,7 +160,7 @@ bundle agent cfe_internal_update_bins
       package_policy => "update",
       package_select => "==",            # picks the newest Nova available
       package_architectures => { "$(pkgarch)" },
-      package_version => "$(update_def.current_version)-1",
+      package_version => "$(update_def.current_version)-$(update_def.current_release)",
       package_method => u_generic( "$(local_software_dir)" ),
       if => "nova_edition.have_software_dir",
       classes => u_if_else("bin_update_success", "bin_update_fail");

--- a/configure.ac
+++ b/configure.ac
@@ -32,7 +32,10 @@ m4_undefine([cfversion])
 m4_undefine([cfversion_from_file])
 m4_undefine([cfversion_from_env])
 
-AS_IF([test -n "$RELEASE"], [AC_SUBST([RELEASE], ["$RELEASE"])], [AC_SUBST([RELEASE], [1])])
+m4_define([cfrelease], m4_normalize(m4_esyscmd([cat CFRELEASE])))
+AC_SUBST([RELEASE], [cfrelease])
+cfengine_release=cfrelease
+m4_undefine([cfrelease])
 
 AC_CANONICAL_TARGET
 
@@ -158,6 +161,7 @@ dnl ######################################################################
 AC_MSG_RESULT()
 AC_MSG_RESULT(Summary:)
 AC_MSG_RESULT(Version              -> $cfengine_version)
+AC_MSG_RESULT(Release              -> $cfengine_release)
 AM_COND_IF(HAVE_CORE,
     AC_MSG_RESULT(Core directory       -> $core_dir),
     AC_MSG_RESULT(Core directory       -> not set - tests are disabled)

--- a/controls/update_def.cf.in
+++ b/controls/update_def.cf.in
@@ -8,6 +8,7 @@ bundle common update_def
     any::
 
       "current_version" string => "@VERSION@";
+      "current_release" string => "@RELEASE@";
 
       # MPF Controls
 

--- a/misc/determine-release.sh
+++ b/misc/determine-release.sh
@@ -1,0 +1,49 @@
+# This script tries to figure out proper RELEASE number
+# and saves its best guess to CFRELEASE file passed as 1st and the only argument.
+
+# It checks $EXPLICIT_RELEASE, $RELEASE, and git tags.
+# If nothing helps, it defaults to 1.
+
+if [ "$#" -ne 1 ]
+then
+    echo "Usage: determine-release.sh path/to/CFRELEASE"
+    exit 1
+fi
+
+if [ "$EXPLICIT_RELEASE" ]; then
+	echo "EXPLICIT_RELEASE is set, using it"
+	echo "$EXPLICIT_RELEASE" > "$1"
+	exit 0
+fi
+
+if [ "$RELEASE" ]; then
+	echo "RELEASE is set, using it"
+	echo "$RELEASE" > "$1"
+	exit 0
+fi
+
+all_tags="$(git tag --points-at HEAD)"
+
+if [ -z "$all_tags" ]; then
+	echo "No tags found, using default release number 1"
+	echo 1 > "$1"
+	exit 0
+fi
+
+echo "All tags pointing to current commit:"
+echo "$all_tags"
+
+full_version="$(echo "$all_tags" | sed 's/-build[0-9]*$//' | sort -u | tail -n1)"
+
+echo "Latest version: $full_version"
+
+if ! expr "$full_version" : "3.*-\([0-9]*\)$" >/dev/null; then
+	echo "Could not parse it, using default release number 1"
+	echo 1 > "$1"
+	exit 0
+fi
+
+release="$(expr "$full_version" : "3.*-\([0-9]*\)$")"
+echo "Using release number from version: $release"
+echo "$release" > "$1"
+exit 0

--- a/standalone_self_upgrade.cf.in
+++ b/standalone_self_upgrade.cf.in
@@ -83,7 +83,7 @@ bundle agent cfengine_software
       # Default desired CFEngine software
       "pkg_name" string => ifelse( isvariable( "def.cfengine_software_pkg_name" ), $(def.cfengine_software_pkg_name), "cfengine-nova");
       "pkg_version" string => ifelse( isvariable( "def.cfengine_software_pkg_version" ), $(def.cfengine_software_pkg_version), "@VERSION@");
-      "pkg_release" string => ifelse( isvariable( "def.cfengine_software_pkg_release" ), $(def.cfengine_software_pkg_release), "1");
+      "pkg_release" string => ifelse( isvariable( "def.cfengine_software_pkg_release" ), $(def.cfengine_software_pkg_release), "@RELEASE@");
       "pkg_arch" string => ifelse( isvariable( "def.cfengine_software_pkg_arch" ), $(def.cfengine_software_pkg_arch), "x86_64");
       "package_dir" string => ifelse( isvariable( "def.cfengine_software_pkg_dir" ), $(def.cfengine_software_pkg_dir), "$(sys.flavour)_$(sys.arch)");
       "pkg_edition_path" string => ifelse( isvariable( "def.cfengine_software_pkg_edition_path" ), $(def.cfengine_software_pkg_edition_path), "enterprise/Enterprise-$(pkg_version)/agent");


### PR DESCRIPTION
For self-update needs.

Current release number is taken from env variables, or detected from git
tags. If everything else fails, it defaults to '1' as before.

Ticket: ENT-4822
(cherry picked from commit 2ec642c0e66f9bbe2455b352b6cbb07a2c3f64b4)