### PR TITLE
CFE-3925: Enable setting environment attribute in body agent control via augments (3.18)

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -1392,6 +1392,44 @@ the watchdog will not be active.
 
 **See Also:** [Watchdog documentation][cfe_internal/core/watchdog]
 
+### Environment Variables
+
+Environment variables that should be inherited by child commands can be set using `def.control_agent_environment_vars_default`. The policy defaults are overridden if this is defined. This can be useful if you want to modify the default environment variables that are set.
+
+For example:
+
+```json
+{
+  "vars": {
+    "control_agent_environment_vars_default":
+      [ "DEBIAN_FRONTEND=noninteractive",
+        "XPG_SUS_ENV=ON" ]
+  }
+}
+```
+
+The environment variables can also be extended by defining `def.control_agent_environment_vars_extra`. The extra environment variables defined here are combined with the defaults (if they exist).
+
+```json
+{
+  "vars": {
+    "control_agent_environment_vars_extra": [ "XPG_SUS_ENV=ON" ]
+  }
+}
+```
+
+**Notes:**
+
+* Simple augments as shown above apply to *all* hosts. Consider using the
+  [augments key][Augments#augments] or [host specific data][Augments#host\_specific.json] if you want to set environment variables
+  differently across different sets of hosts. The value set via Augments takes
+  precedence over policy defaults, so be sure to take that into account when
+  configuring.
+
+**History:**
+
+* Introduced in 3.20.0, 3.18.2
+
 ### Modules
 
 Modules executed by the `usemodule()` function are expected to be found in

--- a/controls/cf_agent.cf
+++ b/controls/cf_agent.cf
@@ -35,6 +35,15 @@ body agent control
       # Maximum number of outgoing connections to a remote cf-serverd.
       maxconnections => "$(def.control_agent_maxconnections)";
 
+      # Environment variables of the agent process.
+      # The values of environment variables are inherited by child commands
+      # EMPTY list is not valid for environment attribute Ref: CFE-3927. So, we
+      # do some validation on it so we can apply it selectively.
+
+   _control_agent_environment_vars_validated::
+
+      environment => { @(def.control_agent_environment_vars) };
+
     _have_control_agent_files_single_copy::
       # CFE-3622
 
@@ -50,9 +59,5 @@ body agent control
       default_repository => "$(def.control_agent_default_repository)";
 
       # Environment variables based on Distro
-
-    debian::
-
-      environment => { @(def.environment_vars) };
 
 }

--- a/controls/def.cf
+++ b/controls/def.cf
@@ -226,18 +226,60 @@ bundle common def
         int => "200",
         if => not( isvariable( "control_server_maxconnections" ) );
 
+      #+begin_src def.control_agent_environment_vars
+      # This configures environment_vars in body agent control
+
+      # It's configurable without having to modify policy, so the default values
+      # are only applied if the variable is not already defined (via augments).
+
+      # Platform defaults are set first, and the global default is set last so
+      # that global default does not override a platform specific setting since
+      # the promises are only applied if the variable is not already defined
+      # which is reverse of what you might normally do in CFEngine since
+      # typically the last promise wins.
+
+  classes:
+
+      "_control_agent_environment_vars_validated" -> { "CFE-3927" }
+        and => {
+                 # The variable must be defined
+                 isvariable( "default:def.control_agent_environment_vars" ),
+                 # The length of the variable must be greater than 0 (can't be an empty list)
+                 isgreaterthan( length( "default:def.control_agent_environment_vars" ), 0),
+                 # Each element of the list must be of the form KEY=VALUE
+                 every( ".+=.+", "default:def.control_agent_environment_vars"),
+                 # In 3.18 and greater we can validate the type of variable in use
+@if minimum_version(3.18.0)
+                 regcmp( "(policy slist|data array)", type( "default:def.control_agent_environment_vars", "true" ) ),
+@endif
+                 };
+
+  vars:
+
     debian::
-      "environment_vars"
-        handle => "common_def_vars_environment_vars",
-        comment => "Environment variables of the agent process. The values
-                    of environment variables are inherited by child commands.",
+
+      "control_agent_environment_vars_default" ->  { "CFE-3925" }
+        handle => "common_def_vars_debian_control_agent_environment_vars_default",
+        if => not( isvariable( "control_agent_environment_vars_default" ) ),
+        comment => "Set default environment variables for using Debian non-interactively",
         slist => {
                    "DEBIAN_FRONTEND=noninteractive",
                   # "APT_LISTBUGS_FRONTEND=none",
                   # "APT_LISTCHANGES_FRONTEND=none",
                  };
 
-      # End change #
+  any::
+
+      # Resolve the final state for environment vars if there is a default var
+      # or if there is a user extra and merge the defined entities
+      "control_agent_environment_vars" ->  { "CFE-3925" }
+        slist => { @(def.control_agent_environment_vars_default),
+                   @(def.control_agent_environment_vars_extra) },
+        policy => "ifdefined",
+        if => or( isvariable( "def.control_agent_environment_vars_default" ), # Protect against defining
+                  isvariable( "def.control_agent_environment_vars_extra" ));  # an empty variable
+
+      #+end_src Agent Environment Variables
 
     any::
       "dir_masterfiles" string => translatepath("$(sys.masterdir)"),


### PR DESCRIPTION
It is sometimes necessary to set environment variables in cfengine context,
as setting them globaly/systemwide is not possible due to various unwanted side effects.
This change enables this.

Changelog: Title
Ticket: CFE-3925