### PR TITLE
ENT-8599: Stopped loading Apache mod_authn_dbm by default on Enterprise Hubs (3.18)

### DIFF
--- a/cfe_internal/enterprise/templates/httpd.conf.mustache
+++ b/cfe_internal/enterprise/templates/httpd.conf.mustache
@@ -12,7 +12,7 @@ PidFile "{{{vars.sys.workdir}}}/httpd/httpd.pid"
 # Note: Not all modules that are built are loaded.
 # Find built modules in {{{vars.sys.workdir}}}/httpd/modules
 
-LoadModule authn_dbm_module modules/mod_authn_dbm.so
+LoadModule authn_file_module modules/mod_authn_file.so
 LoadModule authn_anon_module modules/mod_authn_anon.so
 LoadModule authn_dbd_module modules/mod_authn_dbd.so
 LoadModule authz_host_module modules/mod_authz_host.so


### PR DESCRIPTION
We do not use the features provided by this module, so we should not load it by default.

Merge together: https://github.com/cfengine/buildscripts/pull/1045

