### PR TITLE
CFE-3976 Fix apt_get package module version comparison

### DIFF
--- a/modules/packages/vendored/apt_get.mustache
+++ b/modules/packages/vendored/apt_get.mustache
@@ -31,8 +31,8 @@ apt_get_options = ["-o", "Dpkg::Options::=--force-confold",
                    "-o", "Dpkg::Options::=--force-confdef",
                    "-y"]
 
-# assume apt-get -v returns faily simple version with integers separated by dots
-if [int(x) for x in apt_version.split(".")] < [1, 1]:
+# compare only the first two digits of the version so versions like 1.1.1ubuntu2 work
+if [int(x) for x in apt_version.split(".")[0:2]] < [1, 1]:
     apt_get_options.append("--force-yes")
 
 else:


### PR DESCRIPTION
Relying on the version only having integers didn't work on an old ubuntu
which gave 1.1.1ubuntu2

Ticket: CFE-3976
Changelog: title