### PR TITLE
CFE-3976 revert apt_get changes - 3.18.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,6 @@ Notable changes to the framework should be documented here
 	- Stopped lowercasing software inventory on Windows (ENT-8424)
 	- Updating host-specific CMDB data files now happens asynchronously
 	  (ENT-7357)
-	- Use simple numeric comparison in apt_get package module (CFE-3976)
 
 3.18.1:
 	- Gave cfapache group full access to docroot (ENT-8065)

--- a/modules/packages/vendored/apt_get.mustache
+++ b/modules/packages/vendored/apt_get.mustache
@@ -7,6 +7,7 @@ import sys
 import os
 import subprocess
 import re
+from distutils.version import LooseVersion
 
 PY3 = sys.version_info > (3,)
 
@@ -31,8 +32,7 @@ apt_get_options = ["-o", "Dpkg::Options::=--force-confold",
                    "-o", "Dpkg::Options::=--force-confdef",
                    "-y"]
 
-# assume apt-get -v returns faily simple version with integers separated by dots
-if [int(x) for x in apt_version.split(".")] < [1, 1]:
+if LooseVersion(apt_version) < LooseVersion("1.1"):
     apt_get_options.append("--force-yes")
 
 else:


### PR DESCRIPTION
assumption that `apt-get -v` returns faily simple version with integers separated by dots turned out to be wrong on Ubuntu 14. Let's revert it for now, because it might happen on other versions of Ubuntu, too