### PR TITLE
ENT-8212 Enforce 755 perms on hub htdocs dir (3.15)

### DIFF
--- a/cfe_internal/enterprise/CFE_knowledge.cf
+++ b/cfe_internal/enterprise/CFE_knowledge.cf
@@ -63,6 +63,11 @@ bundle agent cfe_internal_setup_knowledge
       handle => "cfe_internal_setup_knowledge_dir_doc_root",
       perms => mog("0460", "root", $(def.cf_apache_group) );
 
+      "$(sys.workdir)/httpd/."
+      comment => "httpd dir should be 755",
+      handle => "cfe_internal_setup_knowledge_dir_httpd",
+      perms => mog("755", "root", "root");
+
       "$(cfe_internal_hub_vars.docroot)/.htaccess"
       comment => "Correct up htaccess file in doc root",
       handle => "cfe_internal_setup_knowledge_files_doc_root_htaccess",


### PR DESCRIPTION
This is setup by packaging but should be maintained by policy.

Ticket: ENT-8212
Changelog: title
(cherry picked from commit 3f3f1c394696fe9c627bcc2fa8f5dff76ad37068)