### PR TITLE
ENT-8514: Stopped loading Apache mod_autoindex by default on Enterprise Hubs (3.15)

### DIFF
--- a/cfe_internal/enterprise/templates/httpd.conf.mustache
+++ b/cfe_internal/enterprise/templates/httpd.conf.mustache
@@ -43,7 +43,6 @@ LoadModule unique_id_module modules/mod_unique_id.so
 LoadModule setenvif_module modules/mod_setenvif.so
 LoadModule version_module modules/mod_version.so
 LoadModule mime_module modules/mod_mime.so
-LoadModule autoindex_module modules/mod_autoindex.so
 LoadModule asis_module modules/mod_asis.so
 LoadModule vhost_alias_module modules/mod_vhost_alias.so
 LoadModule negotiation_module modules/mod_negotiation.so


### PR DESCRIPTION
Merge Together:
- https://github.com/cfengine/masterfiles/pull/2304

We do not use the features provided by this module, so we should not load it by
default.

Ticket: ENT-8514
Changelog: Title
(cherry picked from commit 149713b87cbd4446693fbad445e64318c6e44300)