### PR TITLE
ENT-8507: Stopped loading Apache mod_include by default on Enterprise Hubs (3.15)

### DIFF
--- a/cfe_internal/enterprise/templates/httpd.conf.mustache
+++ b/cfe_internal/enterprise/templates/httpd.conf.mustache
@@ -27,7 +27,6 @@ LoadModule dbd_module modules/mod_dbd.so
 LoadModule dumpio_module modules/mod_dumpio.so
 LoadModule reqtimeout_module modules/mod_reqtimeout.so
 LoadModule ext_filter_module modules/mod_ext_filter.so
-LoadModule include_module modules/mod_include.so
 LoadModule filter_module modules/mod_filter.so
 LoadModule substitute_module modules/mod_substitute.so
 LoadModule deflate_module modules/mod_deflate.so


### PR DESCRIPTION
Merge Together:
- https://github.com/cfengine/buildscripts/pull/995

We do not use the features provided by this module, so we should not load it by
default.

Ticket: ENT-8507
Changelog: Title
(cherry picked from commit 8ffe176eb3654f3b3aa9f1daa0cbcaa948e816e3)