### PR TITLE
Ignored flycheck temporary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ build
 
 # Emacs
 .*\.~undo-tree~
+flycheck_*


### PR DESCRIPTION
Flycheck (Emacs syntax checker) generates temporary files in the course of it's
checking. They noise up the git status buffer unless they are ignored.