### PR TITLE
Always set 'rxdirs' to true for state dir

### DIFF
--- a/cfe_internal/enterprise/CFE_knowledge.cf
+++ b/cfe_internal/enterprise/CFE_knowledge.cf
@@ -555,15 +555,9 @@ body depth_search cfe_internal_docroot_application_perms
 
 body perms state_dir_system_owned
 {
-#+begin_ENT-951
-# Remove after 3.20 is not supported
-        rxdirs => "true";
-@if minimum_version(3.20)
-        rxdirs => "false";
-@endif
-#+end
-
+      rxdirs => "true";
       mode   => "0600";
+
       !windows::
         owners => { "root" };
 


### PR DESCRIPTION
We need those directories to be properly accessible for our
daemons, PostgreSQL,...

Ticket: CFE-951
Changelog: None