### PR TITLE
ENT-8424: Stopped lowercasing software inventory on Windows

### DIFF
--- a/modules/packages/vendored/msiexec-list.vbs.mustache
+++ b/modules/packages/vendored/msiexec-list.vbs.mustache
@@ -41,8 +41,6 @@ For Each strKey in strKeys
         ' DisplayVersion and InstalledVersion are missing, so try to fall back to a key of the same name as the node, i.e. AOMEI Backupper Server.
         intRet2 = objReg.GetStringValue( HKLM, strKey & strDisplayNameValue, strDisplayNameValue, strDisplayVersionValue )
       End If
-      ' Replace whitespace with dashes for CFEngine
-      ' strDisplayNameValue = Replace(strDisplayNameValue, " ", "-")
       ' Print out the DisplayName
       WScript.Echo "Name=" & strDisplayNameValue
       ' Print out the DisplayVersion

--- a/modules/packages/vendored/msiexec-list.vbs.mustache
+++ b/modules/packages/vendored/msiexec-list.vbs.mustache
@@ -44,7 +44,7 @@ For Each strKey in strKeys
       ' Replace whitespace with dashes for CFEngine
       ' strDisplayNameValue = Replace(strDisplayNameValue, " ", "-")
       ' Print out the DisplayName
-      WScript.Echo "Name=" & LCase(strDisplayNameValue)
+      WScript.Echo "Name=" & strDisplayNameValue
       ' Print out the DisplayVersion
       ' Ensure that Version is set to something, else it can't be inserted into the database.
       If intRet2 <> 0 Then


### PR DESCRIPTION
I can not find any legitimate reason that we are lowercasing software names on
Windows.

Ticket: ENT-8424
Changelog: Title