### PR TITLE
CFE-951: Adjusted MPF to handle rxdirs default from true to false (3.18)

### DIFF
--- a/cfe_internal/enterprise/CFE_hub_specific.cf
+++ b/cfe_internal/enterprise/CFE_hub_specific.cf
@@ -758,19 +758,40 @@ bundle agent cfe_internal_enterprise_policy_analyzer
 
       "policy_analyzer_enabled" expression => fileexists( $(analyzer_flagfile) );
 
-    files:
+  files:
+
+    enterprise_edition.policy_server::
+
+      "$(cfe_internal_hub_vars.docroot)/analyzer/." -> { "CFE-951" }
+        create => "true",
+        handle => "cfe_internal_setup_knowledge_docroot_analyzer_dir",
+        perms => mog( "0470", "root", $(def.cf_apache_group) ),
+        comment => concat( "This directory holds the policy analyzer flag file ",
+                           "that is written by Mission Portal when someone ",
+                           "clicks to enable the feature. Thus, it needs to be ",
+                           "readable, writeable and executable for the web ",
+                           "server.");
+
 
     policy_analyzer_enabled::
 
-      "$(analyzer_dir)/."
-        create => "true",
-        perms => mog( "500", $(def.cf_apache_user), $(def.cf_apache_user) );
-
        "$(analyzer_dir)/."
+         create => "true",
+         handle => "policy_analyzer_sync_analyzer_source",
          copy_from => analyzer_sync( $(analyzer_source) ),
-         file_select => default:ex_list( @(exclude_files) ),
          depth_search => recurse_with_base( inf ),
-         perms => mog( "400", $(def.cf_apache_user), $(def.cf_apache_group) );
+         file_select => default:ex_list( @(exclude_files) );
+
+      "$(analyzer_dir)/." -> { "CFE-951" }
+        file_select => default:dirs,
+        depth_search => recurse_with_base( inf ),
+        perms => mog( "0450", "root", $(def.cf_apache_group) );
+
+      "$(analyzer_dir)/." -> { "CFE-951" }
+        file_select => default:not_dir,
+        depth_search => recurse_with_base( inf ),
+        perms => mog( "0450", "root", $(def.cf_apache_group) );
+
 
   reports:
       DEBUG|DEBUG_cfe_internal_enterprise_policy_analyzer::
@@ -778,7 +799,6 @@ bundle agent cfe_internal_enterprise_policy_analyzer
           if => "policy_analyzer_enabled";
 
 }
