### PR TITLE
ENT-8823: Added policy to patch apachectl for more robust stopping on Enterprise Hubs (3.18)

### DIFF
--- a/cfe_internal/enterprise/mission_portal.cf
+++ b/cfe_internal/enterprise/mission_portal.cf
@@ -16,8 +16,32 @@ bundle agent cfe_internal_enterprise_mission_portal
         comment => "Manage Apache Web server (on/off)";
 
 }
+bundle agent apachectl_patched_for_upgrade
+# @brief Ensure that apacehctl is patched so that it is able to re-start services
+#
+# @description This bundle addresses an issue where upgrades fail trying to stop
+# httpd. Versions prior to 3.20.0, 3.18.2, and 3.15.6 need to have apachectl
+# patched to make it wait for processes to shut down before exiting before
+# upgrading binaries to 3.20.0, 3.18.2, or 3.15.6. CFEngine packages for
+# versions after 3.20.0, 3.18.2, 3.15.6 ship with this patched apachectl which
+# should make this bundle a no-op.
+#
+# TODO Redact when 3.21.0 is the oldest supported version
+{
+  files:
+      "$(sys.bindir)/apachectl"
+        edit_template => "$(this.promise_dirname)/templates/apachectl.mustache",
+        handle => "apachectl_content",
+        template_method => "mustache",
+        template_data => parsejson( '{ "cfengine_enterprise_mission_portal_httpd_dir": "$(sys.workdir)/httpd" }');
+
+      "$(sys.bindir)/apachectl"
+        handle => "apachectl_perms",
+        perms => mog( "0755", "root", "root" );
+}
 
 bundle agent cfe_internal_enterprise_mission_portal_apache
