### PR TITLE
ENT-8464: Use FQDN for cert path in distributed cleanup

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -1490,6 +1490,10 @@ For example, to define this class via Augments:
 }
 ```
 
+**History:**
+
+* Added in CFEngine 3.19.0, 3.18.1
+
 #### Configure SSL Certificate Directory for Federated Reporting Distributed Cleanup
 
 When custom certificates are in use distributed cleanup needs to know where to find them. To configure the path where certificates are found define `default:def.DISTRIBUTED_CLEANUP_SSL_CERT_DIR`, for example:
@@ -1501,6 +1505,10 @@ When custom certificates are in use distributed cleanup needs to know where to f
   }
 }
 ```
+
+**History:**
+
+* Added in CFEngine 3.20.0, 3.18.2
 
 ## Recommendations
 

--- a/MPF.md
+++ b/MPF.md
@@ -1473,6 +1473,35 @@ config when it notices a change in *policy*.
 
 **History**: Added in 3.11.
 
+### Federated Reporting
+#### Enable Federated Reporting Distributed Cleanup
+
+Hosts that report to multiple feeders result in duplicate entries and other issues. Distributed cleanup helps to deal with this condition.
+
+To enable this functionality define the class `default:cfengine_mp_fr_enable_distributed_cleanup` on the _superhub_.
+
+For example, to define this class via Augments:
+
+```json
+{
+  "classes": {
+    "cfengine_mp_fr_enable_distributed_cleanup": [ "any::" ]
+  }
+}
+```
+
+#### Configure SSL Certificate Directory for Federated Reporting Distributed Cleanup
+
+When custom certificates are in use distributed cleanup needs to know where to find them. To configure the path where certificates are found define `default:def.DISTRIBUTED_CLEANUP_SSL_CERT_DIR`, for example:
+
+```json
+{
+  "vars": {
+    "DISTRIBUTED_CLEANUP_SSL_CERT_DIR": "/path/to/my/cert/dir"
+  }
+}
+```
+
 ## Recommendations
 
 The MPF includes policy that inspects the system and makes recommendations about

--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -802,7 +802,16 @@ bundle agent distributed_cleanup_run
     am_superhub.!am_paused.default:cfengine_mp_fr_enable_distributed_cleanup::
       "$(sys.bindir)/cfengine-selected-python"
         args => "$(cfengine_enterprise_federation:config.bin_dir)/distributed_cleanup.py",
-        arglist => { @(_arglist) };
+        arglist => { @(_arglist) },
+        unless => isvariable( "default:def.DISTRIBUTED_CLEANUP_SSL_CERT_DIR" );
+
+      "SSL_CERT_DIR=$(default:def.DISTRIBUTED_CLEANUP_SSL_CERT_DIR) $(sys.bindir)/cfengine-selected-python" -> { "ENT-8477", "ENT-8464" }
+        args => "$(cfengine_enterprise_federation:config.bin_dir)/distributed_cleanup.py",
+        arglist => { @(_arglist) },
+        if => isvariable( "default:def.DISTRIBUTED_CLEANUP_SSL_CERT_DIR"),
+        contain => default:in_shell,
+        comment => "When custom SSL certificates are used from the non default location we need to let the script know where to find them.";
+
 }
 
 body file control

--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -786,10 +786,10 @@ bundle agent distributed_cleanup_setup
     am_superhub|am_feeder::
       "${distributed_cleanup_dir}/."
         create => "true";
-      "${distributed_cleanup_dir}/${sys.host}.pub"
+      "${distributed_cleanup_dir}/${sys.fqhost}.pub"
         copy_from => default:local_cp("${sys.workdir}/ppkeys/localhost.pub");
-      "${distributed_cleanup_dir}/${sys.host}.cert"
-        copy_from => default:local_cp("${sys.workdir}/httpd/ssl/certs/${sys.host}.cert");
+      "${distributed_cleanup_dir}/${sys.fqhost}.cert"
+        copy_from => default:local_cp("${sys.workdir}/httpd/ssl/certs/${sys.fqhost}.cert");
 }
 
 bundle agent distributed_cleanup_run

