### PR TITLE
ENT-8706: Stopped loading Apache mod_authz_owner on Enterprise Hubs by default (3.15)

### DIFF
--- a/cfe_internal/enterprise/templates/httpd.conf.mustache
+++ b/cfe_internal/enterprise/templates/httpd.conf.mustache
@@ -15,7 +15,6 @@ PidFile "{{{vars.sys.workdir}}}/httpd/httpd.pid"
 LoadModule authn_file_module modules/mod_authn_file.so
 LoadModule authz_host_module modules/mod_authz_host.so
 LoadModule authz_dbm_module modules/mod_authz_dbm.so
-LoadModule authz_owner_module modules/mod_authz_owner.so
 LoadModule auth_basic_module modules/mod_auth_basic.so
 LoadModule dbd_module modules/mod_dbd.so
 


### PR DESCRIPTION
We do not use the functionality provided by this module so we should not bother
loading it by default.

Ticket: ENT-8706
Changelog: Title
(cherry picked from commit f41b74e73b8ddc1f7c9e543023af29ce49a48026)