### PR TITLE
ENT-8499: Stopped loading Apache speling_module by default on Enterprise Hubs

### DIFF
--- a/cfe_internal/enterprise/templates/httpd.conf.mustache
+++ b/cfe_internal/enterprise/templates/httpd.conf.mustache
@@ -49,7 +49,6 @@ LoadModule vhost_alias_module modules/mod_vhost_alias.so
 LoadModule negotiation_module modules/mod_negotiation.so
 LoadModule dir_module modules/mod_dir.so
 LoadModule actions_module modules/mod_actions.so
-LoadModule speling_module modules/mod_speling.so
 LoadModule alias_module modules/mod_alias.so
 LoadModule rewrite_module modules/mod_rewrite.so
 LoadModule authnz_ldap_module modules/mod_authnz_ldap.so


### PR DESCRIPTION
Merge Together:
- https://github.com/cfengine/buildscripts/pull/970

We don't use any of the features this module provides, so we should not load the
module by default.

Ticket: ENT-8499
Changelog: Title