--- a/templates/federated_reporting/distributed_cleanup.py
+++ b/templates/federated_reporting/distributed_cleanup.py
@@ -59,14 +59,15 @@ CERT_PATH = os.path.join(DISTRIBUTED_CLEANUP_DIR, "hubs.cert")
 
 # Note: remove the file at DISTRIBUTED_CLEANUP_SECRET_PATH to reset everything.
 # api calls will overwrite fr_distributed_cleanup user and role on superhub and all feeders.
-DISTRIBUTED_CLEANUP_SECRET_PATH = os.path.join(WORKDIR, "state/fr_distributed_cleanup.cfsecret")
+DISTRIBUTED_CLEANUP_SECRET_PATH = os.path.join(
+    WORKDIR, "state/fr_distributed_cleanup.cfsecret"
+)
 
 
 def interactive_setup():
     fr_distributed_cleanup_password = "".join(random.choices(string.printable, k=20))
     admin_pass = getpass(
-        prompt="Enter admin password for superhub {}: ".format(
-            socket.getfqdn())
+        prompt="Enter admin password for superhub {}: ".format(socket.getfqdn())
     )
     api = NovaApi(api_user="admin", api_password=admin_pass)
 

--- a/templates/federated_reporting/distributed_cleanup.py
+++ b/templates/federated_reporting/distributed_cleanup.py
@@ -25,7 +25,7 @@ admin credentials on each feeder.
 import argparse
 import logging
 import os
-import platform
+import socket
 import string
 import random
 import subprocess
