### PR TITLE
ENT-8603: Stopped loading Apache mod_authz_groupfile by default on Enterprise Hubs (3.15)

### DIFF
--- a/cfe_internal/enterprise/templates/httpd.conf.mustache
+++ b/cfe_internal/enterprise/templates/httpd.conf.mustache
@@ -15,7 +15,6 @@ PidFile "{{{vars.sys.workdir}}}/httpd/httpd.pid"
 LoadModule authn_file_module modules/mod_authn_file.so
 LoadModule authn_dbd_module modules/mod_authn_dbd.so
 LoadModule authz_host_module modules/mod_authz_host.so
-LoadModule authz_groupfile_module modules/mod_authz_groupfile.so
 LoadModule authz_dbm_module modules/mod_authz_dbm.so
 LoadModule authz_owner_module modules/mod_authz_owner.so
 LoadModule auth_basic_module modules/mod_auth_basic.so


### PR DESCRIPTION
Merge Together:
- https://github.com/cfengine/buildscripts/pull/1065

We do not use the features provided by this module, so we should not load it by default.