### PR TITLE
ENT-8521: Stopped loading Apache mod_usertrack by default on Enterprise Hubs

### DIFF
--- a/cfe_internal/enterprise/templates/httpd.conf.mustache
+++ b/cfe_internal/enterprise/templates/httpd.conf.mustache
@@ -34,7 +34,6 @@ LoadModule log_forensic_module modules/mod_log_forensic.so
 LoadModule logio_module modules/mod_logio.so
 LoadModule expires_module modules/mod_expires.so
 LoadModule headers_module modules/mod_headers.so
-LoadModule usertrack_module modules/mod_usertrack.so
 LoadModule setenvif_module modules/mod_setenvif.so
 LoadModule mime_module modules/mod_mime.so
 LoadModule dir_module modules/mod_dir.so


### PR DESCRIPTION
Merge Together:
- https://github.com/cfengine/buildscripts/pull/1014

We do not use the features provided by this module, so we should not load it by
default.

Ticket: ENT-8521
Changelog: Title