### PR TITLE
Remove mindepth argument from find since not all platforms support it

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -5,7 +5,7 @@ SUBDIRS += acceptance
 endif
 
 fix-python-hashbang:
-	test -x /usr/bin/python || find $(srcdir) -mindepth 2 \( -name '*.py' -o -name 'mock_*' -o -name 'test_*' \) -exec sed -ri '\~/usr/bin/python($$|[^0-9])~ s|/usr/bin/python|/usr/bin/python3|' '{}' \;
+	test -x /usr/bin/python || find $(srcdir) \( -name '*.py' -o -name 'mock_*' -o -name 'test_*' \) -exec sed -ri '\~/usr/bin/python($$|[^0-9])~ s|/usr/bin/python|/usr/bin/python3|' '{}' \;
 
 # fix-python-hashbang is in check-local here (masterfiles/tests) instead of where it is
 # needed in masterfiles/tests/unit since there is no hook for pre-check there.


### PR DESCRIPTION
The change is OK now because the selection of the files is more careful
after a recent change, quoting @craigcomstock:
> before I added the search for name `*.py and mock_*` it was running
> `sed -ri` on every file under that dir.

Platforms which don't support it are AIX 5 and HP-UX.