### PR TITLE
ENT-8498: Stopped loading Apache substitute module on Enterprise Hubs (3.18)

### DIFF
--- a/cfe_internal/enterprise/templates/httpd.conf.mustache
+++ b/cfe_internal/enterprise/templates/httpd.conf.mustache
@@ -29,7 +29,6 @@ LoadModule reqtimeout_module modules/mod_reqtimeout.so
 LoadModule ext_filter_module modules/mod_ext_filter.so
 LoadModule include_module modules/mod_include.so
 LoadModule filter_module modules/mod_filter.so
-LoadModule substitute_module modules/mod_substitute.so
 LoadModule deflate_module modules/mod_deflate.so
 LoadModule log_config_module modules/mod_log_config.so
 LoadModule log_forensic_module modules/mod_log_forensic.so


### PR DESCRIPTION
Merge Together:
- https://github.com/cfengine/buildscripts/pull/969

We do not use functionality provided by this module so we should not load it by
default.

Ticket: ENT-8498
Changelog: Title
(cherry picked from commit 1a3a662e16116a1789a81578b57d8983aeedbb06)