### PR TITLE
ENT-8505: Stopped loading Apache mod_asis by default on Enterprise Hubs (3.18)

### DIFF
--- a/cfe_internal/enterprise/templates/httpd.conf.mustache
+++ b/cfe_internal/enterprise/templates/httpd.conf.mustache
@@ -40,7 +40,6 @@ LoadModule usertrack_module modules/mod_usertrack.so
 LoadModule unique_id_module modules/mod_unique_id.so
 LoadModule setenvif_module modules/mod_setenvif.so
 LoadModule mime_module modules/mod_mime.so
-LoadModule asis_module modules/mod_asis.so
 LoadModule vhost_alias_module modules/mod_vhost_alias.so
 LoadModule negotiation_module modules/mod_negotiation.so
 LoadModule dir_module modules/mod_dir.so


### PR DESCRIPTION
Merge Together:
- https://github.com/cfengine/buildscripts/pull/991


We do not use the features provided by this module, so we should not load it by
default.

Ticket: ENT-8505
Changelog: Title
(cherry picked from commit 6237f333df7736f2fcc941a617c5f438d23a457e)