### PR TITLE
ENT-8618: Added Enterprise Hub postgresql.conf to files monitored for diffs by default (3.15)

### DIFF
--- a/cfe_internal/enterprise/file_change.cf
+++ b/cfe_internal/enterprise/file_change.cf
@@ -18,6 +18,7 @@ bundle agent change_management
                    "/etc/passwd",
                    "/etc/group",
                    "/etc/services",
+                   "$(sys.statedir)/pg/data/postgresql.conf",
                   },
         comment => "These files will be watched for change, and diffs will be
                     reported back to mission portal if you are running CFEngine


### PR DESCRIPTION
This change adds the postgresql.conf file used on Enterprise Hubs to the list of
files we report detailed changes on by default. This allows for better tracking
of alterations to the file over time.