### PR TITLE
ENT-8393 Fixed inclusion of distributed cleanup python files during install

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -225,7 +225,7 @@ do
 done
 for i in templates cfe_internal modules/packages/vendored
 do
-    for j in `find "$srcdir/$i" -name '*.mustache' -o -name '*.sh' -o -name '*.awk' -o -name '*.sed' -o -name '*.ps1'`
+    for j in `find "$srcdir/$i" -name '*.mustache' -o -name '*.sh' -o -name '*.awk' -o -name '*.sed' -o -name '*.ps1' -o -name '*.py'`
     do
         MASTERFILES_INSTALL_TARGETS="$MASTERFILES_INSTALL_TARGETS $j"
     done


### PR DESCRIPTION
configure.ac was missing entry

controls/update.cf already includes *.py so OK there.

Ticket: ENT-8393
Changelog: title