### PR TITLE
CEF-4037: Added ssh in paths.cf so that policy writers can use $(paths.ssh)

### DIFF
--- a/lib/paths.cf
+++ b/lib/paths.cf
@@ -147,6 +147,7 @@ bundle common paths
       "path[getent]"        string => "/usr/bin/getent";
       "path[mailx]"         string => "/usr/bin/mailx";
       "path[prelink]"       string => "/usr/sbin/prelink";
+      "path[ssh]"           string => "/usr/bin/ssh";
 
     aix::
 


### PR DESCRIPTION
Ticket: CFE-4037
Changelog: Title