### PR TITLE
CFE-3976 Use simple numeric comparison in apt_get package module (3.15)

### DIFF
--- a/modules/packages/vendored/apt_get.mustache
+++ b/modules/packages/vendored/apt_get.mustache
@@ -7,7 +7,6 @@ import sys
 import os
 import subprocess
 import re
-from distutils.version import LooseVersion
 
 PY3 = sys.version_info > (3,)
 
@@ -32,7 +31,8 @@ apt_get_options = ["-o", "Dpkg::Options::=--force-confold",
                    "-o", "Dpkg::Options::=--force-confdef",
                    "-y"]
 
-if LooseVersion(apt_version) < LooseVersion("1.1"):
+# assume apt-get -v returns faily simple version with integers separated by dots
+if [int(x) for x in apt_version.split(".")] < [1, 1]:
     apt_get_options.append("--force-yes")
 
 else:


### PR DESCRIPTION
Previously we used distutils.LooseVersion but distutils is being
deprecated in newer Python versions, such as that available in Ubuntu 22,
so we must migrate to something else.

After looking around a bit and considering our use of LooseVersion it
seems a simple version of this check is all that is needed.

Assuming that apt-get -v always returns simple numeric versions
we compare versions as a list of integers.

Ticket: CFE-3976
Changelog: title
(cherry picked from commit 34cfe809154280b1bb0fa8e1477d8b5c8ee6e8a0)