### PR TITLE
ENT-9130: Make fix-python-hashbang more precise

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -5,8 +5,10 @@ SUBDIRS += acceptance
 endif
 
 fix-python-hashbang:
-	@-test -x /usr/bin/python || find $(srcdir) -mindepth 2 -type f -exec sed -ri '\~/usr/bin/python($$|[^0-9])~ s|/usr/bin/python|/usr/bin/python3|' '{}' \;
+	test -x /usr/bin/python || find $(srcdir) -mindepth 2 \( -name '*.py' -o -name 'mock_*' -o -name 'test_*' \) -exec sed -ri '\~/usr/bin/python($$|[^0-9])~ s|/usr/bin/python|/usr/bin/python3|' '{}' \;
 
+# fix-python-hashbang is in check-local here (masterfiles/tests) instead of where it is
+# needed in masterfiles/tests/unit since there is no hook for pre-check there.
 check-local: fix-python-hashbang
 
 .PHONY: fix-python-hashbang


### PR DESCRIPTION
This Makefile target is only needed for files in tests/unit.

The existing target was causing tests/unit/Makefile.in to be modified
and causing tests/unit/Makefile to be re-created by config.status
which on some platforms fails due to automake version mismatch.

Ticket: ENT-9130
Changelog: none