### PR TITLE
ENT-9057: Amazon Linux now uses --setopt-exit_on_lock=True in redhat_no_locking_knowledge (3.18)

### DIFF
--- a/lib/packages.cf
+++ b/lib/packages.cf
@@ -269,7 +269,7 @@ bundle common rpm_knowledge
 bundle common redhat_no_locking_knowledge {
   vars:
     # Option was introduced in rhel 6.1
-    (redhat|centos).!(redhat_3|redhat_4|redhat_5|redhat_6_0|centos_3|centos_4|centos_5|centos_6_0)::
+    (amazon_linux|redhat|centos).!(redhat_3|redhat_4|redhat_5|redhat_6_0|centos_3|centos_4|centos_5|centos_6_0)::
       "no_locking_option" string => "--setopt=exit_on_lock=True";
     redhat_3|redhat_4|redhat_5|redhat_6_0|centos_3|centos_4|centos_5|centos_6_0::
       "no_locking_option" string => "";


### PR DESCRIPTION
Thanks @ccoager for suggesting this improvement.

Ticket: ENT-9057
Changelog: Title
(cherry picked from commit c1af045f0a338dda2b382ff4ae51d5002c4b215c)