### PR TITLE
Add a test that custom promises are only evaluated once in an agent run

### DIFF
--- a/tests/acceptance/30_custom_promise_types/22_single_evaluation.cf
+++ b/tests/acceptance/30_custom_promise_types/22_single_evaluation.cf
@@ -1,0 +1,86 @@
+######################################################
+#
+#  Test that custom promises are only evaluated once, just like other promises
+#
+#####################################################
+body common control
+{
+    inputs => { "../default.cf.sub" };
+    bundlesequence => { "init", "test", "check" };
+}
+
+#######################################################
+
+bundle common version_check
+{
+  classes:
+    "python_version_compatible_with_cfengine_library"
+      expression => returnszero("/usr/bin/python3 -c 'import sys; assert sys.version_info >= (3,6)'", "useshell");
+@if minimum_version(3.20.0)
+    "custom_promises_locking" expression => "any";
+@endif
+}
+
+bundle agent init
+{
+  meta:
+      "test_skip_unsupported" string => "!custom_promises_locking|!python_version_compatible_with_cfengine_library";
+
+  files:
+      "$(G.testfile)"
+        delete => init_delete;
+
+      "$(this.promise_dirname)/cfengine.py"
+        copy_from => local_cp("$(this.promise_dirname)/../../../modules/promises/cfengine.py");
+}
+
+body delete init_delete
+{
+      dirlinks => "delete";
+      rmdirs   => "true";
+}
+
+#######################################################
+
+@if minimum_version(3.18.0)
+promise agent append
+{
+    interpreter => "/usr/bin/python3";
+    path => "$(this.promise_dirname)/append_promises.py";
+}
+
+bundle agent test
+{
+  meta:
+    "description" -> { "CFE-3434" }
+      string => "Test that custom promises are only evaluated once";
+
+  append:
+    "$(G.testfile)"
+      string => "hello",
+      always => "true";
+}
+@endif
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+      "expected"
+        string => "hello";
+      "found"
+        string => readfile("$(G.testfile)");
+
+  classes:
+      "ok"
+        expression => strcmp("$(expected)", "$(found)");
+
+  reports:
+    DEBUG::
+      "Expected '$(expected)', found '$(found)'";
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/30_custom_promise_types/append_promises.py
+++ b/tests/acceptance/30_custom_promise_types/append_promises.py
@@ -31,11 +31,21 @@ class AppendPromiseTypeModule(PromiseModule):
         if type(attributes["string"]) != str:
             raise ValidationError("Attribute 'string' must be of type string")
 
+        if "always" in attributes and attributes["always"] not in ("true", "false"):
+            raise ValidationError("Attribute 'always' must be either 'true' or 'false'")
+
     def evaluate_promise(self, promiser, attributes):
         assert "string" in attributes
 
+        always = attributes.get("always", "false") == "true"
+
         try:
             with open(promiser, "a+") as f:
+                if always:
+                    f.write(attributes["string"])
+                    self.log_verbose("Promise '%s' repaired" % promiser)
+                    return Result.REPAIRED
+
                 f.seek(0)
                 if (attributes["string"] not in f.read()):
                     f.write(attributes["string"])
@@ -44,6 +54,7 @@ class AppendPromiseTypeModule(PromiseModule):
                 else:
                     self.log_verbose("Promise '%s' kept" % promiser)
                     return Result.KEPT
+
         except Exception as e:
             self.log_error(e)
             self.log_error("Promise '%s' not kept" % promiser)


### PR DESCRIPTION
I.e. that elementary promise locking works, as implemented in
cfengine/core@24e2de71c749.

Ticket: CFE-3434
Changelog: None

Merge together:
https://github.com/cfengine/core/pull/4905
https://github.com/cfengine/masterfiles/pull/2223