### PR TITLE
ENT-8533: Added lib/templates to packaged assets

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -223,7 +223,7 @@ do
         MASTERFILES_INSTALL_TARGETS="$MASTERFILES_INSTALL_TARGETS `echo $j | sed -e 's/\.in$//'`"
     done
 done
-for i in templates cfe_internal modules/packages/vendored
+for i in templates cfe_internal modules/packages/vendored lib/templates
 do
     for j in `find "$srcdir/$i" -name '*.mustache' -o -name '*.sh' -o -name '*.awk' -o -name '*.sed' -o -name '*.ps1' -o -name '*.py'`
     do


### PR DESCRIPTION
lib/testing.cf (which is not loaded as part of the stdlib by default) uses
lib/templates/tap.mustache and lib/templates/junit.mustache but those files were
not part of the packaged MPF prior to this change, making it difficult to simply
add lib/testing.cf to inputs to start writing policy tests.

Ticket: ENT-8533
Changelog: Title