### PR TITLE
CFE-3992: Skip package-inventory test on aarch64 platform

### DIFF
--- a/tests/acceptance/17_packages/11_old/unsafe/package-inventory.cf
+++ b/tests/acceptance/17_packages/11_old/unsafe/package-inventory.cf
@@ -20,7 +20,10 @@ body common control
 bundle agent init
 {
   meta:
-      "test_skip_needs_work" string => "!redhat.!debian";
+      # need packages for platforms other than redhat and debian on x86_64 architecture
+      # see tests/acceptance/17_packages/meta_skip.cf.sub
+      "test_skip_needs_work" string => "(!redhat.!debian)|(!x86_64)",
+        meta => { "CFE-3992" };
       # RedHat 4 RPM has a bug which corrupts the RPM DB during our tests, so it is untestable.
       # And available patches is an Enterprise feature.
       "test_skip_unsupported" string => "redhat_4|centos_4|!enterprise";

--- a/tests/acceptance/17_packages/meta_skip.cf.sub
+++ b/tests/acceptance/17_packages/meta_skip.cf.sub
@@ -1,7 +1,7 @@
 bundle common 17_packages_meta
 {
   meta:
-    "test_skip_needs_work" string => "(!redhat.!debian)|aarch64",
+    "test_skip_needs_work" string => "(!redhat.!debian)|(!x86_64)",
       comment => "Need to create test packages for platforms other than x86 redhat and debian based distributions.",
       meta => { "CFE-3993", "CFE-3992"};
 


### PR DESCRIPTION
Need to generate package files.

Ticket: CFE-3992
Changelog: none