### PR TITLE
ENT-8523: Stopped loading Apache mod_deflate by default on Enterprise Hubs

### DIFF
--- a/cfe_internal/enterprise/templates/httpd.conf.mustache
+++ b/cfe_internal/enterprise/templates/httpd.conf.mustache
@@ -24,7 +24,6 @@ LoadModule authz_owner_module modules/mod_authz_owner.so
 LoadModule auth_basic_module modules/mod_auth_basic.so
 LoadModule auth_digest_module modules/mod_auth_digest.so
 LoadModule dbd_module modules/mod_dbd.so
-LoadModule deflate_module modules/mod_deflate.so
 LoadModule log_config_module modules/mod_log_config.so
 LoadModule logio_module modules/mod_logio.so
 LoadModule expires_module modules/mod_expires.so


### PR DESCRIPTION
Merge Together:
- https://github.com/cfengine/buildscripts/pull/1025

We do not use the features provided by this module, so we should not load it by default.