-
 body copy_from analyzer_sync(path)
 # @brief Keep promised files in sync with local `path`
 {

--- a/cfe_internal/enterprise/CFE_knowledge.cf
+++ b/cfe_internal/enterprise/CFE_knowledge.cf
@@ -51,17 +51,63 @@ bundle agent cfe_internal_setup_knowledge
       "$(install_logs)" -> { "ENT-4506" }
         perms => mog("0600", "root", "root" );
 
-      "$(cfe_internal_hub_vars.docroot)"
-      comment => "All files in there should be at least 0460. Giving cfapache group full access",
-      handle => "cfe_internal_setup_knowledge_files_doc_root_2",
-      file_select => cfe_internal_docroot_perms,
-      perms => mog("0460", "root", $(def.cf_apache_group) ),
-      depth_search => recurse_exclude("inf");   # see exclude dirs in recurse_exclude() body
-
-      "$(cfe_internal_hub_vars.docroot)/."
-      comment => "The top level docroot dir should be at least 0460 with root:cfapache",
+      "$(cfe_internal_hub_vars.docroot)/." -> { "CFE-951" }
+      comment => "The top level docroot needs to be readable and executable by the web server.",
       handle => "cfe_internal_setup_knowledge_dir_doc_root",
-      perms => mog("0460", "root", $(def.cf_apache_group) );
+      perms => mog("0550", "root", $(def.cf_apache_group) );
+
+      "$(cfe_internal_hub_vars.docroot)/vendor/." -> { "CFE-951" }
+        comment => "The vendor directory and sub-directories contains dependencies from the code ignitor framework and the directories need to be searchable by the web server.",
+        handle => "cfe_internal_setup_knowledge_dir_doc_root_vendor_dirs",
+        depth_search => recurse_with_base("inf"),
+        file_select => dirs,
+        perms => mog("0450", "root", $(def.cf_apache_group) );
+
+      "$(cfe_internal_hub_vars.docroot)/vendor/." -> { "CFE-951" }
+        comment => "The files in the vendor directory contain dependencies from the code ignitor framework and need to be readable by the web server.",
+        handle => "cfe_internal_setup_knowledge_dir_doc_root_vendor_not_dir",
+        depth_search => recurse_with_base("inf"),
+        file_select => not_dir,
+        perms => mog("0440", "root", $(def.cf_apache_group) );
+
+      "$(cfe_internal_hub_vars.public_docroot)/themes/." -> { "CFE-951" }
+        comment => "The public docroot themes directory needs to be searchable by the web server so that it can find css and images to make Mission Portal look as expected.",
+        handle => "cfe_internal_setup_knowledge_dir_doc_root_public_themes_dirs",
+        depth_search => recurse_with_base("inf"),
+        file_select => dirs,
+        perms => mog("0450", "root", $(def.cf_apache_group) );
+
+      "$(cfe_internal_hub_vars.public_docroot)/themes/." -> { "CFE-951" }
+        comment => "The public docroot themes directory needs to be searchable by the web server so that it can find css and images to make Mission Portal look as expected.",
+        handle => "cfe_internal_setup_knowledge_dir_doc_root_public_themes_not_dir",
+        depth_search => recurse_with_base("inf"),
+        file_select => not_dir,
+        perms => mog("0440", "root", $(def.cf_apache_group) );
+
+      "$(cfe_internal_hub_vars.public_docroot)/."
+        comment => "The public dir in the docroot needs the to be executable by the webserver",
+        handle => "cfe_internal_setup_knowledge_dir_doc_root_public",
+        perms => mog("0450", "root", $(def.cf_apache_group) );
+
+      "$(cfe_internal_hub_vars.public_docroot)/index.php"
+        comment => "The public dir in the docroot needs the to be executable by the webserver",
+        handle => "cfe_internal_setup_knowledge_dir_doc_root_public_index_php",
+        perms => mog("0440", "root", $(def.cf_apache_group) );
+
+      "$(cfe_internal_hub_vars.public_docroot)/images/." -> { "CFE-951" }
+        comment => "The public docroot images directory needs to be searchable by the webserver so that Mission Portal can load images and look as expected.",
+        handle => "cfe_internal_setup_knowledge_dir_doc_root_public_images_dirs",
+        depth_search => recurse_with_base("inf"),
+        file_select => dirs,
+        perms => mog("0450", "root", $(def.cf_apache_group) );
+
+      "$(cfe_internal_hub_vars.public_docroot)/images/." -> { "CFE-951" }
+        comment => "The public docroot images directory needs to be searchable by the webserver so that Mission Portal can load images and look as expected.",
+        handle => "cfe_internal_setup_knowledge_dir_doc_root_public_images_not_dir",
+        depth_search => recurse_with_base("inf"),
+        file_select => not_dir,
+        perms => mog("0440", "root", $(def.cf_apache_group) );
+
 
       "$(sys.workdir)/httpd/."
       comment => "httpd dir should be 755",
@@ -73,23 +119,39 @@ bundle agent cfe_internal_setup_knowledge
       handle => "cfe_internal_setup_knowledge_files_doc_root_htaccess",
       copy_from => no_backup_cp("$(sys.workdir)/share/GUI/Apache-htaccess");
 
-      "$(cfe_internal_hub_vars.public_docroot)/scripts/."
+      "$(cfe_internal_hub_vars.public_docroot)/scripts/." -> { "CFE-951" }
       comment => "Ensure permissions for $(cfe_internal_hub_vars.public_docroot)/scripts",
-      handle => "cfe_internal_setup_knowledge_files_doc_root_scripts",
+      handle => "cfe_internal_setup_knowledge_files_doc_root_scripts_dir",
       create => "true",
-      depth_search => recurse_basedir("inf"),
-      perms => mog("0440", "root", $(def.cf_apache_group) );
+      perms => mog("0470", "root", $(def.cf_apache_group) );
 
-      "$(cfe_internal_hub_vars.docroot)/static/."
-      handle => "cfe_internal_setup_knowledge_files_doc_root_tmp",
+      "$(cfe_internal_hub_vars.public_docroot)/scripts/." -> { "CFE-951" }
+        comment => "Ensure permissions for $(cfe_internal_hub_vars.public_docroot)/scripts",
+        handle => "cfe_internal_setup_knowledge_files_doc_root_scripts_not_dir",
+        create => "true",
+        file_select => not_dir,
+        depth_search => recurse_basedir("inf"),
+        perms => mog("0440", "root", $(def.cf_apache_group) );
+
+      "$(cfe_internal_hub_vars.docroot)/static/." -> { "CFE-951" }
+      handle => "cfe_internal_setup_knowledge_files_doc_root_static_dir",
       create => "true",
-      depth_search => recurse_basedir("inf"),
-      perms => mog("0660", "root", $(def.cf_apache_group)),
+      perms => mog("0670", "root", $(def.cf_apache_group)),
       comment => "Ensure permissions for $(cfe_internal_hub_vars.docroot)/static.
                   This is where exported and scheduled reports generated by Mission Portal
                   (temp files to email)";
 
-      "$(cfe_internal_hub_vars.public_docroot)/tmp/."
+      "$(cfe_internal_hub_vars.docroot)/static/." -> { "CFE-951" }
+        handle => "cfe_internal_setup_knowledge_files_doc_root_static_not_dir",
+        create => "true",
+        depth_search => recurse_basedir("inf"),
+        file_select => not_dir,
+        perms => mog("0660", "root", $(def.cf_apache_group)),
+        comment => "Ensure permissions for $(cfe_internal_hub_vars.docroot)/static/*.
+                  This is where exported and scheduled reports generated by Mission Portal
+                  (temp files to email)";
+
+      "$(cfe_internal_hub_vars.public_docroot)/tmp/." -> { "CFE-951" }
       handle => "cfe_internal_setup_knowledge_files_public_doc_root_tmp_dir",
       create => "true",
       depth_search => recurse_basedir("inf"),
@@ -98,22 +160,31 @@ bundle agent cfe_internal_setup_knowledge
       comment => "Ensure permissions for $(cfe_internal_hub_vars.public_docroot)/tmp.
                   This is where css and js files generated by Mission Portal";
 
-      "$(cfe_internal_hub_vars.public_docroot)/tmp/."
-        handle => "cfe_internal_setup_knowledge_files_public_doc_root_tmp_files",
+      "$(cfe_internal_hub_vars.public_docroot)/tmp/." -> { "CFE-951" }
+        handle => "cfe_internal_setup_knowledge_files_public_doc_root_tmp_not_dir",
         create => "true",
         depth_search => recurse_basedir("inf"),
-        file_select => plain,
+        file_select => not_dir,
         perms => mog("0440", $(def.cf_apache_user), $(def.cf_apache_group)),
         comment => "Ensure permissions for $(cfe_internal_hub_vars.public_docroot)/tmp.
                   This is where css and js files generated by Mission Portal";
 
-
-      "$(cfe_internal_hub_vars.docroot)/application"
+      "$(cfe_internal_hub_vars.docroot)/application" -> { "CFE-951" }
       comment => "No one should be able to write to the application, and only
                   the webserver needs access",
-      handle => "cfe_internal_setup_knowledge_files_all_files_in_application",
+      handle => "cfe_internal_setup_knowledge_files_all_not_dir_in_application",
       depth_search => cfe_internal_docroot_application_perms,
+      file_select => not_dir,
       perms => mog("0440", "root", $(def.cf_apache_group) );
+
+      "$(cfe_internal_hub_vars.docroot)/application" -> { "CFE-951" }
+        comment => "No one should be able to write to the application, and only
+                  the webserver needs access",
+        handle => "cfe_internal_setup_knowledge_files_all_dirs_in_application",
+        depth_search => cfe_internal_docroot_application_perms,
+        file_select => dirs,
+        perms => mog("0550", "root", $(def.cf_apache_group) );
+
 
       "$(cfe_internal_hub_vars.docroot)/api/." -> { "ENT-4250" }
         comment => "The api directory and it's subdirectories need to be
@@ -121,7 +192,7 @@ bundle agent cfe_internal_setup_knowledge
         perms => mog("0550", "root", $(def.cf_apache_group) );
 
 
-      "$(cfe_internal_hub_vars.docroot)/api/." -> { "ENT-4250" }
+      "$(cfe_internal_hub_vars.docroot)/api/." -> { "ENT-4250", "CFE-951" }
         depth_search => recurse_ignore( "inf", "static" ),
         file_select => dirs,
         comment => "The api subdirectories need to be executable by cfapache,
@@ -129,7 +200,7 @@ bundle agent cfe_internal_setup_knowledge
                     well take care of it separately",
         perms => mog("0550", "root", $(def.cf_apache_group) );
 
-      "$(cfe_internal_hub_vars.docroot)/api/."
+      "$(cfe_internal_hub_vars.docroot)/api/." -> { "CFE-951" }
       depth_search => recurse_basedir("inf"),
       handle => "cfe_internal_setup_knowledge_files_doc_root_api",
       file_select => cfe_internal_exclude_sh_pl_scripts,
@@ -150,14 +221,14 @@ bundle agent cfe_internal_setup_knowledge
       comment => "This is where exported PDF and CSV reports from Mission
                   Portal are written, it be writeable by the webserver";
 
-      "$(cfe_internal_hub_vars.docroot)/api/static/."
-      comment => "Exported reports only need to be readable by the webserver.",
-      handle => "cfe_internal_setup_knowledge_files_doc_root_api_static",
-      depth_search => recurse("inf"),
-      file_select => cfe_internal_docroot_api_static_perms,
-      perms => mog("0440", "root", $(def.cf_apache_group) );
+      "$(cfe_internal_hub_vars.docroot)/api/static/." -> { "CFE-951" }
+        comment => "Exported reports only need to be readable by the webserver.",
+        handle => "cfe_internal_setup_knowledge_files_doc_root_api_static_not_dir",
+        depth_search => recurse("inf"),
+        file_select => cfe_internal_docroot_api_static_perms,
+        perms => mog("0440", "root", $(def.cf_apache_group) );
 
-      "$(cfe_internal_hub_vars.docroot)/api/static/." -> { "ENT-4551" }
+      "$(cfe_internal_hub_vars.docroot)/api/static/." -> { "ENT-4551", "CFE-951" }
         comment => ".status, .pid, and potentially .abort files need to be writeable so that the async query API will function properly",
         handle => "cfe_internal_setup_knowledge_files_doc_root_api_static_async_query_status",
         depth_search => recurse("inf"),
@@ -177,11 +248,11 @@ bundle agent cfe_internal_setup_knowledge
         depth_search => recurse( "inf" ),
         perms => mog("0600", $(def.cf_apache_user), $(def.cf_apache_group));
 
-      "$(sys.workdir)/httpd/logs/."
+      "$(sys.workdir)/httpd/logs/." -> { "CFE-951" }
       comment => "Ensure permissions for $(sys.workdir)/httpd/logs",
       handle => "cfe_internal_setup_knowledge_files_httpd_logs_dir",
       create => "true",
-      perms => mog("0640", $(def.cf_apache_user), $(def.cf_apache_group));
+      perms => mog("0750", $(def.cf_apache_user), $(def.cf_apache_group));
 
       "$(sys.workdir)/httpd/logs/." -> { "ENT-7730" }
         comment => "Ensure permissions for $(sys.workdir)/httpd/logs",
@@ -224,7 +295,7 @@ bundle agent cfe_internal_setup_knowledge
                     a request. For example Mission Portals api.";
 
 
-      "$(cfe_internal_hub_vars.docroot)/"
+      "$(cfe_internal_hub_vars.docroot)/." -> { "CFE-951"}
         depth_search => recurse_basedir("inf"),
         handle => "cfe_internal_setup_knowledge_files_doc_root_htaccess_perms",
         file_select => cfe_internal_htaccess,
@@ -294,28 +365,49 @@ bundle agent cfe_internal_permissions
   files:
 
     !(policy_server|am_policy_hub)::
-      "$(sys.statedir)/." -> { "ENT-4773" }
-        perms => state_dir_system_owned(),
+      "$(sys.statedir)/." -> { "ENT-4773", "CFE-951" }
+        handle => "state_dir_not_dir_perms",
+        perms => state_dir_system_owned_files(),
         # Important to recurse across file system boundaries, as databases and or state are commonly on different filesystems
         depth_search => recurse_with_base( inf ),
-        file_select => all;
+        file_select => not_dir;
+
+      "$(sys.statedir)/." -> { "ENT-4773", "CFE-951" }
+        handle => "state_dir_dirs_perms",
+        perms => state_dir_system_owned_dirs(),
+        # Important to recurse across file system boundaries, as databases and or state are commonly on different filesystems
+        depth_search => recurse_with_base( inf ),
+        file_select => dirs;
 
     enterprise_edition.(policy_server|am_policy_hub)::
 
-     "$(sys.statedir)/."
+      "$(sys.statedir)/." -> { "CFE-951" }
         perms => mog("0750", "root", "cfpostgres"),
         acl => cf_statedir_acl( @(_cf_statedir_user_aces) ),
         comment => "The database user must be able to read the parent directory of the database or it won't be accessible";
 
-     "$(sys.statedir)/."
-        perms => state_dir_system_owned(),
+     "$(sys.statedir)/." -> { "CFE-951" }
+        perms => state_dir_system_owned_files(),
         depth_search => recurse_except( inf, @(_statedir_standard_perm_exceptions) ),
-        file_select => all,
+        file_select => not_dir,
         comment => "The database user must be able to read the parent directory of the database or it won't be accessible";
 
-      "$(sys.statedir)/pg/."
+      "$(sys.statedir)/." -> { "CFE-951" }
+        perms => state_dir_system_owned_dirs(),
+        depth_search => recurse_except( inf, @(_statedir_standard_perm_exceptions) ),
+        file_select => dirs,
+        comment => "The database user must be able to read the parent directory of the database or it won't be accessible";
+
+      "$(sys.statedir)/pg/." -> { "CFE-951" }
         perms => mog("0600", "cfpostgres", "cfpostgres"),
         depth_search => recurse_with_base( inf ),
+        file_select => not_dir,
+        comment => "No one except for the database user needs to access where the db is installed.";
+
+      "$(sys.statedir)/pg/." -> { "CFE-951" }
+        perms => mog("0700", "cfpostgres", "cfpostgres"),
+        depth_search => recurse_with_base( inf ),
+        file_select => dirs,
         comment => "No one except for the database user needs to access where the db is installed.";
 
       "$(sys.statedir)/cf-execd.sockets/." -> { "ENT-6777" }
@@ -466,13 +558,15 @@ body depth_search recurse_basedir_exclude(d)
 ############################################################################
 
 body file_select cfe_internal_docroot_perms
-# @brief Select files not named `.htacces` or `settings.ldap.php`
+# @brief Select files (not dirs) not named `.htaccess` or `settings.ldap.php`
 {
   leaf_name => { "\.htaccess", "settings.ldap.php", "ha_enabled" };
+  path_name => { "$(cfe_internal_hub_vars.docroot)/vendor/.*"};
+  file_types => { "dir" };
       # htaccess are going the way of the dodo bird
       # settings.ldap.php permissions are handled explicitly in it's own bundle
       # ha_enabled permissions is handled explicitly by cfengine_enterprise_ha_enabled_semaphore_present
-  file_result => "!leaf_name";
+  file_result => "!leaf_name.!file_types.!path_name";
 }
 
 ############################################################################
@@ -509,7 +603,8 @@ body file_select cfe_internal_htaccess
 # @brief select files named `.htaccess`
 {
   leaf_name => { "\.htaccess" };
-  file_result => "leaf_name";
+  file_types => { "dir" };
+  file_result => "leaf_name.!file_types";
 }
 
 ############################################################################
@@ -529,7 +624,8 @@ body file_select cfe_internal_docroot_api_static_perms
       # files here to avoid continual promise repair.
 
   leaf_name => { "\.htaccess", "\.status", "\.pid", "\.abort" };
-  file_result => "!leaf_name";
+  file_types => { "dir" };
+  file_result => "!leaf_name.!file_types";
 }
 ############################################################################
 
