### PR TITLE
CFE-4037: Added ssh in paths.cf so that policy writers can use $(paths.ssh) (3.15)

### DIFF
--- a/lib/paths.cf
+++ b/lib/paths.cf
@@ -177,6 +177,7 @@ bundle common paths
       "path[pgrep]"         string => "/usr/bin/pgrep";
       "path[getent]"        string => "/usr/bin/getent";
       "path[mailx]"         string => "/usr/bin/mailx";
+      "path[ssh]"           string => "/usr/bin/ssh";
 
     aix::
 


### PR DESCRIPTION
Ticket: CFE-4037
Changelog: Title
(cherry picked from commit 770cd89929cce8768a3ba08cbf95328a531fe1bc)