### PR TITLE
Fix typo of classname in distributed cleanup python script (3.18)

### DIFF
--- a/templates/federated_reporting/distributed_cleanup.py
+++ b/templates/federated_reporting/distributed_cleanup.py
@@ -10,7 +10,7 @@ This enables policy in cfe_internal/enterprise/federation/federation.cf
 ```json
 {
   "classes": {
-    "cfengine_mp_enable_fr_distributed_cleanup": [ "any::" ]
+    "cfengine_mp_fr_enable_distributed_cleanup": [ "any::" ]
   }
 }
 ```


### PR DESCRIPTION
Changelog: none
Ticket: none
(cherry picked from commit 2e8624000af10591b766c5ab36e623f53cbd798e)