@@ -540,7 +636,8 @@ body file_select cfe_internal_docroot_api_static_async_query_status_status_perms
       # query mechanism need to be writeable by the webserver
 
         leaf_name => { "\.status", "\.pid", "\.abort" };
-        file_result => "leaf_name";
+        file_types => { "dir" };
+        file_result => "leaf_name.!file_types";
 }
 
 ############################################################################
@@ -553,7 +650,7 @@ body depth_search cfe_internal_docroot_application_perms
 
 ############################################################################
 
-body perms state_dir_system_owned
+body perms state_dir_system_owned_files
 {
 #+begin_ENT-951
 # Remove after 3.20 is not supported
@@ -578,4 +675,9 @@ body perms state_dir_system_owned
 
       !(freebsd|openbsd|netbsd|darwin|aix|hpux)::
         groups => { "root" };
+}
+body perms state_dir_system_owned_dirs
+{
+  inherit_from => state_dir_system_owned_files;
+  mode => "0700";
 }

--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -260,10 +260,19 @@ bundle agent transport_user
   files:
     "$(create_files)"
       create => "true";
-    "$(home)/."
+
+    "$(home)/." -> { "CFE-951" }
       depth_search => default:recurse_with_base("inf"),
-      file_select => default:all,
-      perms => default:mog( "600", $(user), "root" );
+      file_select => default:dirs,
+      perms => default:mog( "700", $(user), "root" ),
+      comment => "The transport users home directory and children should be accessible only by the transport user itself.";
+
+    "$(home)/." -> { "CFE-951" }
+      depth_search => default:recurse_with_base("inf"),
+      file_select => default:not_dir,
+      perms => default:mog( "600", $(user), "root" ),
+      comment => "The files within the transport users home directory should be readable and writable by the transport user";
+
     "$(ssh_auth_keys)"
       create => "true",
       handle => "ssh_auth_keys_configured",
