### PR TITLE
CFE-3920: Cleaned up policy related to versions prior to 3.12

### DIFF
--- a/cfe_internal/update/update_policy.cf
+++ b/cfe_internal/update/update_policy.cf
@@ -204,15 +204,6 @@ bundle agent cfe_internal_update_policy_cpv
         comment => "Symlink to Python we found (if any)",
         handle => "cfe_internal_update_policy_python_symlink";
 
-    cfredis_in_enterprise::
-
-      # TODO Remove from MPF after 3.12 EOL
-
-      "redis_conf_file" -> { "ENT-2797" }
-        string => translatepath("$(sys.workdir)/config/redis.conf"),
-        comment => "Path to Redis configuration file",
-        handle => "cfe_internal_update_policy_redis_conf_file";
-
   classes:
 
       "validated_updates_ready"

--- a/cfe_internal/update/update_processes.cf
+++ b/cfe_internal/update/update_processes.cf
@@ -104,16 +104,6 @@ bundle agent cfe_internal_update_processes
       "agent[cf_runalerts]" string => "cf-runalerts";
       "agent[cf_apache]"   string => "cf-apache";
 
-    cfredis_in_enterprise::
-      # TODO Remove from MPF after 3.12 EOL
-      "agent[cf_redis_server]" -> { "ENT-2797" }
-        string => "cf-redis-server";
-
-    cfconsumer_in_enterprise::
-      # TODO Remove from MPF after 3.12 EOL
-      "agent[cf_consumer]" -> { "ENT-2797" }
-        string => "cf-consumer";
-
     any::
       # We get a consolidated list of all agents for the executing host.
       "all_agents" slist => getvalues( agent );
@@ -260,22 +250,6 @@ bundle agent maintain_cfe_hub_process
       handle => "cfe_internal_maintain_cfe_hub_process_processes_check_vacuumdb",
       if => "nova|enterprise";
 
-   am_policy_hub.cfredis_in_enterprise::
-
-      # TODO Remove from MPF after 3.12 EOL
-      "$(cfe_internal_process_knowledge.bindir)/redis-server" -> { "ENT-2797" }
-      restart_class => "start_redis_server",
-      comment => "Monitor redis-server process",
-      handle => "cfe_internal_maintain_cfe_hub_process_processes_redis",
-      if => "nova|enterprise";
-
-    am_policy_hub.cfconsumer_in_enterprise::
-      "$(cfe_internal_process_knowledge.bindir)/cf-consumer" -> { "ENT-2797" }
-      restart_class => "start_cf_consumer",
-      comment => "Monitor cf-consumer process",
-      handle => "cfe_internal_maintain_cfe_hub_process_processes_cf_consumer",
-      if => "(nova|enterprise).no_vacuumdb";
-
    am_policy_hub.!enable_cfengine_enterprise_hub_ha::
       "$(cfe_internal_process_knowledge.bindir)/postgres"
       restart_class => "start_postgres_server",
@@ -309,29 +283,12 @@ bundle agent maintain_cfe_hub_process
 
   commands:
 
-    !windows.am_policy_hub.start_redis_server.cfredis_in_enterprise::
-
-      # TODO Remove from MPF after 3.12 EOL
-     "$(cfe_internal_process_knowledge.bindir)/redis-server $(cfe_internal_update_policy_cpv.redis_conf_file)" -> { "ENT-2797" }
-      contain => u_in_dir("/"),
-      comment => "Start redis process",
-      classes => u_kept_successful_command,
-      handle => "cfe_internal_maintain_cfe_hub_process_commands_start_redis";
-
     !windows.am_policy_hub.!enable_cfengine_enterprise_hub_ha.start_postgres_server::
      "$(cfe_internal_process_knowledge.bindir)/pg_ctl -D $(cfe_internal_update_policy_cpv.postgresdb_dir) -l $(cfe_internal_update_policy_cpv.postgresdb_log) start"
       contain => u_postgres,
       comment => "Start postgres process",
       classes => u_kept_successful_command,
       handle => "cfe_internal_maintain_cfe_hub_process_commands_start_postgres";
-
-    !windows.am_policy_hub.start_cf_consumer.cfconsumer_in_enterprise::
-      # TODO Remove from MPF after 3.12 EOL
-
-      "$(cfe_internal_process_knowledge.bindir)/cf-consumer"
-      comment => "Start cf-consumer process",
-      classes => u_kept_successful_command,
-      handle => "cfe_internal_maintain_cfe_hub_process_commands_start_cf-consumer";
 
     !windows.am_policy_hub.start_hub::
       "$(sys.cf_hub)"

--- a/controls/def.cf
+++ b/controls/def.cf
@@ -560,12 +560,6 @@ bundle common def
       # Enable paths to POSIX tools instead of native tools when possible.
       "mpf_stdlib_use_posix_utils" expression => "any";
 
-      # TODO Remove from MPF after 3.12 EOL
-      "cfredis_in_enterprise" -> { "ENT-2797" }
-        or => { "cfengine_3_7", "cfengine_3_8", "cfengine_3_9", "cfengine_3_10", "cfengine_3_11" };
-      "cfconsumer_in_enterprise"  -> { "ENT-2797" }
-        or => { "cfengine_3_7", "cfengine_3_8", "cfengine_3_9", "cfengine_3_10", "cfengine_3_11" };
-
 }
 
 bundle common inventory_control

