### PR TITLE
ENT-8608: Stopped loading Apache mod_auth_digest by default on Enterprise Hubs (3.15)

### DIFF
--- a/cfe_internal/enterprise/templates/httpd.conf.mustache
+++ b/cfe_internal/enterprise/templates/httpd.conf.mustache
@@ -19,7 +19,6 @@ LoadModule authz_groupfile_module modules/mod_authz_groupfile.so
 LoadModule authz_dbm_module modules/mod_authz_dbm.so
 LoadModule authz_owner_module modules/mod_authz_owner.so
 LoadModule auth_basic_module modules/mod_auth_basic.so
-LoadModule auth_digest_module modules/mod_auth_digest.so
 LoadModule dbd_module modules/mod_dbd.so
 
 # Our default log format uses features provided by these modules


### PR DESCRIPTION
Merge Together:
- https://github.com/cfengine/buildscripts/pull/1062

We do not use the features provided by this module, so we should not load it by default.