@@ -317,8 +326,10 @@ bundle agent clean_when_off
     "user" string => "$(cfengine_enterprise_federation:transport_user.user)";
     "home" string => "$(cfengine_enterprise_federation:transport_user.home)";
 @if minimum_version(3.15)
-    "remote_hubs_table_row_count" string => execresult(`$(sys.bindir)/psql cfsettings --quiet --tuples-only --command "SELECT COUNT(*) FROM remote_hubs" 2>/dev/null`, useshell);
-    "federated_reporting_settings_table_row_count" string => execresult(`$(sys.bindir)/psql cfsettings --quiet --tuples-only --command "SELECT COUNT(*) FROM federated_reporting_settings" 2>/dev/null`, useshell);
+      "remote_hubs_table_row_count"
+        string => execresult(`$(sys.bindir)/psql cfsettings --quiet --tuples-only --command "SELECT COUNT(*) FROM remote_hubs" 2>/dev/null`, useshell);
+      "federated_reporting_settings_table_row_count"
+        string => execresult(`$(sys.bindir)/psql cfsettings --quiet --tuples-only --command "SELECT COUNT(*) FROM federated_reporting_settings" 2>/dev/null`, useshell);
 @endif
 
   users:
@@ -345,6 +356,7 @@ bundle agent clean_when_off
       # Oh, the humanity! Where for art thou databases: promises for psql!
       `$(sys.bindir)/psql cfsettings --quiet --command "TRUNCATE TABLE remote_hubs"` -> { "ENT-7233" }
         if => isgreaterthan( "$(remote_hubs_table_row_count)", "0" );
