### PR TITLE
Use 'rxdirs => "true"' explicitly

### DIFF
--- a/cfe_internal/enterprise/CFE_knowledge.cf
+++ b/cfe_internal/enterprise/CFE_knowledge.cf
@@ -555,13 +555,7 @@ body depth_search cfe_internal_docroot_application_perms
 
 body perms state_dir_system_owned
 {
-#+begin_ENT-951
-# Remove after 3.20 is not supported
-        rxdirs => "true";
-@if minimum_version(3.20)
-        rxdirs => "false";
-@endif
-#+end
+      rxdirs => "true";
 
       mode   => "0600";
       !windows::

--- a/lib/files.cf
+++ b/lib/files.cf
@@ -1633,14 +1633,7 @@ body perms m(mode)
 # @param mode The new mode
 {
       mode   => "$(mode)";
-
-#+begin_ENT-951
-# Remove after 3.20 is not supported
-        rxdirs => "true";
-@if minimum_version(3.20)
-        rxdirs => "false";
-@endif
-#+end
+      rxdirs => "true";
 }
 
 ##
@@ -1652,14 +1645,7 @@ body perms mo(mode,user)
 {
       owners => { "$(user)" };
       mode   => "$(mode)";
-
-#+begin_ENT-951
-# Remove after 3.20 is not supported
-        rxdirs => "true";
-@if minimum_version(3.20)
-        rxdirs => "false";
-@endif
-#+end
+      rxdirs => "true";
 }
 
 ##
@@ -1673,14 +1659,7 @@ body perms mog(mode,user,group)
       owners => { "$(user)" };
       groups => { "$(group)" };
       mode   => "$(mode)";
-
-#+begin_ENT-951
-# Remove after 3.20 is not supported
-        rxdirs => "true";
-@if minimum_version(3.20)
-        rxdirs => "false";
-@endif
-#+end
+      rxdirs => "true";
 }
 
 ##
@@ -1716,14 +1695,7 @@ body perms system_owned(mode)
 {
       mode   => "$(mode)";
       owners => { "root" };
-
-#+begin_ENT-951
-# Remove after 3.20 is not supported
-        rxdirs => "true";
-@if minimum_version(3.20)
-        rxdirs => "false";
-@endif
-#+end
+      rxdirs => "true";
 
     freebsd|openbsd|netbsd|darwin::
       groups => { "wheel" };


### PR DESCRIPTION
Effectively reverting the change of the default for rxdirs in
https://github.com/cfengine/core/commit/c79917e80682fecb444a9949742fcf4096c9e6b3 for now until we have a proper solution
with explicit values for specific cases in our policy.