### PR TITLE
ENT-8617: Added PostgreSQL tunables for Federated Reporting (3.18)

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -1510,6 +1510,106 @@ When custom certificates are in use distributed cleanup needs to know where to f
 
 * Added in CFEngine 3.20.0, 3.18.2
 
+#### PostgreSQL Configuration
+
+It's not uncommon to need to configure some PostgreSQL settings differently for Federated Reporting. The settings that are exposed as tunables which can be set via augments are listed here. These do not comprise all settings that may need adjusted, only those that are most commonly adjusted.
+
+**Note:** When [setting parameters for the PostgreSQL configuration](https://www.postgresql.org/docs/current/config-setting.html)
+file various units can be used. Valid memory units are B (bytes), kB
+(kilobytes), MB (megabytes), GB (gigabytes), and TB (terabytes). The multiplier
+for memory units is 1024, not 1000. Valid time units are us (microseconds), ms
+(milliseconds), s (seconds), min (minutes), h (hours), and d (days).
+
+##### shared_buffers
+
+Shared buffers are the amount of memory the database server uses for shared memory buffers. Settings significantly higher than the minimum are usually needed for good performance.
+
+The value should be set to 15% to 25% of the machine's total RAM. For example: if your machine's RAM size is 32 GB, then the recommended value for shared_buffers is 8 GB.
+
+To adjust this set `cfengine_enterprise_federation:postgres_config.shared_buffers` via Augments.
+
+For example:
+
+```json
+{
+  "variables": {
+    "cfengine_enterprise_federation:postgres_config.shared_buffers": "2560MB"
+  }
+}
+```
+
+**History:**
+
+* Added in 3.20.0, 3.18.2
+
+##### max_locks_per_transaction
+
+The ```max_locks_per_transaction``` value indicates the number of database objects that can be locked simultaneously. When Federated Reporting is enabled, the MPF default is `4000`.
+
+```json
+{
+  "variables": {
+    "cfengine_enterprise_federation:postgres_config.max_locks_per_transaction": "4100"
+  }
+}
+```
+
+**History:**
+
+* Added in 3.20.0, 3.18.2
+
+##### log_lock_waits
+
+Controls whether a log message is produced when a session waits longer than `deadlock_timeout` to acquire a lock. This is useful in determining if lock waits are causing poor performance. When Federated Reporting is enabled, the MPF default is `on`.
+
+```json
+{
+  "variables": {
+    "cfengine_enterprise_federation:postgres_config.log_lock_waits": "off"
+  }
+}
+```
+
+**History:**
+
+* Added in 3.20.0, 3.18.2
+
+##### max_wal_size
+
+Sets the WAL size that triggers a checkpoint.
+
+Maximum size to let the WAL grow during automatic checkpoints. This is a soft limit; WAL size can exceed `max_wal_size` under special circumstances, such as heavy load, a failing `archive_command`, or a high `wal_keep_size` setting. If this value is specified without units, it is taken as megabytes. The default is 1 GB (`1024MB`). Increasing this parameter can increase the amount of time needed for crash recovery.
+
+```json
+{
+  "variables": {
+    "cfengine_enterprise_federation:postgres_config.max_wal_size": "20G"
+  }
+}
+```
+
+**History:**
+
+* Added in 3.20.0, 3.18.2
+
+##### checkpoint_timeout
+
+Sets the maximum time between automatic WAL checkpoints.
+
+Maximum time between automatic WAL checkpoints. If this value is specified without units, it is taken as seconds. The valid range is between 30 seconds and one day. The default is five minutes (`5min`). Increasing this parameter can increase the amount of time needed for crash recovery.
+
+```json
+{
+  "variables": {
+    "cfengine_enterprise_federation:postgres_config.checkpoint_timeout": "30min"
+  }
+}
+```
+
+**History:**
+
+* Added in 3.20.0, 3.18.2
+
 ## Recommendations
 
 The MPF includes policy that inspects the system and makes recommendations about

--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -528,18 +528,40 @@ bundle agent federation_manage_files
 
 bundle agent postgres_config
 # @brief Customize postgres config for superhub
+# @variable cfengine_enterprise_federation:postgres_config.shared_buffers - Sets the maximum number of locks per transaction.
+# @variable cfengine_enterprise_federation:postgres_config.max_locks_per_transaction - Sets the maximum number of locks per transaction.
+# @variable cfengine_enterprise_federation:postgres_config.log_lock_waits - Logs long lock waits.
+# @variable cfengine_enterprise_federation:postgres_config.max_wal_size - Sets the WAL size that triggers a checkpoint.
+# @variable cfengine_enterprise_federation:postgres_config.checkpoint_timeout- Sets the maximum time between automatic WAL checkpoints.
 {
   vars:
     am_superhub::
-      "c[shared_buffers]"
-        string => "1GB",
+      "c[shared_buffers]" -> { "ENT-8617" }
+        string => ifelse( isvariable( "cfengine_enterprise_federation:postgres_config.shared_buffers"),
+                          $(cfengine_enterprise_federation:postgres_config.shared_buffers),
+                          "1GB"),
         comment => "Changing this setting requires restarting the database.";
-      "c[max_locks_per_transaction]"
-        string => "4000",
+      "c[max_locks_per_transaction]" -> { "ENT-8617" }
+        string => ifelse( isvariable( "cfengine_enterprise_federation:postgres_config.max_locks_per_transaction"),
+                          $(cfengine_enterprise_federation:postgres_config.max_locks_per_transaction),
+                          "4000"),
         comment => "Changing this setting requires restarting the database.";
-      "c[log_lock_waits]"
-        string => "on",
+      "c[log_lock_waits]" -> { "ENT-8617" }
+        string => ifelse( isvariable( "cfengine_enterprise_federation:postgres_config.log_lock_waits"),
+                          $(cfengine_enterprise_federation:postgres_config.log_lock_waits),
+                          "on"),
         comment => "Changing this setting requires restarting the database.";
+
+      "c[max_wal_size]" -> { "ENT-8617" }
+        string => ifelse( isvariable( "cfengine_enterprise_federation:postgres_config.max_wal_size"),
+                          $(cfengine_enterprise_federation:postgres_config.max_wal_size),
+                          "1GB");
+
+      "c[checkpoint_timeout]" -> { "ENT-8617" }
+        string => ifelse( isvariable( "cfengine_enterprise_federation:postgres_config.checkpoint_timeout"),
+                          $(cfengine_enterprise_federation:postgres_config.checkpoint_timeout),
+                          "5min");
+
   files:
     am_superhub::
       "$(sys.statedir)/pg/data/postgresql.conf"


### PR DESCRIPTION
This change instruments tunables for postgresql.conf when Federated Reporting is
enabled.

The existing defaults for shared_buffers, max_locks_per_transaction, and
log_lock_waits have been exposed as cfengine_enterprise_federation.postgres_config.shared_buffers,
cfengine_enterprise_federation.postgres_config.max_locks_per_transaction, and
cfengine_enterprise_federation.postgres_config.log_lock_waits respectively.

Additionally, since the superhub common needs checkpoint_timeout and
max_wal_size adjusted, they have been added to the default
configuration with their default values and exposed as
cfengine_enterprise_federation.postgres_config.checkpoint_timeout and
cfengine_enterprise_federation.postgres_config.max_wal_size respectively.