+
       `$(sys.bindir)/psql cfsettings --quiet --command "TRUNCATE TABLE federated_reporting_settings"` -> { "ENT-7233" }
         if => isgreaterthan( "$(federated_reporting_settings_table_row_count)", "0" );
 
@@ -387,20 +399,31 @@ bundle agent federation_manage_files
   files:
     enterprise_edition.(policy_server|am_policy_hub)::
       # Both cfpache and $(transport_user) need permission so adding o+x here
-      "$(cfengine_enterprise_federation:config.federation_dir)/."
+      "$(cfengine_enterprise_federation:config.federation_dir)/." -> { "CFE-951" }
         create => "true",
-        perms => default:mog( "661", "root", "root" );
+        perms => default:mog( "755", "root", "cfapache" );
+
       "$(cfengine_enterprise_federation:config.federation_dir)/cfapache/."
         create => "true",
-        perms => default:mog( "600", "cfapache", "root" );
-      "$(cfengine_enterprise_federation:config.federation_dir)/cfapache/."
+        perms => default:mog( "700", "cfapache", "root" );
+
+      "$(cfengine_enterprise_federation:config.federation_dir)/cfapache/." -> { "CFE-951" }
         depth_search => default:recurse_with_base("inf"),
-        file_select => default:all,
-        perms => default:mog( "600", "cfapache", "root" );
+        file_select => default:dirs,
+        perms => default:mog( "700", "cfapache", "root" ),
+        comment => "The cfapache home directory and children need to be accessible by the web-server";
+
+      "$(cfengine_enterprise_federation:config.federation_dir)/cfapache/." -> { "CFE-951" }
+        depth_search => default:recurse_with_base("inf"),
+        file_select => default:not_dir,
+        perms => default:mog( "600", "cfapache", "root" ),
+        comment => "Files within the cfapache home directory need to be readable and writable by the web server.";
+
     enabled::
