### PR TITLE
ENT-8503: Stopped loading Apache mod_actions by default on Enterprise Hubs (3.15)

### DIFF
--- a/cfe_internal/enterprise/templates/httpd.conf.mustache
+++ b/cfe_internal/enterprise/templates/httpd.conf.mustache
@@ -48,7 +48,6 @@ LoadModule asis_module modules/mod_asis.so
 LoadModule vhost_alias_module modules/mod_vhost_alias.so
 LoadModule negotiation_module modules/mod_negotiation.so
 LoadModule dir_module modules/mod_dir.so
-LoadModule actions_module modules/mod_actions.so
 LoadModule alias_module modules/mod_alias.so
 LoadModule rewrite_module modules/mod_rewrite.so
 LoadModule authnz_ldap_module modules/mod_authnz_ldap.so


### PR DESCRIPTION
Merge Together:
- https://github.com/cfengine/buildscripts/pull/989

We do not use the features provided by this module, so we should not load it by
default.

Ticket: ENT-8503
Changelog: Title
(cherry picked from commit d8f8f7272e0b237c240ca9475a1327c5f3c7fc50)