### PR TITLE
ENT-8832 Improve distributed_cleanup utility setup

### DIFF
--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -171,6 +171,56 @@ bundle agent config
       "I'm paused so won't do any import/dump";
 }
 
+bundle agent distributed_cleanup_dependencies
+# @brief warn if python3 and urllib3 required dependencies are not installed
+# if cfengine_mp_fr_enable_distributed_cleanup class is defined
+{
+  vars:
+    debian|ubuntu|redhat_8|centos_8::
+      "packages" slist => { "python3", "python3-urllib3" };
+
+    centos_7::
+      "packages" slist => { "python3" };
+
+  classes:
+    (redhat_6|centos_6)::
+      "cfengine_mp_fr_distributed_cleanup_python3_installed"
+        expression => returnszero(
+          "$(sys.bindir)/cfengine-selected-python --version | grep -q ' 3.'",
+          "useshell"
+        );
+
+    (redhat_6|centos_6|redhat_7|centos_7)::
+      "cfengine_mp_fr_distributed_cleanup_urllib3_installed"
+        expression => returnszero(
+          "echo 'import urllib3' | $(sys.bindir)/cfengine-selected-python 2>/dev/null",
+          "useshell"
+        );
+
+  packages:
+    debian|ubuntu::
+      "$(packages)"
+        policy => "present",
+        classes => default:results("bundle", "cfengine_mp_fr_distributed_cleanup_packages"),
+        action => default:policy ( "warn" ),
+        package_module => default:apt_get;
+
+    redhat.!(centos_6|redhat_6)::
+      "$(packages)"
+        policy => "present",
+        classes => default:results("bundle", "cfengine_mp_fr_distributed_cleanup_packages"),
+        action => default:policy ( "warn" ),
+        package_module => default:yum;
+
+  reports:
+    (redhat_6|centos_6).!cfengine_mp_fr_distributed_cleanup_python3_installed::
+      "error: python3 is required for distributed cleanup utility. On this platform it is recommened you install python3 from source (https://docs.python.org/3.10/using/unix.html#building-python)";
+    (redhat_6|centos_6).!cfengine_mp_fr_distributed_cleanup_urllib3_installed::
+      "error: python3 module urllib3 is required for distributed cleanup utility. On this platform it is recommend you install via pip3 after installing python3 from source";
+    (redhat_7|centos_7).!cfengine_mp_fr_distributed_cleanup_urllib3_installed::
+      "error: python3 module urllib3 is required for distributed cleanup utility. On this platform please install with the command `pip3 install urllib3`";
+}
+
 bundle agent semanage_installed
 # @brief Install semanage utility if selinux enabled and
 # cfengine_mp_fr_dependencies_auto_install class is defined
@@ -768,13 +818,17 @@ bundle agent entry
         depends_on => { "transport_user", "ensure_feeders" },
         usebundle => imported_data;
 
-    default:cfengine_mp_fr_enable_distributed_cleanup::
+    am_policy_hub.default:cfengine_mp_fr_enable_distributed_cleanup::
+      "Distributed Cleanup Dependencies"
+        handle => "distributed_cleanup_dependencies",
+        usebundle => "distributed_cleanup_dependencies";
       "Distributed Cleanup Setup"
         handle => "distributed_cleanup_setup",
-        depends_on => { "data_transport" },
+        depends_on => { "transport_user", "data_transport", "distributed_cleanup_dependencies" },
         usebundle => "distributed_cleanup_setup";
       "Distributed Federated Host Cleanup"
         handle => "distributed_cleanup",
+        if => "enabled.am_on.am_superhub.!am_paused",
         depends_on => { "imported_data", "distributed_cleanup_setup" },
         usebundle => distributed_cleanup_run;
 

--- a/templates/federated_reporting/distributed_cleanup.py
+++ b/templates/federated_reporting/distributed_cleanup.py
@@ -66,8 +66,8 @@ DISTRIBUTED_CLEANUP_SECRET_PATH = os.path.join(
 
 def interactive_setup_feeder(hub, email, fr_distributed_cleanup_password):
     feeder_credentials = getpass(
-        prompt="Enter admin credentials for {} at {}: ".format(
-            hub["ui_name"], hub["api_url"]
+        prompt="Enter admin credentials for {}: ".format(
+            hub["ui_name"]
         )
     )
     feeder_hostname = hub["ui_name"]
@@ -212,6 +212,8 @@ def main():
     group = parser.add_mutually_exclusive_group()
     group.add_argument("--debug", action="store_true")
     group.add_argument("--inform", action="store_true")
+
+    parser.add_argument("--stdin", action="store_true")
     args = parser.parse_args()
 
     global logger
@@ -226,7 +228,7 @@ def main():
     logger.addHandler(ch)
 
     if not os.path.exists(DISTRIBUTED_CLEANUP_SECRET_PATH):
-        if sys.stdout.isatty():
+        if sys.stdout.isatty() or args.stdin:
             interactive_setup()
         else:
             print(
@@ -247,8 +249,10 @@ def main():
         and response["configured"]
     ):
         print(
-            "{} can only be run on a Federated Reporting hub configured to be superhub".format(
-                os.path.basename(__file__)
+            "{} can only be run on a properly configured superhub." +
+            " {}".format(
+                os.path.basename(__file__),
+                response
             )
         )
         sys.exit(1)


### PR DESCRIPTION
Added policy to install required dependencies: python3 and python3-urllib3
Added interactive option to distributed_cleanup.py to support automation

https://github.com/cfengine/system-testing/pull/438
https://github.com/cfengine/documentation/pull/2734
https://github.com/cfengine/masterfiles/pull/2403