-      "$(cfengine_enterprise_federation:config.bin_dir)/."
+      "$(cfengine_enterprise_federation:config.bin_dir)/." -> { "CFE-951" }
         create => "true",
-        perms => default:mog( "660", "root", "$(transport_user)" );
+        perms => default:mog( "0770", "root", "$(transport_user)" );
+
     am_superhub::
       "$(cfengine_enterprise_federation:config.federation_dir)/superhub/."
         create => "true",
@@ -466,7 +489,7 @@ bundle agent federation_manage_files
         perms => default:mog( "600", "root", "root" );
 
     am_transporter::
-      "$(cfengine_enterprise_federation:config.bin_dir)/transport.sh"
+      "$(cfengine_enterprise_federation:config.bin_dir)/transport.sh" -> { "CFE-951" }
         copy_from => default:local_dcp( "$(this.promise_dirname)/../../../templates/federated_reporting/transport.sh" ),
         perms => default:mog( "500", "$(transport_user)", "root" );
 
@@ -597,6 +620,7 @@ bundle agent data_transport
       "/bin/bash"
         arglist => {"$(cfengine_enterprise_federation:config.bin_dir)/transport.sh pull $(pull_args)"},
         contain => contain_transport_user;
+
     am_puller.!am_paused.default:cfengine_mp_fr_enable_distributed_cleanup::
       "/bin/bash"
         arglist => {"$(cfengine_enterprise_federation:config.bin_dir)/transfer_distributed_cleanup_items.sh $(pull_args)"},

