### PR TITLE
ENT-9028: Skip two tests on older platforms due to lack of fix there (3.18)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,17 +19,28 @@ matrix:
       script:
         - sudo ./travis-scripts/valgrind.sh
 
+    # JOB
+    # - env: CF_VERSION=master
+    #   install:
+    #     - sudo apt update
+    #     - sudo apt -y install python3
+    #     - sudo apt -y install python3-pip
+    #     - sudo pip3 install cf-remote
+    #     - BRANCH=$CF_VERSION
+    #     - PKG_URL=`cf-remote --version $BRANCH list ubuntu20 agent | tail -n 1`
+    #     - wget $PKG_URL
+    #     - sudo dpkg -i ./$(basename ${PKG_URL})
+
     # JOB 2
-    - env: CF_VERSION=master
-      install:
-        - sudo apt update
-        - sudo apt -y install python3
-        - sudo apt -y install python3-pip
-        - sudo pip3 install cf-remote
-        - BRANCH=$CF_VERSION
-        - PKG_URL=`cf-remote --version $BRANCH list ubuntu20 agent | tail -n 1`
-        - wget $PKG_URL
-        - sudo dpkg -i ./$(basename ${PKG_URL})
+    - env: CF_VERSION=3.18.x
+      addons:
+        apt:
+          sources:
+            - sourceline: "deb https://cfengine-package-repos.s3.amazonaws.com/pub/apt/packages stable main"
+              key_url: https://cfengine-package-repos.s3.amazonaws.com/pub/gpg.key
+          packages:
+            - cfengine-community=3.18.*
+
 
     # JOB 3
     - env: CF_VERSION=3.15.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,17 +19,13 @@ matrix:
       script:
         - sudo ./travis-scripts/valgrind.sh
 
-    # JOB
-    # - env: CF_VERSION=master
-    #   install:
-    #     - sudo apt update
-    #     - sudo apt -y install python3
-    #     - sudo apt -y install python3-pip
-    #     - sudo pip3 install cf-remote
-    #     - BRANCH=$CF_VERSION
-    #     - PKG_URL=`cf-remote --version $BRANCH list ubuntu20 agent | tail -n 1`
-    #     - wget $PKG_URL
-    #     - sudo dpkg -i ./$(basename ${PKG_URL})
+    # NOTE: In stable branches aka LTS series (e.g. 3.18.x, 3.15.x) we do not test against binaries that are /newer/.
+    #       - General advice is that you should run MPF version at or newer than your binary version.
+    #       - When upgrading, MPF should be upgraded /before/ binaries.
+    #       - Fixes come to a stable branch /after/ having gone through master.
+    #       - master is expected to be tested against all currently supported series.
+    #       - A stable branch should be tested against all versions that were supported at the time when the stable branch was born.
+    #         - e.g. When 3.18.0 was released 3.12.x was supported, so the 3.18.x branch should be tested against 3.12.x binaries in perpetuity.
 
     # JOB 2
     - env: CF_VERSION=3.18.x

--- a/lib/files.cf
+++ b/lib/files.cf
@@ -778,7 +778,15 @@ bundle edit_line set_line_based(v, sep, bp, kp, cp)
       unless => strcmp( "true", $(edit.empty_before_use) );
 @endif
 
-    (cfengine_3_15|cfengine_3_16|cfengine_3_17|cfengine_3_18|cfengine_3_19|cfengine_3_20)::
+@if minimum_version(3.18)
+    !(cfengien_3_18_0|cfengine_3_18_1|cfengine_3_18_2)::
+      "exists_$(ci[$(i)])"
+        expression => regline("^\s*($(i)$(bp).*|$(i))$",
+                              $(edit.filename)),
+        unless => strcmp( "true", $(edit.empty_before_use) );
+@endif
+
+    (cfengine_3_15|cfengine_3_16|cfengine_3_17|cfengine_3_18_0|cfengine_3_18_1|cfengine_3_18_2|cfengine_3_19|cfengine_3_20)::
       # Version 3.15.0 does not know about the before_version macro, so we keep the same behavior
       # TODO Remove after 3.21 is no longer supported. (3.15.0 was supported when 3.21 was released)
       # Check to see if this line exists

--- a/tests/acceptance/lib/files/set_line_based-ENT-5866.cf
+++ b/tests/acceptance/lib/files/set_line_based-ENT-5866.cf
@@ -28,8 +28,13 @@ bundle agent test
       "description" -> { "ENT-5866" }
         string => "Test that set_line_based works when a file exists and edit_defaults.empty_file_before_editing is true.";
 
+      "test_skip_unsupported"
+        string => "cfengine_3_15|cfengine_3_12|cfengine_3_10",
+        comment => "The fix for this ticket was only back ported as far back as 3.18.x",
+        meta => { "ENT-5866" };
+
       "test_soft_fail"
-        string => "cfengine_3_18|cfengine_3_15|cfengine_3_12|cfengine_3_10",
+        string => "cfengine_3_18",
         meta => { "ENT-5866" };
 
   vars:

--- a/tests/acceptance/lib/files/set_line_based-ENT-5866.cf
+++ b/tests/acceptance/lib/files/set_line_based-ENT-5866.cf
@@ -29,12 +29,8 @@ bundle agent test
         string => "Test that set_line_based works when a file exists and edit_defaults.empty_file_before_editing is true.";
 
       "test_skip_unsupported"
-        string => "cfengine_3_15|cfengine_3_12|cfengine_3_10",
-        comment => "The fix for this ticket was only back ported as far back as 3.18.x",
-        meta => { "ENT-5866" };
-
-      "test_soft_fail"
-        string => "cfengine_3_18",
+        string => "cfengine_3_15|cfengine_3_12|cfengine_3_10|cfengine_3_18_0|cfengine_3_18_1|cfengine_3_18_2",
+        comment => "The fix for this ticket was only back ported as far back as 3.18.x after 3.18.2 was released",
         meta => { "ENT-5866" };
 
   vars:

--- a/tests/acceptance/lib/files/set_line_based_variable_values.cf
+++ b/tests/acceptance/lib/files/set_line_based_variable_values.cf
@@ -15,6 +15,12 @@ body common control
 
 bundle agent init
 {
+  meta:
+    "test_skip_unsupported"
+      string => "cfengine_3_15|cfengine_3_12|cfengine_3_10",
+      comment => "The fix for this ticket was only back ported as far back as 3.18.x",
+      meta => { "ENT-5866" };
+
   files:
       "$(G.testfile)-1.expected"
       copy_from => local_cp("$(this.promise_filename).finish");


### PR DESCRIPTION
ENT-5866 fix for set_line_based() does not work when combined
with edit_defaults => empty was only back ported to 3.18.x.

Ticket: ENT-9028
Changelog: none
(cherry picked from commit 636908732ff086d48cd59b861641b2d294ef6210)