### PR TITLE
ENT-8915: Made it possible to cfbs add the masterfiles repository directly

### DIFF
--- a/cfbs.json
+++ b/cfbs.json
@@ -1,0 +1,14 @@
+{
+  "name": "Masterfiles",
+  "description": "Official CFEngine Masterfiles Policy Framework (MPF)",
+  "type": "module",
+  "provides": {
+    "masterfiles": {
+      "description": "Official CFEngine Masterfiles Policy Framework (MPF)",
+      "tags": ["supported", "base"],
+      "repo": "https://github.com/cfengine/masterfiles",
+      "by": "https://github.com/cfengine",
+      "steps": ["run ./prepare.sh -y", "copy ./ ./"]
+    }
+  }
+}


### PR DESCRIPTION
I imagine this is most useful for testing or those who want to live on the edge.
Installing masterfiles directly prohibits cfbs upgrade functionality, commit sha
changing must be done manually.