### PR TITLE
ENT-5866: Fixed set_line_based() for case when edit_defaults.empty_before_use is true

### DIFF
--- a/lib/files.cf
+++ b/lib/files.cf
@@ -768,10 +768,25 @@ bundle edit_line set_line_based(v, sep, bp, kp, cp)
 
 
   classes:
+      # 3.21.0 and greater know about a file being emptied before editing and
+      # skip this check since it does not make sense.
+@if minimum_version(3.21)
       # Check to see if this line exists
       "exists_$(ci[$(i)])"
       expression => regline("^\s*($(i)$(bp).*|$(i))$",
-                            $(edit.filename));
+                            $(edit.filename)),
+      unless => strcmp( "true", $(edit.empty_before_use) );
+@endif
+
+    (cfengine_3_15|cfengine_3_16|cfengine_3_17|cfengine_3_18|cfengine_3_19|cfengine_3_20)::
+      # Version 3.15.0 does not know about the before_version macro, so we keep the same behavior
+      # TODO Remove after 3.21 is no longer supported. (3.15.0 was supported when 3.21 was released)
+      # Check to see if this line exists
+      "exists_$(ci[$(i)])"
+        expression => regline("^\s*($(i)$(bp).*|$(i))$",
+                              $(edit.filename));
+
+    any::
 
       # if there's more than one comment, just add new (don't know who to use)
       "multiple_comments_$(ci[$(i)])"

--- a/tests/acceptance/lib/files/set_line_based-ENT-5866.cf
+++ b/tests/acceptance/lib/files/set_line_based-ENT-5866.cf
@@ -1,0 +1,56 @@
+#######################################################
+#
+# Test bundle set_line_based
+#
+#######################################################
+
+body common control
+{
+      inputs => { '../../default.cf.sub' };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  files:
+      "$(G.testfile)"
+        copy_from => local_cp("$(this.promise_filename).start");
+}
+
+#######################################################
+
+bundle agent test
+{
+  meta:
+      "description" -> { "ENT-5866" }
+        string => "Test that set_line_based works when a file exists and edit_defaults.empty_file_before_editing is true.";
+
+      "test_soft_fail"
+        string => "cfengine_3_18|cfengine_3_15|cfengine_3_12|cfengine_3_10",
+        meta => { "ENT-5866" };
+
+  vars:
+      "config[one]" string => "1";
+      "config[two]" string => "2";
+      "config[three]" string => "3";
+
+  files:
+      "$(G.testfile)"
+        edit_defaults => empty,
+        edit_line => set_line_based("$(this.bundle).config", "=", "=", ".*", "\s*#\s*");
+}
+
+#######################################################
+
+bundle agent check
+{
+  methods:
+
+      "Pass/Fail"
+        usebundle => dcs_check_diff( "$(G.testfile)",
+                                     "$(G.testfile).expected-result",
+                                     "$(this.promise_filename)");
+}

--- a/tests/acceptance/lib/files/set_line_based-ENT-5866.cf.expected-result
+++ b/tests/acceptance/lib/files/set_line_based-ENT-5866.cf.expected-result
@@ -1,0 +1,3 @@
+one=1
+three=3
+two=2

--- a/tests/acceptance/lib/files/set_line_based-ENT-5866.cf.start
+++ b/tests/acceptance/lib/files/set_line_based-ENT-5866.cf.start
@@ -1,0 +1,3 @@
+one=1
+three=3
+two=banana


### PR DESCRIPTION
Merge together:

* https://github.com/cfengine/core/pull/4993
* https://github.com/cfengine/documentation/pull/2779

* new variable `edit.empty_before_use` in docs (http://buildcache.cfengine.com/packages/build-documentation-pr/jenkins-fast-build-and-deploy-docs-master-62/output/_site/reference-special-variables-edit.html#edit-empty_before_use)
** Cross referenced from `edit_defaults.empty_file_before_editing` (http://buildcache.cfengine.com/packages/build-documentation-pr/jenkins-fast-build-and-deploy-docs-master-62/output/_site/reference-promise-types-files.html#empty_file_before_editing)


http://buildcache.cfengine.com/packages/build-documentation-pr/jenkins-fast-build-and-deploy-docs-master-62/output/_site/reference-promise-types-files.html#empty_file_before_editing

The implementation now avoids looking in the original file when the files
promise instructed to disregard the files starting content (`edit_defaults => empty`) on cfengine versions where this is knowable from within edit_line bundles.