### PR TITLE
ENT-8519: Stopped loading Apache mod_unique_id by default on Enterprise Hubs (3.18)

### DIFF
--- a/cfe_internal/enterprise/templates/httpd.conf.mustache
+++ b/cfe_internal/enterprise/templates/httpd.conf.mustache
@@ -39,7 +39,6 @@ LoadModule mime_magic_module modules/mod_mime_magic.so
 LoadModule expires_module modules/mod_expires.so
 LoadModule headers_module modules/mod_headers.so
 LoadModule usertrack_module modules/mod_usertrack.so
-LoadModule unique_id_module modules/mod_unique_id.so
 LoadModule setenvif_module modules/mod_setenvif.so
 LoadModule version_module modules/mod_version.so
 LoadModule mime_module modules/mod_mime.so


### PR DESCRIPTION
Merge Together:
- https://github.com/cfengine/buildscripts/pull/1012

We do not use the features provided by this module, so we should not load it by
default.

Ticket: ENT-8519
Changelog: Title