### PR TITLE
Fixed FR clean bundle when off state (3.18.x)

### DIFF
--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -317,8 +317,8 @@ bundle agent clean_when_off
     "user" string => "$(cfengine_enterprise_federation:transport_user.user)";
     "home" string => "$(cfengine_enterprise_federation:transport_user.home)";
 @if minimum_version(3.15)
-    "remote_hubs_row_count" string => execresult(`$(sys.bindir)/psql cfsettings --quiet --tuples-only --command "SELECT COUNT(*) FROM remote_hubs" 2>/dev/null`, useshell);
-    "federated_reporting_settings_row_count" string => execresult(`$(sys.bindir)/psql cfsettings --quiet --tuples-only --command "SELECT COUNT(*) FROM federated_reporting_settings" 2>/dev/null`, useshell);
+    "remote_hubs_table_row_count" string => execresult(`$(sys.bindir)/psql cfsettings --quiet --tuples-only --command "SELECT COUNT(*) FROM remote_hubs" 2>/dev/null`, useshell);
+    "federated_reporting_settings_table_row_count" string => execresult(`$(sys.bindir)/psql cfsettings --quiet --tuples-only --command "SELECT COUNT(*) FROM federated_reporting_settings" 2>/dev/null`, useshell);
 @endif
 
   users:
@@ -329,6 +329,9 @@ bundle agent clean_when_off
       "$(cfengine_enterprise_federation:config.path_setup_status)" -> { "ENT-7233" }
         comment => "We must remove this file for Mission Portal to understand that the federation is not configured",
         delete => default:tidy;
+      "$(cfengine_enterprise_federation:config.path)" -> { "ENT-7969" }
+         comment => "We must remove this file for Mission Portal to understand that the federation is not configured",
+         delete => default:tidy;
 
   methods:
     "rm_rf_cftransport_home_dir" usebundle => default:rm_rf("$(home)");


### PR DESCRIPTION
Ticket: ENT-7969

ChangeLog: Title

- Fixed variables name that check if remote_hubs and federated_reporting_settings tables exist.
- Removed federation-config.json when state is off

(cherry picked from commit b63b0fc6471d9be21f4f5d99db50090351ea0dbc)