### PR TITLE
CFE-3947: Renamed bundle agent main to bundle agent mpf_main

### DIFF
--- a/promises.cf.in
+++ b/promises.cf.in
@@ -56,7 +56,7 @@ body common control
 
                          # Agent bundle
                           cfe_internal_management,   # See cfe_internal/CFE_cfengine.cf
-                          main,
+                          mpf_main,
                           @(cfengine_enterprise_hub_ha.management_bundles),
                           @(def.bundlesequence_end),
 

--- a/services/main.cf
+++ b/services/main.cf
@@ -1,11 +1,11 @@
 ###############################################################################
 #
-# bundle agent main
+# bundle agent mpf_main
 #  - User/Site policy entry
 #
 ###############################################################################
 
-bundle agent main
+bundle agent mpf_main
 # User Defined Service Catalogue
 {
   methods:


### PR DESCRIPTION
This change helps to avoid potential duplicate definition of bundle errors from
having a bundle named main included by a policy entry that contains a bundle
agent __main__.

Ticket: CFE-3947
Changelog: Title