--- a/cfe_internal/update/update_policy.cf
+++ b/cfe_internal/update/update_policy.cf
@@ -280,12 +280,22 @@ bundle agent cfe_internal_update_policy_cpv
 
     am_policy_hub::
 
-      "$(master_location)/."
-      comment => "Make sure masterfiles folder has right file permissions",
-      handle => "cfe_internal_update_policy_files_sys_workdir_masterfiles",
-      perms => u_m($(update_def.masterfiles_perms_mode)),
-      depth_search => u_recurse_basedir("inf"),
-      action => u_immediate;
+      "$(master_location)/." -> { "CFE-951" }
+        comment => "Make sure masterfiles folder has right file permissions",
+        handle => "cfe_internal_update_policy_files_sys_workdir_masterfiles_dirs",
+        perms => u_m($(update_def.masterfiles_perms_mode_dirs)),
+        file_select => u_dirs,
+        depth_search => u_recurse_basedir("inf"),
+        action => u_immediate;
+
+      "$(master_location)/." -> { "CFE-951" }
+        comment => "Make sure masterfiles folder has right file permissions",
+        handle => "cfe_internal_update_policy_files_sys_workdir_masterfiles_not_dir",
+        perms => u_m($(update_def.masterfiles_perms_mode_not_dir)),
+        file_select => u_not_dir,
+        depth_search => u_recurse_basedir("inf"),
+        action => u_immediate;
+
 
   methods:
     debian|redhat|amazon_linux|suse|sles|opensuse::
@@ -845,3 +855,17 @@ body file_select not_vendored_modules(pathname)
   file_result => "path_name";
 }
 #########################################################
+body file_select u_dirs
+# @brief Select directories
+{
+        file_types  => { "dir" };
+        file_result => "file_types";
+}
+body file_select u_not_dir
+# @brief Select all files that are not directories
+{
+        file_types => { "dir" };
+        file_result => "!file_types";
+}
+
+

--- a/controls/update_def.cf.in
+++ b/controls/update_def.cf.in
@@ -66,10 +66,17 @@ bundle common update_def
                            not(isvariable("input_name_patterns"))),
         meta => { "defvar" };
 
-      # the permissions for your masterfiles, which will propagate to inputs
-      "masterfiles_perms_mode" string => "0600",
-      handle => "common_def_vars_masterfiles_perms_mode",
-      meta => { "defvar" };
+      # the permissions for your masterfiles files (not dirs), which will propagate to inputs
+      "masterfiles_perms_mode_not_dir" -> { "CFE-951" }
+        string => "0600",
+        handle => "common_def_vars_masterfiles_perms_mode_not_dir",
+        meta => { "defvar" };
+
+      "masterfiles_perms_mode_dirs" -> { "CFE-951" }
+        string => "0700",
+        handle => "common_def_vars_masterfiles_perms_mode_dirs",
+        meta => { "defvar" };
+
 
       "dc_scripts" string => "$(sys.workdir)/httpd/htdocs/api/dc-scripts",
       comment => "Directory where VCS scripts are located on Enterprise Hub";

