### PR TITLE
ENT-8501: Stopped loading Apache mod_log_forensic by default on Enterprise Hubs (3.18)

### DIFF
--- a/cfe_internal/enterprise/templates/httpd.conf.mustache
+++ b/cfe_internal/enterprise/templates/httpd.conf.mustache
@@ -32,7 +32,6 @@ LoadModule filter_module modules/mod_filter.so
 LoadModule substitute_module modules/mod_substitute.so
 LoadModule deflate_module modules/mod_deflate.so
 LoadModule log_config_module modules/mod_log_config.so
-LoadModule log_forensic_module modules/mod_log_forensic.so
 LoadModule logio_module modules/mod_logio.so
 LoadModule env_module modules/mod_env.so
 LoadModule mime_magic_module modules/mod_mime_magic.so


### PR DESCRIPTION
Merge Together:
- https://github.com/cfengine/buildscripts/pull/985

We do not use the features provided by this module, so we should not load it by
default.

Ticket: ENT-8501
Changelog: Title
(cherry picked from commit 15a7df927d57c76d4190cb9b74fb3de430415ed9)