### PR TITLE
ENT-9140: Disable more package tests on non x86_64 platforms (3.18)

### DIFF
--- a/tests/acceptance/17_packages/12_new/timed/local-updates-list-cached.cf
+++ b/tests/acceptance/17_packages/12_new/timed/local-updates-list-cached.cf
@@ -10,7 +10,7 @@ body common control
 bundle agent init
 {
   meta:
-    "test_skip_needs_work" string => "solaris|suse";
+    "test_skip_needs_work" string => "(solaris|suse)|(!x86_64)";
 
   files:
     test_pass_1::

--- a/tests/acceptance/17_packages/12_new/timed/updates-list-cached.cf
+++ b/tests/acceptance/17_packages/12_new/timed/updates-list-cached.cf
@@ -9,7 +9,7 @@ body common control
 bundle agent init
 {
   meta:
-    "test_skip_needs_work" string => "solaris|suse";
+    "test_skip_needs_work" string => "(solaris|suse)|(!x86_64)";
 
   files:
     test_pass_1::


### PR DESCRIPTION
Ticket: ENT-9140
Changelog: none
(cherry picked from commit c19abd4bf6eeda3b184f3b8ea46611bd6604fcf0)