--- a/lib/cfe_internal_hub.cf
+++ b/lib/cfe_internal_hub.cf
@@ -137,7 +137,7 @@ AND    t.$(settings[$(index)][time_key]) <= (z.latest - '$(settings[$(index)][hi
 @if minimum_version(3.15.0)
         inform => "false",
 @endif
-        contain => silent,
+        contain => default:silent,
         handle => "cf_database_maintain_report_$(settings[$(index)][report])";
 }
 
@@ -189,14 +189,14 @@ bundle agent cfe_internal_database_cleanup_consumer_status (row_count)
 @if minimum_version(3.15.0)
         inform => "false",
 @endif
-        contain => silent,
+        contain => default:silent,
         handle => "cf_database_maintain_consumer_status";
 
       "$(sys.bindir)/psql cfdb -c \"$(delete_future_ts_query)\"" -> { "ENT-4362" }
 @if minimum_version(3.15.0)
         inform => "false",
 @endif
-        contain => silent,
+        contain => default:silent,
         handle => "cf_database_maintain_consumer_status_no_future_timestamps";
 
 }
@@ -214,7 +214,7 @@ bundle agent cfe_internal_database_cleanup_diagnostics (settings)
 @if minimum_version(3.15.0)
         inform => "false",
 @endif
-        contain => silent,
+        contain => default:silent,
         handle => "cf_database_maintain_diagnostics_$(settings[$(index)][report])";
 }
 
@@ -234,14 +234,14 @@ bundle agent cfe_internal_database_cleanup_promise_log (history_length_days)
 @if minimum_version(3.15.0)
         inform => "false",
 @endif
-        contain => silent,
+        contain => default:silent,
         handle => "cf_database_maintain_promise_log_repaired";
 
       "$(sys.bindir)/psql cfdb -c \"$(cleanup_query_notkept)\""
 @if minimum_version(3.15.0)
         inform => "false",
 @endif
-        contain => silent,
+        contain => default:silent,
         handle => "cf_database_maintain_promise_log_notkept";
 }
 
@@ -260,7 +260,7 @@ bundle agent cfe_internal_database_partitioning()
 @if minimum_version(3.15.0)
         inform => "false",
 @endif
-        contain => silent,
+        contain => default:silent,
         handle => "cf_database_create_partition_promise_log_$(promise_outcome)";
 }
 

--- a/lib/files.cf
+++ b/lib/files.cf
@@ -1941,6 +1941,13 @@ body file_select exclude(name)
 
 ##
 
+body file_select not_dir
+# @brief Select all files that are not directories
+{
+      file_types => { "dir" };
+      file_result => "!file_types";
+}
+
 body file_select plain
 # @brief Select plain, regular files
 {
@@ -1971,7 +1978,7 @@ body file_select ex_list(names)
 # @brief Select all files except those that match `names`
 # @param names A list of regular expressions
 {
-      leaf_name  => { @(names)};
+      leaf_name  => { @(names) };
       file_result => "!leaf_name";
 }
 

--- a/templates/federated_reporting/psql_wrapper.sh.mustache
+++ b/templates/federated_reporting/psql_wrapper.sh.mustache
@@ -13,6 +13,7 @@ if [ $# -ne 2 ]; then
 fi
 
 TMP=$(mktemp)
+cd /tmp
 OUT=$(su - cfpostgres --command "{{{vars.sys.bindir}}}/psql --quiet --tuples-only --no-align --no-psqlrc \"$1\" --command=\"$2\"" 2> $TMP)
 RETURN_CODE=$?
 ERR=$(<$TMP)


### PR DESCRIPTION
This change aligns the Masterfiles Policy Framework and the CFEngine binary
default for rxdirs. With this change, the vendored policy should not result in
any warnings about rxdirs not being explicitly defined. Cases where rxdirs was
previously relied on have been adjusted so that cases were directories should
have the executable bit are explicitly promised.

Ticket: CFE-951
Changelog: Title
(cherry picked from commit 999a27585567e6e1689917d1250e03eb1cbd37b3)

Merge together:
https://github.com/cfengine/core/pull/4930
https://github.com/cfengine/masterfiles/pull/2270