--- a/controls/update_def.cf.in
+++ b/controls/update_def.cf.in
@@ -198,11 +198,4 @@ bundle common update_def
       # Enable failover to node which is outside cluster
       #"failover_to_replication_node_enabled" expression => "enterprise_edition";
 
-    any::
-      # TODO Remove from MPF after 3.12 EOL
-      "cfredis_in_enterprise"  -> { "ENT-2797" }
-        or => { "cfengine_3_7", "cfengine_3_8", "cfengine_3_9", "cfengine_3_10", "cfengine_3_11" };
-      "cfconsumer_in_enterprise"  -> { "ENT-2797" }
-        or => { "cfengine_3_7", "cfengine_3_8", "cfengine_3_9", "cfengine_3_10", "cfengine_3_11" };
-
 }

--- a/lib/README.md
+++ b/lib/README.md
@@ -3,9 +3,6 @@ referred to as the Common Open Promise Body Library.
 
 Layout of this `lib` directory:
 
-* `3.6/*.cf`: Modularized version of the CFEngine Standard Library for
-  3.6.x.
-
 * `lib/*.cf`: Re-unified library compatible with 3.7+
   - *autorun.cf*: This file contains bundles that support automatic activation
     of bundles based on tags as well as automatically adding policy files found

--- a/lib/cfe_internal_hub.cf
+++ b/lib/cfe_internal_hub.cf
@@ -92,8 +92,8 @@ bundle agent cfe_internal_hub_maintain
       usebundle => cfe_internal_database_cleanup_reports(@(report_settings)),
       action => if_elapsed_day;
 
-      "Remove cf-consumer history"
-      usebundle => cfe_internal_database_cleanup_consumer_status("3"),
+      "Remove cf-hub status history"
+      usebundle => cfe_internal_database_cleanup_cf_hub_status("3"),
       action => if_elapsed_day;
 
       "Remove diagnostics history"
@@ -141,10 +141,8 @@ AND    t.$(settings[$(index)][time_key]) <= (z.latest - '$(settings[$(index)][hi
         handle => "cf_database_maintain_report_$(settings[$(index)][report])";
 }
 
-bundle agent cfe_internal_database_cleanup_consumer_status (row_count)
+bundle agent cfe_internal_database_cleanup_cf_hub_status (row_count)
 # @brief keep up to row_count entries in the database
-# @note ENT-2797 After cf-consumer removal, this will still be necessary, functionality
-# of cf-consumer to be replaced with cf-hub-worker per Ole.
 {
 
   classes:
@@ -162,6 +160,10 @@ bundle agent cfe_internal_database_cleanup_consumer_status (row_count)
   vars:
 
     any::
+
+      # TODO Redact after 3.15.x is no longer under standard support. Since this
+      # is used in 3.12.x and 3.12.x was supported at the time 3.15.0 was
+      # released we need to maintain the path for people upgrading from 3.12.x
 
       # The status table changed it's name for 3.12.2 and 3.10.6, this handles
       # using the proper table name in the cleanup query

--- a/lib/cfe_internal_hub.cf
+++ b/lib/cfe_internal_hub.cf
@@ -272,22 +272,6 @@ bundle agent cfe_internal_postgresql_maintenance
       comment => "Vacuum Full PostgreSQL (database: cfdb)",
       handle => "cfe_internal_postgresql_maintenance_vacuum_full";
 
-    policy_server.enterprise.cfconsumer_in_enterprise::
-      # TODO Remove after 3.15 is EOL (3.12 was last version containing cf-consumer 3.15 was released while 3.12 was supported)
-
-      "cf_consumer_pid" -> { "ENT-2797" }
-        string => readfile("$(sys.workdir)/cf-consumer.pid", 0),
-        if => fileexists( "$(sys.workdir)/cf-consumer.pid" ),
-        comment => "Read cf-consumer.pid for the main cf-consumer PID";
-
-  classes:
-
-    cfconsumer_in_enterprise::
-      # TODO Remove after 3.12 EOL
-      "cf_consumer_pid_correct" -> { "ENT-2972" }
-        expression => isvariable("cf_consumer_pid"),
-        comment => "Check if cf-consumer pid is correctly defined";
-
   processes:
 
     any::
@@ -295,15 +279,6 @@ bundle agent cfe_internal_postgresql_maintenance
       "cf-hub"      signals => { "term" },
       comment => "Terminate cf-hub while doing PostgreSQL maintenance",
       handle => "cfe_internal_postgresql_maintenance_processes_term_cf_hub";
-
-    cf_consumer_pid_correct.cfconsumer_in_enterprise::
-      # TODO Remove from MPF after 3.12 EOL
-
-      "cf-consumer" -> { "ENT-2797" }
-        signals => { "kill" },
-        process_select => by_pid("$(cf_consumer_pid)"),
-        comment => "Kill cf-consumer while doing PostgreSQL maintenance",
-        handle => "cfe_internal_postgresql_maintenance_processes_kill_cf_consumer";
 
   commands:
 


### PR DESCRIPTION
Now that 3.12.x is not under standard support, we can remove anything that was
not used in 3.12. Things used in 3.12 need to remain to cover the case where
someone is upgrading to 3.15.x because 3.12.x was supported when 3.15.0 was
released.

This change redacts policy related to cf-consumer and cf-redis-server.

Ticket: CFE-3920
Changelog: Title