### PR TITLE
ENT-8601: Stopped loading Apache mod_authn_dbd by default on Enterprise Hubs (3.18)

### DIFF
--- a/cfe_internal/enterprise/templates/httpd.conf.mustache
+++ b/cfe_internal/enterprise/templates/httpd.conf.mustache
@@ -13,7 +13,6 @@ PidFile "{{{vars.sys.workdir}}}/httpd/httpd.pid"
 # Find built modules in {{{vars.sys.workdir}}}/httpd/modules
 
 LoadModule authn_file_module modules/mod_authn_file.so
-LoadModule authn_dbd_module modules/mod_authn_dbd.so
 LoadModule authz_host_module modules/mod_authz_host.so
 LoadModule authz_groupfile_module modules/mod_authz_groupfile.so
 LoadModule authz_dbm_module modules/mod_authz_dbm.so


### PR DESCRIPTION
We do not use the features provided by this module, so we should not load it by default.