### PR TITLE
ENT-8522: Stopped loading Apache mod_env by default on Enterprise Hubs (3.18)

### DIFF
--- a/cfe_internal/enterprise/templates/httpd.conf.mustache
+++ b/cfe_internal/enterprise/templates/httpd.conf.mustache
@@ -34,7 +34,6 @@ LoadModule deflate_module modules/mod_deflate.so
 LoadModule log_config_module modules/mod_log_config.so
 LoadModule log_forensic_module modules/mod_log_forensic.so
 LoadModule logio_module modules/mod_logio.so
-LoadModule env_module modules/mod_env.so
 LoadModule mime_magic_module modules/mod_mime_magic.so
 LoadModule expires_module modules/mod_expires.so
 LoadModule headers_module modules/mod_headers.so


### PR DESCRIPTION
Merge Together:
- https://github.com/cfengine/buildscripts/pull/1018

We do not use the features provided by this module, so we should not load it by
default.

Ticket: ENT-8522
Changelog: Title
(cherry picked from commit 0a766d665f920654027911c38675f5a05f399893)