### PR TITLE
ENT-8600: Stopped loading Apache mod_authn_anon by default on Enterprise Hubs

### DIFF
--- a/cfe_internal/enterprise/templates/httpd.conf.mustache
+++ b/cfe_internal/enterprise/templates/httpd.conf.mustache
@@ -13,7 +13,6 @@ PidFile "{{{vars.sys.workdir}}}/httpd/httpd.pid"
 # Find built modules in {{{vars.sys.workdir}}}/httpd/modules
 
 LoadModule authn_file_module modules/mod_authn_file.so
-LoadModule authn_anon_module modules/mod_authn_anon.so
 LoadModule authn_dbd_module modules/mod_authn_dbd.so
 LoadModule authz_host_module modules/mod_authz_host.so
 LoadModule authz_groupfile_module modules/mod_authz_groupfile.so


### PR DESCRIPTION
Merge Together:
- https://github.com/cfengine/buildscripts/pull/1048