### PR TITLE
ENT-8823: Fixed path to apachectl

### DIFF
--- a/cfe_internal/enterprise/mission_portal.cf
+++ b/cfe_internal/enterprise/mission_portal.cf
@@ -29,13 +29,13 @@ bundle agent apachectl_patched_for_upgrade
 # TODO Redact when 3.21.0 is the oldest supported version
 {
   files:
-      "$(sys.bindir)/apachectl"
+      "$(sys.workdir)/httpd/bin/apachectl"
         edit_template => "$(this.promise_dirname)/templates/apachectl.mustache",
         handle => "apachectl_content",
         template_method => "mustache",
         template_data => parsejson( '{ "cfengine_enterprise_mission_portal_httpd_dir": "$(sys.workdir)/httpd" }');
 
-      "$(sys.bindir)/apachectl"
+      "$(sys.workdir)/httpd/bin/apachectl"
         handle => "apachectl_perms",
         perms => mog( "0755", "root", "root" );
 }


### PR DESCRIPTION
It's not with the rest of the binaries, it's in $WORKDIR/httpd/bin