### PR TITLE
ENT-9028: Skip two tests on older platforms due to lack of fix there

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,16 @@ matrix:
         - sudo dpkg -i ./$(basename ${PKG_URL})
 
     # JOB 3
+    - env: CF_VERSION=3.18.x
+      addons:
+        apt:
+          sources:
+            - sourceline: "deb https://cfengine-package-repos.s3.amazonaws.com/pub/apt/packages stable main"
+              key_url: https://cfengine-package-repos.s3.amazonaws.com/pub/gpg.key
+          packages:
+            - cfengine-community=3.18.*
+
+    # JOB 4
     - env: CF_VERSION=3.15.x
       addons:
         apt:
@@ -40,16 +50,6 @@ matrix:
               key_url: https://cfengine-package-repos.s3.amazonaws.com/pub/gpg.key
           packages:
             - cfengine-community=3.15.*
-
-    # JOB 4
-    - env: CF_VERSION=3.12.x
-      addons:
-        apt:
-          sources:
-            - sourceline: "deb https://cfengine-package-repos.s3.amazonaws.com/pub/apt/packages stable main"
-              key_url: https://cfengine-package-repos.s3.amazonaws.com/pub/gpg.key
-          packages:
-            - cfengine-community=3.12.*
 
 script:
 - sudo apt-get install -y fakeroot

--- a/tests/acceptance/lib/files/set_line_based-ENT-5866.cf
+++ b/tests/acceptance/lib/files/set_line_based-ENT-5866.cf
@@ -28,8 +28,13 @@ bundle agent test
       "description" -> { "ENT-5866" }
         string => "Test that set_line_based works when a file exists and edit_defaults.empty_file_before_editing is true.";
 
+      "test_skip_unsupported"
+        string => "cfengine_3_15|cfengine_3_12|cfengine_3_10",
+        comment => "The fix for this ticket was only back ported as far back as 3.18.x",
+        meta => { "ENT-5866" };
+
       "test_soft_fail"
-        string => "cfengine_3_18|cfengine_3_15|cfengine_3_12|cfengine_3_10",
+        string => "cfengine_3_18",
         meta => { "ENT-5866" };
 
   vars:

--- a/tests/acceptance/lib/files/set_line_based-ENT-5866.cf
+++ b/tests/acceptance/lib/files/set_line_based-ENT-5866.cf
@@ -28,13 +28,8 @@ bundle agent test
       "description" -> { "ENT-5866" }
         string => "Test that set_line_based works when a file exists and edit_defaults.empty_file_before_editing is true.";
 
-      "test_skip_unsupported"
-        string => "cfengine_3_15|cfengine_3_12|cfengine_3_10",
-        comment => "The fix for this ticket was only back ported as far back as 3.18.x",
-        meta => { "ENT-5866" };
-
       "test_soft_fail"
-        string => "cfengine_3_18",
+        string => "cfengine_3_15|cfengine_3_18_0|cfengine_3_18_1|cfengine_3_18_2",
         meta => { "ENT-5866" };
 
   vars:

--- a/tests/acceptance/lib/files/set_line_based_variable_values.cf
+++ b/tests/acceptance/lib/files/set_line_based_variable_values.cf
@@ -15,6 +15,12 @@ body common control
 
 bundle agent init
 {
+  meta:
+    "test_skip_unsupported"
+      string => "cfengine_3_15|cfengine_3_12|cfengine_3_10",
+      comment => "The fix for this ticket was only back ported as far back as 3.18.x",
+      meta => { "ENT-5866" };
+
   files:
       "$(G.testfile)-1.expected"
       copy_from => local_cp("$(this.promise_filename).finish");


### PR DESCRIPTION
ENT-5866 fix for set_line_based() does not work when combined
with edit_defaults => empty was only back ported to 3.18.x.

Ticket: ENT-9028
Changelog: none