### PR TITLE
ENT-8497: Stopped loading Apache mod_version by default on Enterprise Hubs (3.15)

### DIFF
--- a/cfe_internal/enterprise/templates/httpd.conf.mustache
+++ b/cfe_internal/enterprise/templates/httpd.conf.mustache
@@ -41,7 +41,6 @@ LoadModule headers_module modules/mod_headers.so
 LoadModule usertrack_module modules/mod_usertrack.so
 LoadModule unique_id_module modules/mod_unique_id.so
 LoadModule setenvif_module modules/mod_setenvif.so
-LoadModule version_module modules/mod_version.so
 LoadModule mime_module modules/mod_mime.so
 LoadModule autoindex_module modules/mod_autoindex.so
 LoadModule asis_module modules/mod_asis.so


### PR DESCRIPTION
Merge Together:
- https://github.com/cfengine/buildscripts/pull/974

We do not use the functionality provided by this module, so we should  not load
it by default.

Ticket: ENT-8497
Changelog: Title
(cherry picked from commit c9b9ed92f4cbe8d765836d3223defff558c40881)