### PR TITLE
ENT-9162: Fixed up dependent github workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   style_check:
-    uses: cfengine/masterfiles/.github/workflows/style_check.yml
+    uses: ./github/workflows/style_check.yml
   tests:
     needs: style_check
-    uses: cfengine/masterfiles/.github/workflows/tests.yml
+    uses: ./github/workflows/tests.yml


### PR DESCRIPTION
This should "just work" in several situations:
- pull requests which change github actions/workflows
- push activity which uses the pushed/merged code

Ticket: ENT-9162
Changelog: none