### PR TITLE
ENT-8209: Worked around apachectl stop returning before all processes are actually stopped

### DIFF
--- a/cfe_internal/enterprise/mission_portal.cf
+++ b/cfe_internal/enterprise/mission_portal.cf
@@ -131,8 +131,7 @@ bundle agent mission_portal_apache_from_stage(config, staged_config)
   commands:
 
     !systemd_supervised::
-      "LD_LIBRARY_PATH=$(sys.workdir)/lib:$LD_LIBRARY_PATH $(sys.workdir)/httpd/bin/apachectl"
-        args => "stop",
+      "LD_LIBRARY_PATH=$(sys.workdir)/lib:$LD_LIBRARY_PATH $(sys.workdir)/httpd/bin/apachectl stop; sleep 2" -> { "ENT-8209" }
         if => and( returnszero("$(validate_config) > /dev/null 2>&1 ", "useshell"),
                    isnewerthan( $(staged_config), $(config) ) ),
         contain => in_shell,


### PR DESCRIPTION
This change works around the fact that apachectl stop returns before it has
actually completed stopping all httpd processes. A subsequent promise can fail
to re-start apache since there are still active processes. Limited testing
showed that the processes hung around for less than one second, so hopefully a 2
second sleep after issuing stop will be sufficient.

Ticket: ENT-8209
Changelog: Title
(cherry picked from commit a68ea8c0a17abd41b5a4e2819f30008678191e01)