### PR TITLE
ENT-8512: Stopped loading Apache mod_authnz_ldap by default on Enterprise Hubs (3.15)

### DIFF
--- a/cfe_internal/enterprise/templates/httpd.conf.mustache
+++ b/cfe_internal/enterprise/templates/httpd.conf.mustache
@@ -43,7 +43,6 @@ LoadModule vhost_alias_module modules/mod_vhost_alias.so
 LoadModule dir_module modules/mod_dir.so
 LoadModule alias_module modules/mod_alias.so
 LoadModule rewrite_module modules/mod_rewrite.so
-LoadModule authnz_ldap_module modules/mod_authnz_ldap.so
 LoadModule ssl_module modules/mod_ssl.so
 
 # Required to drop privledges


### PR DESCRIPTION
Merge Together:
- https://github.com/cfengine/buildscripts/pull/1004

We do not use the features provided by this module, so we should not load it by
default.

Ticket: ENT-8512
Changelog: Title
(cherry picked from commit b3fbdd36bf1caf32a1e741d4f1c471327116a2f4)