+# @brief Manage Apache instance that runs Mission Portal
 {
   vars:
 
@@ -42,6 +66,9 @@ bundle agent cfe_internal_enterprise_mission_portal_apache
       data => datastate();
 
   methods:
+
+      "apachectl patched for resilient stop " -> { "ENT-8823" }
+        usebundle => apachectl_patched_for_upgrade;
 
       "Stage Apache Config"
         usebundle => file_make_mustache( $(staged_config), $(template), @(data) ),

--- a/cfe_internal/enterprise/templates/apachectl.mustache
+++ b/cfe_internal/enterprise/templates/apachectl.mustache
@@ -1,0 +1,152 @@
+#!/bin/sh
+#
+# This is CFEngine version of apachectl script, being more persistent when
+# killing httpd and more resillient when doing so. The only change is special
+# processing of "stop" inside "case $ACMD in". When asked to kill httpd
+# process, it not just sends a "kill" signal and happily quits, but first waits
+# for it to be gone (by checking `ps p` output), and if it's not gone - kills
+# the main httpd process and all its children (found via `pgrep --parent` or by
+# parsing `ps -eo ppid,pid` output) by sending `kill -9` singal to them. If
+# process(es) exist even after that - it gives up with an error message.
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+# Apache control script designed to allow an easy command line interface
+# to controlling Apache.  Written by Marc Slemko, 1997/08/23
+#
+# Modified by Northern.Tech to try harder in killing httpd process(es)
+# and wait for them to be gone before returning to caller.
+#
+# The exit codes returned are:
+#   XXX this doc is no longer correct now that the interesting
+#   XXX functions are handled by httpd
+#       0 - operation completed successfully
+#       1 -
+#       2 - usage error
+#       3 - httpd could not be started
+#       4 - httpd could not be stopped
+#       5 - httpd could not be started during a restart
+#       6 - httpd could not be restarted during a restart
+#       7 - httpd could not be restarted during a graceful restart
+#       8 - configuration syntax error
+#
+# When multiple arguments are given, only the error from the _last_
+# one is reported.  Run "apachectl help" for usage info
+#
+ACMD="$1"
+ARGV="$@"
+#
+# |||||||||||||||||||| START CONFIGURATION SECTION  ||||||||||||||||||||
+# --------------------                              --------------------
+#
+# the path to your httpd binary, including options if necessary
+HTTPD='{{{cfengine_enterprise_mission_portal_httpd_dir}}}/bin/httpd'
+#
+# pick up any necessary environment variables
+if test -f {{{cfengine_enterprise_mission_portal_httpd_dir}}}/bin/envvars; then
+  . {{{cfengine_enterprise_mission_portal_httpd_dir}}}/bin/envvars
+fi
+#
+# a command that outputs a formatted text version of the HTML at the
+# url given on the command line.  Designed for lynx, however other
+# programs may work.
+LYNX="lynx -dump"
+#
+# the URL to your server's mod_status status page.  If you do not
+# have one, then status and fullstatus will not work.
+STATUSURL="http://localhost:80/server-status"
+#
+# Set this variable to a command that increases the maximum
+# number of file descriptors allowed per child process. This is
+# critical for configurations that use many file descriptors,
+# such as mass vhosting, or a multithreaded server.
+ULIMIT_MAX_FILES="ulimit -S -n `ulimit -H -n`"
+# --------------------                              --------------------
+# ||||||||||||||||||||   END CONFIGURATION SECTION  ||||||||||||||||||||
+
+# Set the maximum number of file descriptors allowed per child process.
+if [ "x$ULIMIT_MAX_FILES" != "x" ] ; then
+    $ULIMIT_MAX_FILES
+fi
+
+ERROR=0
+if [ "x$ARGV" = "x" ] ; then
+    ARGV="-h"
+fi
+
+case $ACMD in
+start|restart|graceful|graceful-stop)
+    $HTTPD -k $ARGV
+    ERROR=$?
+    ;;
+stop)
+    # Added by CFEngine
+    PIDFILE='{{{cfengine_enterprise_mission_portal_httpd_dir}}}/httpd.pid'
+    if [ ! -f "$PIDFILE" ] ; then
+        PIDFILE='{{{cfengine_enterprise_mission_portal_httpd_dir}}}/logs/httpd.pid'
+    fi
+    if [ ! -f "$PIDFILE" ] ; then
+        echo PID file not found, nothing to stop
+        exit 2
+    fi
+    PID="$(cat "$PIDFILE")"
+    $HTTPD -k $ARGV
+    ERROR=$?
+    # wait for pid to terminate, up to 5 seconds
+    for _iteration in `seq 50`; do
+        ps p $PID >/dev/null || exit $ERROR
+        sleep 0.1
+    done
+    echo "process didn't finish gracefully, commencing murder"
+    # collect all child processes
+    if command -v pgrep >/dev/null; then
+        PIDS="$PID $(pgrep --parent $PID)"
+    else
+        PIDS="$PID $(ps -eo ppid,pid | awk "/ $PID /{print \$2}")"
+    fi
+    # send KILL signal to all of them
+    kill -9 $PIDS
+    # wait for them to terminate, up to 5 seconds
+    for _iteration in `seq 50`; do
+        ps p $PIDS >/dev/null || exit $ERROR
+        sleep 0.1
+    done
+    echo Failed to terminate processes
+    ps p $PIDS
+    ;;
+startssl|sslstart|start-SSL)
+    echo The startssl option is no longer supported.
+    echo Please edit httpd.conf to include the SSL configuration settings
+    echo and then use "apachectl start".
+    ERROR=2
+    ;;
+configtest)
+    $HTTPD -t
+    ERROR=$?
+    ;;
+status)
+    $LYNX $STATUSURL | awk ' /process$/ { print; exit } { print } '
+    ;;
+fullstatus)
+    $LYNX $STATUSURL
+    ;;
+*)
+    $HTTPD "$@"
+    ERROR=$?
+esac
+
+exit $ERROR


### PR DESCRIPTION
The stock apachectl does not wait to see if a signal had the desired effect. In
the case of stopping and restarting this can result in httpd processes being
left running preventing new configuration from taking effect.

This change renders a patched apachectl which is instrumented to briefly wait
for httpd to be fully terminated and takes more aggressive actions to ensure
httpd is fully stopped before exiting.

This script is part of the package but needs to also be handled by the MPF to
cover the case of upgrade where policy from the newer version is running before
binaries from the newer version are running.