### PR TITLE
CFE-3976: Fix apt_get package module version comparison (3.18)

### DIFF
--- a/modules/packages/vendored/apt_get.mustache
+++ b/modules/packages/vendored/apt_get.mustache
@@ -7,7 +7,6 @@ import sys
 import os
 import subprocess
 import re
-from distutils.version import LooseVersion
 
 PY3 = sys.version_info > (3,)
 
@@ -32,7 +31,8 @@ apt_get_options = ["-o", "Dpkg::Options::=--force-confold",
                    "-o", "Dpkg::Options::=--force-confdef",
                    "-y"]
 
-if LooseVersion(apt_version) < LooseVersion("1.1"):
+# compare only the first two digits of the version so versions like 1.1.1ubuntu2 work
+if [int(x) for x in apt_version.split(".")[0:2]] < [1, 1]:
     apt_get_options.append("--force-yes")
 
 else:


### PR DESCRIPTION
Relying on the version only having integers didn't work on an old ubuntu
which gave 1.1.1ubuntu2

Ticket: CFE-3976
Changelog: title
(cherry picked from commit 9cdc23e7ea238f71c24374bcd16ba1e76f75be7e)

Conflicts:
	modules/packages/vendored/apt_get.mustache

with https://github.com/cfengine/buildscripts/pull/1098