### PR TITLE
ENT-8511: Stopped loading Apache mod_negotiation by default on Enterprise Hubs

### DIFF
--- a/cfe_internal/enterprise/templates/httpd.conf.mustache
+++ b/cfe_internal/enterprise/templates/httpd.conf.mustache
@@ -46,7 +46,6 @@ LoadModule mime_module modules/mod_mime.so
 LoadModule autoindex_module modules/mod_autoindex.so
 LoadModule asis_module modules/mod_asis.so
 LoadModule vhost_alias_module modules/mod_vhost_alias.so
-LoadModule negotiation_module modules/mod_negotiation.so
 LoadModule dir_module modules/mod_dir.so
 LoadModule actions_module modules/mod_actions.so
 LoadModule alias_module modules/mod_alias.so


### PR DESCRIPTION
Merge Together:
- https://github.com/cfengine/buildscripts/pull/999

We do not use the features provided by this module, so we should not load it by
default.

Ticket: ENT-8511
Changelog: Title