### PR TITLE
CFE-951: Adjusted rxdirs to have correct explicit default

### DIFF
--- a/cfe_internal/enterprise/CFE_knowledge.cf
+++ b/cfe_internal/enterprise/CFE_knowledge.cf
@@ -555,6 +555,14 @@ body depth_search cfe_internal_docroot_application_perms
 
 body perms state_dir_system_owned
 {
+#+begin_ENT-951
+# Remove after 3.20 is not supported
+        rxdirs => "true";
+@if minimum_version(3.20)
+        rxdirs => "false";
+@endif
+#+end
+
       mode   => "0600";
       !windows::
         owners => { "root" };

--- a/cfe_internal/update/lib.cf
+++ b/cfe_internal/update/lib.cf
@@ -226,4 +226,13 @@ body perms u_mog(mode,user,group)
       owners => { "$(user)" };
       groups => { "$(group)" };
       mode   => "$(mode)";
+
+#+begin_ENT-951
+# Remove after 3.20 is not supported
+        rxdirs => "true";
+@if minimum_version(3.20)
+        rxdirs => "false";
+@endif
+#+end
+
 }

--- a/cfe_internal/update/update_policy.cf
+++ b/cfe_internal/update/update_policy.cf
@@ -436,6 +436,14 @@ body perms u_m(p)
 # @param p Desired file mode
 {
       mode  => "$(p)";
+
+#+begin_ENT-951
+# Remove after 3.20 is not supported
+        rxdirs => "true";
+@if minimum_version(3.20)
+        rxdirs => "false";
+@endif
+#+end
 }
 
 #########################################################
@@ -446,6 +454,15 @@ body perms u_mo(p,o)
 # @param p Desired file owner (username or uid)
 {
       mode   => "$(p)";
+
+#+begin_ENT-951
+# Remove after 3.20 is not supported
+        rxdirs => "true";
+@if minimum_version(3.20)
+        rxdirs => "false";
+@endif
+#+end
+
       !(windows|termux)::
         owners => {"$(o)"};
 }
@@ -455,6 +472,14 @@ body perms u_mo(p,o)
 body perms u_shared_lib_perms
 # @brief Shared library permissions
 {
+#+begin_ENT-951
+# Remove after 3.20 is not supported
+        rxdirs => "true";
+@if minimum_version(3.20)
+        rxdirs => "false";
+@endif
+#+end
+
     !hpux::
       mode => "0644";
     hpux::

--- a/lib/files.cf
+++ b/lib/files.cf
@@ -1633,6 +1633,14 @@ body perms m(mode)
 # @param mode The new mode
 {
       mode   => "$(mode)";
+
+#+begin_ENT-951
+# Remove after 3.20 is not supported
+        rxdirs => "true";
+@if minimum_version(3.20)
+        rxdirs => "false";
+@endif
+#+end
 }
 
 ##
@@ -1644,6 +1652,14 @@ body perms mo(mode,user)
 {
       owners => { "$(user)" };
       mode   => "$(mode)";
+
+#+begin_ENT-951
+# Remove after 3.20 is not supported
+        rxdirs => "true";
+@if minimum_version(3.20)
+        rxdirs => "false";
+@endif
+#+end
 }
 
 ##
@@ -1657,6 +1673,14 @@ body perms mog(mode,user,group)
       owners => { "$(user)" };
       groups => { "$(group)" };
       mode   => "$(mode)";
+
+#+begin_ENT-951
+# Remove after 3.20 is not supported
+        rxdirs => "true";
+@if minimum_version(3.20)
+        rxdirs => "false";
+@endif
+#+end
 }
 
 ##
@@ -1692,6 +1716,14 @@ body perms system_owned(mode)
 {
       mode   => "$(mode)";
       owners => { "root" };
+
+#+begin_ENT-951
+# Remove after 3.20 is not supported
+        rxdirs => "true";
+@if minimum_version(3.20)
+        rxdirs => "false";
+@endif
+#+end
 
     freebsd|openbsd|netbsd|darwin::
       groups => { "wheel" };


### PR DESCRIPTION
Beginning with CFEngine 3.20 rxdirs default has changed from true to false.

This change explicitly sets the value to align with binary defaults. When
running binary versions prior to 3.20 rxdirs is enabled. For versions 3.20 and
greater rxdirs is disabled by default.

Starting with CFEngine 3.18.2, if a perms body sets mode without
specifying rxdirs a warning will be emitted. This change prevents those warnings
for perms bodies that are part of the MPF.

Ticket: CFE-951
Changelog: Title