### PR TITLE
ENT-8517: Stopped loading Apache mod_mime_magic by default on Enterprise Hubs (3.18)

### DIFF
--- a/cfe_internal/enterprise/templates/httpd.conf.mustache
+++ b/cfe_internal/enterprise/templates/httpd.conf.mustache
@@ -32,7 +32,6 @@ LoadModule deflate_module modules/mod_deflate.so
 LoadModule log_config_module modules/mod_log_config.so
 LoadModule log_forensic_module modules/mod_log_forensic.so
 LoadModule logio_module modules/mod_logio.so
-LoadModule mime_magic_module modules/mod_mime_magic.so
 LoadModule expires_module modules/mod_expires.so
 LoadModule headers_module modules/mod_headers.so
 LoadModule usertrack_module modules/mod_usertrack.so


### PR DESCRIPTION
Merge Together:
- https://github.com/cfengine/buildscripts/pull/1009

We do not use the features provided by this module, so we should not load it by
default.

Ticket: ENT-8517
Changelog: Title
(cherry picked from commit 9fbdb77a01c4457e6cd6ef8dd243c0e3f6dfe1a4)