### PR TITLE
ENT-8509: Stopped loading Apache mod_ldap by default on Enterprise Hubs (3.15)

### DIFF
--- a/cfe_internal/enterprise/templates/httpd.conf.mustache
+++ b/cfe_internal/enterprise/templates/httpd.conf.mustache
@@ -52,7 +52,6 @@ LoadModule actions_module modules/mod_actions.so
 LoadModule alias_module modules/mod_alias.so
 LoadModule rewrite_module modules/mod_rewrite.so
 LoadModule authnz_ldap_module modules/mod_authnz_ldap.so
-LoadModule ldap_module modules/mod_ldap.so
 LoadModule ssl_module modules/mod_ssl.so
 
 # Required to drop privledges


### PR DESCRIPTION
Merge Together:
- https://github.com/cfengine/buildscripts/pull/998

We do not use the features provided by this module, so we should not load it by
default.

Ticket: ENT-8509
Changelog: Title
(cherry picked from commit c423f32fb5d36502438a7765c7f06640b6efbe1e)