### PR TITLE
Fix travis test versions (3.18)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,16 @@ matrix:
         - sudo dpkg -i ./$(basename ${PKG_URL})
 
     # JOB 3
+    - env: CF_VERSION=3.18.x
+      addons:
+        apt:
+          sources:
+            - sourceline: "deb https://cfengine-package-repos.s3.amazonaws.com/pub/apt/packages stable main"
+              key_url: https://cfengine-package-repos.s3.amazonaws.com/pub/gpg.key
+          packages:
+            - cfengine-community=3.18.*
+
+    # JOB 4
     - env: CF_VERSION=3.15.x
       addons:
         apt:
@@ -40,16 +50,6 @@ matrix:
               key_url: https://cfengine-package-repos.s3.amazonaws.com/pub/gpg.key
           packages:
             - cfengine-community=3.15.*
-
-    # JOB 4
-    - env: CF_VERSION=3.12.x
-      addons:
-        apt:
-          sources:
-            - sourceline: "deb https://cfengine-package-repos.s3.amazonaws.com/pub/apt/packages stable main"
-              key_url: https://cfengine-package-repos.s3.amazonaws.com/pub/gpg.key
-          packages:
-            - cfengine-community=3.12.*
 
 script:
 - sudo apt-get install -y fakeroot


### PR DESCRIPTION
Instead of 3.15 and 3.12 as 3.12 is end of life.

Ticket: none
Changelog: none
(cherry picked from commit beabee82002221b7c95cf071d31cd02b73bcc59e)