### PR TITLE
ENT-8504: Stopped loading mod_info

### DIFF
--- a/cfe_internal/enterprise/templates/httpd.conf.mustache
+++ b/cfe_internal/enterprise/templates/httpd.conf.mustache
@@ -46,7 +46,6 @@ LoadModule mime_module modules/mod_mime.so
 LoadModule status_module modules/mod_status.so
 LoadModule autoindex_module modules/mod_autoindex.so
 LoadModule asis_module modules/mod_asis.so
-LoadModule info_module modules/mod_info.so
 LoadModule vhost_alias_module modules/mod_vhost_alias.so
 LoadModule negotiation_module modules/mod_negotiation.so
 LoadModule dir_module modules/mod_dir.so


### PR DESCRIPTION
Since we do not use the features provided by this module we don't need to load
it by default.

Ticket: ENT-8504
Changelog: Title