### PR TITLE
ENT-8609: Stopped loading Apache mod_dbd on Enterprise Hubs by default

### DIFF
--- a/cfe_internal/enterprise/templates/httpd.conf.mustache
+++ b/cfe_internal/enterprise/templates/httpd.conf.mustache
@@ -17,7 +17,6 @@ LoadModule authz_host_module modules/mod_authz_host.so
 LoadModule authz_dbm_module modules/mod_authz_dbm.so
 LoadModule authz_owner_module modules/mod_authz_owner.so
 LoadModule auth_basic_module modules/mod_auth_basic.so
-LoadModule dbd_module modules/mod_dbd.so
 
 # Our default log format uses features provided by these modules
 LoadModule log_config_module modules/mod_log_config.so


### PR DESCRIPTION
We do not use the functionality provided by this module so we should not bother
loading it by default.

Ticket: ENT-8609
Changelog: Title