### PR TITLE
ENT-8628: Add inventory for Raspberry Pi and DeviceTree devices

### DIFF
--- a/controls/def.cf
+++ b/controls/def.cf
@@ -633,6 +633,7 @@ bundle common inventory_control
     !freebsd::
 
       "dmidecoder" string => "/usr/sbin/dmidecode";
+      "proc_device_tree" string => "/proc/device-tree";
 
   classes:
       # setting this disables all the inventory modules except package_refresh
@@ -646,10 +647,15 @@ bundle common inventory_control
       "disable_inventory_lsb" expression => "disable_inventory";
       "disable_inventory_lsb" not => fileexists($(lsb_exec));
 
+      # If we have /proc/device-tree we should likely disable dmi completely
+      # as of 2022 systems with dmi dont have device-tree and vice versa.
+      "have_proc_device_tree" expression => fileexists($(proc_device_tree));
+
       # by default disable the dmidecode inventory if the general
       # inventory is disabled or the binary does not exist.  Note that
       # typically this is a very fast binary.
       "disable_inventory_dmidecode" expression => "disable_inventory";
+      "disable_inventory_dmidecode" expression => "have_proc_device_tree";
       "disable_inventory_dmidecode" not => fileexists($(dmidecoder));
 
       # by default disable the LLDP inventory if the general inventory

--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -455,6 +455,8 @@ bundle agent cfe_autorun_inventory_proc_cpuinfo
       # Ref: redmine#7088 https://dev.cfengine.com/issues/7088
       "have_cpuinfo_cpu_cores" expression => strcmp("cpu cores", "$(default:cfe_autorun_inventory_proc.cpuinfo_array[$(default:cfe_autorun_inventory_proc.cpuinfo_idx)][0])");
       "have_cpuinfo_model_name" expression => strcmp("model name", "$(default:cfe_autorun_inventory_proc.cpuinfo_array[$(default:cfe_autorun_inventory_proc.cpuinfo_idx)][0])");
+      "have_cpuinfo_hardware" expression => strcmp("Hardware", "$(default:cfe_autorun_inventory_proc.cpuinfo_array[$(default:cfe_autorun_inventory_proc.cpuinfo_idx)][0])");
+      "have_cpuinfo_revision" expression => strcmp("Revision", "$(default:cfe_autorun_inventory_proc.cpuinfo_array[$(default:cfe_autorun_inventory_proc.cpuinfo_idx)][0])");
 
   vars:
     _have_cpuinfo::
@@ -465,6 +467,14 @@ bundle agent cfe_autorun_inventory_proc_cpuinfo
       "cpuinfo_cpu_model_name"
         string => "$(default:cfe_autorun_inventory_proc.cpuinfo[model name])",
         if => "have_cpuinfo_model_name";
+
+      "cpuinfo_hardware"
+        string => "$(default:cfe_autorun_inventory_proc.cpuinfo[Hardware])",
+        if => "have_cpuinfo_hardware";
+
+      "cpuinfo_revision"
+        string => "$(default:cfe_autorun_inventory_proc.cpuinfo[Revision])",
+        if => "have_cpuinfo_revision";
 
     # We need to be able to count the number of unique physical id lines in
     # /proc/cpu in order to get a physical processor count.
@@ -521,6 +531,8 @@ bundle agent cfe_autorun_inventory_cpuinfo
 {
   classes:
     "_have_proc_cpu_model_name" expression => isvariable("default:cfe_autorun_inventory_proc_cpuinfo.cpuinfo_cpu_model_name");
+    "_have_proc_hardware" expression => isvariable("default:cfe_autorun_inventory_proc_cpuinfo.cpuinfo_hardware");
+    "_have_proc_revision" expression => isvariable("default:cfe_autorun_inventory_proc_cpuinfo.cpuinfo_revision");
     "_have_proc_cpu_physical_cores" expression => isvariable("default:cfe_autorun_inventory_proc_cpuinfo.cpuinfo_physical_cores");
 
     # We only accept dmidecode values that don't look like cfengine variables,
@@ -539,6 +551,15 @@ bundle agent cfe_autorun_inventory_cpuinfo
       "cpu_model"
         string => "$(default:cfe_autorun_inventory_proc_cpuinfo.cpuinfo_cpu_model_name)",
         meta => { "inventory", "attribute_name=CPU model", "derived-from=$(default:cfe_autorun_inventory_proc.files[cpuinfo])" };
+
+    _have_proc_hardware::
+      "cpu_model"
+        string => "$(default:cfe_autorun_inventory_proc_cpuinfo.cpuinfo_hardware)",
+        meta => { "inventory", "attribute_name=CPU model", "derived-from=$(default:cfe_autorun_inventory_proc.files[cpuinfo])" };
+    _have_proc_revision::
+      "system_product_name"
+        string => "$(default:cfe_autorun_inventory_proc_cpuinfo.cpuinfo_revision)",
+        meta => { "inventory", "attribute_name=System product name", "derived-from=$(default:cfe_autorun_inventory_proc.files[cpuinfo])" };
 
     _have_dmidecode_cpu_model_name.!_have_proc_cpu_model_name::
       "cpu_model"
@@ -920,7 +941,7 @@ bundle agent cfe_autorun_inventory_dmidecode
 
     # Redhat 4 can support the -s option to dmidecode if
     # kernel-utils-2.4-15.el4 or greater is installed.
-    have_dmidecode.!(redhat_4|redhat_3)::
+    have_dmidecode.!(redhat_4|redhat_3).!have_proc_device_tree::
       "dmi[$(dmivars)]" string => execresult("$(decoder) -s $(dmivars)",
                                              "useshell"),
       unless => isvariable("dmi[$(dmivars)]"), # If already defined from sysfs, don't run dmidecode

--- a/inventory/linux.cf
+++ b/inventory/linux.cf
@@ -7,6 +7,15 @@ bundle common inventory_linux
 #  systemd class based on linktarget of /proc/1/cmdline
 {
   vars:
+    have_proc_device_tree::
+      "proc_device_tree_model" string => readfile("/proc/device-tree/model"),
+      comment => "Read model from /proc/device-tree",
+      meta => { "inventory", "attribute_name=System version" };
+
+      "proc_device_tree_serial_number" string => readfile("/proc/device-tree/serial-number"),
+      meta => { "inventory", "attribute_name=System serial number" };
+
+
     has_proc_1_cmdline::
       "proc_1_cmdline_split" slist => string_split(readfile("/proc/1/cmdline", "512"), " ", "2"),
       comment => "Read /proc/1/cmdline and split off arguments";


### PR DESCRIPTION
Raspberry Pi kernel has odd entries in /proc/cpuinfo: Model, Hardware, Revision

Also present is /proc/device-tree which generaly excludes the presence of usable dmi information from dmidecode.

Use device tree model, serial-number and compatible data for inventory and defining appropriate classes describing the host.

Ticket: ENT-8628
Changelog: title