### PR TITLE
ENT-8547: Removed comments about underscore prefixed vars not being reported by default

### DIFF
--- a/controls/reports.cf
+++ b/controls/reports.cf
@@ -27,10 +27,6 @@ bundle server report_access_rules
 
 body report_data_select default_data_select_host
 # @brief Data authorized by non policy servers for collection by cf-hub
-#
-# By convention variables and classes known to be internal, (having no
-# reporting value) should be prefixed with an underscore. By default cf-hub
-# explicitly excludes these variables and classes from collection.
 {
       metatags_include => { "inventory", "report" };
       metatags_exclude => { "noreport" };
@@ -40,10 +36,6 @@ body report_data_select default_data_select_host
 
 body report_data_select default_data_select_policy_hub
 # @brief Data authorized by policy servers for collection by cf-hub
-#
-# By convention variables and classes known to be internal, (having no
-# reporting value) should be prefixed with an underscore. By default cf-hub
-# explicitly excludes these variables and classes from collection.
 {
       metatags_include => { "inventory", "report" };
       metatags_exclude => { "noreport" };


### PR DESCRIPTION
This has not been true since 3.6.0 when variables_exclude was removed. Prior to
it's removal it did indeed exclude underscore prefixed variables as part of
bce7032f603deb2b8df8f87a26838816d6d2266d.

Ticket: ENT-8547
Changelog: None