### PR TITLE
CFE-3993: Removed policy deprecated by sys.os_release

### DIFF
--- a/inventory/debian.cf
+++ b/inventory/debian.cf
@@ -27,7 +27,7 @@ bundle common inventory_debian
     any::
       "debian_derived_evaluated"
       scope => "bundle",
-      or => { "has_os_release", "has_lsb_release", "has_etc_linuxmint_info" } ;
+      or => { isvariable("sys.os_release"), "has_lsb_release", "has_etc_linuxmint_info" } ;
 
       "linuxmint"
       expression => "has_etc_linuxmint_info",
@@ -40,7 +40,7 @@ bundle common inventory_debian
       comment => "this is a Linux Mint system, of some sort",
       meta => { "inventory", "attribute_name=none" } ;
 
-    linuxmint.has_os_release::
+    linuxmint::
       "lmde"
       expression => regcmp('.*LMDE.*', "$(sys.os_release[NAME])"),
       comment => "this is a Linux Mint Debian Edition",

--- a/inventory/debian.cf
+++ b/inventory/debian.cf
@@ -42,9 +42,9 @@ bundle common inventory_debian
 
     linuxmint.has_os_release::
       "lmde"
-      expression => regcmp('(?ms).*^NAME="Linux Mint LMDE"$.*', "$(inventory_linux.os_release_info)"),
+      expression => regcmp('.*LMDE.*', "$(sys.os_release[NAME])"),
       comment => "this is a Linux Mint Debian Edition",
-      meta => { "inventory", "attribute_name=none", "derived-from=inventory_linux.os_release_info" } ;
+      meta => { "inventory", "attribute_name=none", "derived-from=sys.os_release[NAME]" } ;
 
     linuxmint.has_lsb_release::
       "lmde"

--- a/inventory/linux.cf
+++ b/inventory/linux.cf
@@ -84,11 +84,6 @@ bundle common inventory_linux
     has_proc_1_cmdline::
       "systemd" expression => strcmp(lastnode($(proc_1_process), "/"), "systemd"),
       comment => "Check if (the link target of) /proc/1/cmdline is systemd";
-
-  reports:
-    (DEBUG|DEBUG_inventory_linux).has_os_release::
-      "DEBUG $(this.bundle)";
-      "$(const.t)OS release ID = $(os_release_id), OS release version = $(os_release_version)";
 }
 
 bundle monitor measure_entropy_available

--- a/inventory/linux.cf
+++ b/inventory/linux.cf
@@ -4,7 +4,6 @@ bundle common inventory_linux
 # This common bundle is for Linux inventory work.
 #
 # Provides:
-#  has_os_release class based on presence of /etc/os-release
 #  systemd class based on linktarget of /proc/1/cmdline
 {
   vars:
@@ -49,9 +48,6 @@ bundle common inventory_linux
   classes:
 
     any::
-      "has_os_release" expression => fileexists("/etc/os-release"),
-      comment => "Check if we can get more info from /etc/os-release";
-
       "has_proc_1_cmdline" expression => fileexists("/proc/1/cmdline"),
       comment => "Check if we can read /proc/1/cmdline";
 

--- a/inventory/linux.cf
+++ b/inventory/linux.cf
@@ -4,20 +4,10 @@ bundle common inventory_linux
 # This common bundle is for Linux inventory work.
 #
 # Provides:
-#  os_release_id, and os_release_version based on parsing of /etc/os-release
+#  has_os_release class based on presence of /etc/os-release
 #  systemd class based on linktarget of /proc/1/cmdline
 {
   vars:
-    has_os_release::
-      "os_release_info" string => readfile("/etc/os-release", "512"),
-      comment => "Read /etc/os-release" ;
-
-    os_release_has_id::
-      "os_release_id" string => canonify("$(id_array[1])");
-
-    os_release_has_version::
-      "os_release_version" string => canonify("$(version_array[1])");
-
     has_proc_1_cmdline::
       "proc_1_cmdline_split" slist => string_split(readfile("/proc/1/cmdline", "512"), " ", "2"),
       comment => "Read /proc/1/cmdline and split off arguments";
@@ -62,24 +52,8 @@ bundle common inventory_linux
       "has_os_release" expression => fileexists("/etc/os-release"),
       comment => "Check if we can get more info from /etc/os-release";
 
-      "os_release_has_id" expression => regextract('^ID="?([^"\s]+)"?$',
-                                                   $(os_release_info),
-                                                   "id_array"),
-      comment => "Extract ID= line from os-release to id_array";
-
-      "os_release_has_version" expression => regextract('^VERSION_ID="?([^"]+)"?$',
-                                                        $(os_release_info),
-                                                        "version_array"),
-      comment => "Extract VERSION_ID= line from os-release to version_array";
-
       "has_proc_1_cmdline" expression => fileexists("/proc/1/cmdline"),
       comment => "Check if we can read /proc/1/cmdline";
-
-    os_release_has_id::
-      "$(os_release_id)" expression => "any";
-
-    os_release_has_version::
-      "$(os_release_id)_$(os_release_version)" expression => "any";
 
     has_proc_1_cmdline::
       "systemd" expression => strcmp(lastnode($(proc_1_process), "/"), "systemd"),


### PR DESCRIPTION
CFEngine 3.11.0 brought classification based on /etc/os-release to core.
This change removes policy pre-dating core support for classification based on /etc/os-release.