### PR TITLE
Make sure the 'test' bundle is defined in the 22_single_evaluation test

### DIFF
--- a/tests/acceptance/30_custom_promise_types/22_single_evaluation.cf
+++ b/tests/acceptance/30_custom_promise_types/22_single_evaluation.cf
@@ -6,7 +6,8 @@
 body common control
 {
     inputs => { "../default.cf.sub" };
-    bundlesequence => { "init", "test", "check" };
+    bundlesequence  => { default("$(this.promise_filename)") };
+    version => "1.0";
 }
 
 #######################################################
@@ -48,9 +49,11 @@ promise agent append
     interpreter => "/usr/bin/python3";
     path => "$(this.promise_dirname)/append_promises.py";
 }
+@endif
 
 bundle agent test
 {
+@if minimum_version(3.18.0)
   meta:
     "description" -> { "CFE-3434" }
       string => "Test that custom promises are only evaluated once";
@@ -59,8 +62,8 @@ bundle agent test
     "$(G.testfile)"
       string => "hello",
       always => "true";
-}
 @endif
+}
 
 #######################################################
 


### PR DESCRIPTION
It is supposed to be defined in the test on all versions, even on
those where the test is skipped.

Also use the full bundle sequence we use in tests.

(cherry picked from commit 18ca01277cf55246ca1bfc6981249365e0919b4f)