@@ -65,7 +65,8 @@ DISTRIBUTED_CLEANUP_SECRET_PATH = os.path.join(WORKDIR, "state/fr_distributed_cl
 def interactive_setup():
     fr_distributed_cleanup_password = "".join(random.choices(string.printable, k=20))
     admin_pass = getpass(
-        prompt="Enter admin password for superhub {}: ".format(platform.node())
+        prompt="Enter admin password for superhub {}: ".format(
+            socket.getfqdn())
     )
     api = NovaApi(api_user="admin", api_password=admin_pass)
 

--- a/templates/federated_reporting/nova_api.py
+++ b/templates/federated_reporting/nova_api.py
@@ -36,7 +36,12 @@ _DEFAULT_SECRETS_PATH = "{}/httpd/secrets.ini".format(_WORKDIR)
 
 class NovaApi:
     def __init__(
-        self, hostname=None, api_user="CFE_ROBOT", api_password=None, cert_path=None, ca_cert_dir=None
+        self,
+        hostname=None,
+        api_user="CFE_ROBOT",
+        api_password=None,
+        cert_path=None,
+        ca_cert_dir=None,
     ):
         self._hostname = hostname or str(socket.getfqdn())
         self._api_user = api_user
@@ -51,7 +56,7 @@ class NovaApi:
         else:
             self._cert_path = cert_path
         if ca_cert_dir is None:
-            self._ca_cert_dir = os.environ.get('SSL_CERT_DIR')
+            self._ca_cert_dir = os.environ.get("SSL_CERT_DIR")
         else:
             self._ca_cert_dir = ca_cert_dir
 
@@ -94,8 +99,7 @@ class NovaApi:
             payload = json.JSONEncoder().encode(body)
         else:
             payload = body
-        response = self._http.request(
-            method, url, headers=self._headers, body=payload)
+        response = self._http.request(method, url, headers=self._headers, body=payload)
         return self._build_response(response)
 
     def _build_response(self, response):

--- a/templates/federated_reporting/nova_api.py
+++ b/templates/federated_reporting/nova_api.py
@@ -26,7 +26,7 @@ print(api.put_role_permissions("yj", ["query.post"]))
 
 import json
 import os
-import platform
+import socket
 import sys
 import urllib3
 
@@ -36,9 +36,9 @@ _DEFAULT_SECRETS_PATH = "{}/httpd/secrets.ini".format(_WORKDIR)
 
 class NovaApi:
     def __init__(
-        self, hostname=None, api_user="CFE_ROBOT", api_password=None, cert_path=None
+        self, hostname=None, api_user="CFE_ROBOT", api_password=None, cert_path=None, ca_cert_dir=None
     ):
-        self._hostname = hostname or str(platform.node())
+        self._hostname = hostname or str(socket.getfqdn())
         self._api_user = api_user
         if api_password is None:
             self._api_password = self._get_robot_password()
@@ -46,14 +46,19 @@ class NovaApi:
             self._api_password = api_password
         if cert_path is None:
             self._cert_path = "{}/httpd/ssl/certs/{}.cert".format(
-                _WORKDIR, platform.node()
+                _WORKDIR, socket.getfqdn()
             )
         else:
             self._cert_path = cert_path
+        if ca_cert_dir is None:
+            self._ca_cert_dir = os.environ.get('SSL_CERT_DIR')
+        else:
+            self._ca_cert_dir = ca_cert_dir
 
         self._http = urllib3.PoolManager(
             cert_reqs="CERT_REQUIRED",
             ca_certs=self._cert_path,
+            ca_cert_dir=self._ca_cert_dir,
         )
         self._headers = urllib3.make_headers(
             basic_auth="{}:{}".format(self._api_user, self._api_password)
@@ -89,7 +94,8 @@ class NovaApi:
             payload = json.JSONEncoder().encode(body)
         else:
             payload = body
-        response = self._http.request(method, url, headers=self._headers, body=payload)
+        response = self._http.request(
+            method, url, headers=self._headers, body=payload)
         return self._build_response(response)
 
     def _build_response(self, response):

--- a/templates/federated_reporting/transfer_distributed_cleanup_items.sh
+++ b/templates/federated_reporting/transfer_distributed_cleanup_items.sh
@@ -36,7 +36,7 @@ done
 
 # check that hubs.cert is the most recent *.cert file, if not then update it
 # from the other cert files (all the hubs).
-ls -t1 $CFE_FR_DISTRIBUTED_CLEANUP_DIR/*.cert | head -n1 | grep -q hubs.cert || cat $(ls $CFE_FR_DISTRIBUTED_CLEANUP_DIR/*.cert | grep -v hubs.cert) > "$CFE_FR_DISTRIBUTED_CLEANUP_DIR/hubs.cert"
+ls -t1 $CFE_FR_DISTRIBUTED_CLEANUP_DIR/*.cert | head -n1 | grep -q hubs.cert || sed -sn 'p' $(ls $CFE_FR_DISTRIBUTED_CLEANUP_DIR/*.cert | grep -v hubs.cert) > "$CFE_FR_DISTRIBUTED_CLEANUP_DIR/hubs.cert"
 
 for feeder in $@; do
   "$CFE_FR_TRANSPORTER" $CFE_FR_TRANSPORTER_ARGS "$CFE_FR_DISTRIBUTED_CLEANUP_DIR/hubs.cert" "$CFE_FR_FEEDER_USERNAME@${feeder}:/$CFE_FR_DISTRIBUTED_CLEANUP_DIR/" ||

--- a/templates/federated_reporting/transfer_distributed_cleanup_items.sh
+++ b/templates/federated_reporting/transfer_distributed_cleanup_items.sh
@@ -27,7 +27,7 @@ if [ $# = 0 ]; then
 fi
 
 for feeder in $@; do
-  feeder_hostname=$("$CFE_FR_SSH" $CFE_FR_SSH_ARGS "$CFE_FR_FEEDER_USERNAME@${feeder}" hostname)
+  feeder_hostname=$("$CFE_FR_SSH" $CFE_FR_SSH_ARGS "$CFE_FR_FEEDER_USERNAME@${feeder}" hostname -f)
   "$CFE_FR_TRANSPORTER" $CFE_FR_TRANSPORTER_ARGS "$CFE_FR_FEEDER_USERNAME@${feeder}:/$CFE_FR_DISTRIBUTED_CLEANUP_DIR/${feeder_hostname}.pub" "$CFE_FR_DISTRIBUTED_CLEANUP_DIR/" &&
   "$CFE_FR_TRANSPORTER" $CFE_FR_TRANSPORTER_ARGS "$CFE_FR_FEEDER_USERNAME@${feeder}:/$CFE_FR_DISTRIBUTED_CLEANUP_DIR/${feeder_hostname}.cert" "$CFE_FR_DISTRIBUTED_CLEANUP_DIR/" ||
     log "Failed to pull fr_distributed_cleanup items from hub $feeder"


### PR DESCRIPTION
Testing was done on machines where platform.node() was
the same as socket.getfqdn() but this is often not
the case.

Ticket: ENT-8464
Changelog: title