### PR TITLE
ENT-8602: Stopped loading Apache mod_authz_host on Enterprise Hubs by default

### DIFF
--- a/cfe_internal/enterprise/templates/httpd.conf.mustache
+++ b/cfe_internal/enterprise/templates/httpd.conf.mustache
@@ -13,7 +13,6 @@ PidFile "{{{vars.sys.workdir}}}/httpd/httpd.pid"
 # Find built modules in {{{vars.sys.workdir}}}/httpd/modules
 
 LoadModule authn_file_module modules/mod_authn_file.so
-LoadModule authz_host_module modules/mod_authz_host.so
 LoadModule authz_dbm_module modules/mod_authz_dbm.so
 LoadModule authz_owner_module modules/mod_authz_owner.so
 LoadModule auth_basic_module modules/mod_auth_basic.so


### PR DESCRIPTION
We do not use the functionality provided by this module so we should not bother
loading it by default.

Ticket: ENT-8602
Changelog: Title