### PR TITLE
ENT-9209: Added self upgrade knowledge for Suse 12, 15 and opensuse leap 15 (3.18)

### DIFF
--- a/standalone_self_upgrade.cf.in
+++ b/standalone_self_upgrade.cf.in
@@ -459,7 +459,7 @@ bundle common cfengine_package_names
       "pkg_release" string => "$(cfengine_software.pkg_release)";
       "pkg_arch" string => "$(cfengine_software.pkg_arch)";
 
-      # Redhat/Centos/Oracle 5, SLES 11 use the same package
+      # Redhat/Centos/Oracle 5, SuSE 11 use the same package
 
       "pkg[redhat_5_x86_64]" string => "$(pkg_name)-$(pkg_version)-$(pkg_release).el5.centos.x86_64.rpm";
       "pkg[centos_5_x86_64]" string => "$(pkg[redhat_5_x86_64])";
@@ -469,13 +469,14 @@ bundle common cfengine_package_names
       # 32bit RPMs
       "pkg[$(cfengine_master_software_content._rpm_dists)_$(cfengine_master_software_content._32bit_arches)]" string => "$(pkg_name)-$(pkg_version)-$(pkg_release).el5.centos.i386.rpm";
 
-      # Redhat/Centos/Oracle 6, SLES 12-15 use the same package
+      # Redhat/Centos/Oracle 6, SuSE 12-15, Opensuse Leap 15 use the same package
 
       "pkg[redhat_6_x86_64]" string => "$(pkg_name)-$(pkg_version)-$(pkg_release).el6.x86_64.rpm";
       "pkg[centos_6_x86_64]" string => "$(pkg[redhat_6_x86_64])";
       "pkg[oracle_6_x86_64]" string => "$(pkg[redhat_6_x86_64])";
       "pkg[SuSE_12_x86_64]" string => "$(pkg[redhat_6_x86_64])";
       "pkg[SuSE_15_x86_64]" string => "$(pkg[redhat_6_x86_64])";
+      "pkg[opensuse_leap_15_x86_64]" string => "$(pkg[redhat_6_x86_64])";
 
       # Redhat/Centos/Oracle 7 use the same package
       "pkg[redhat_7_x86_64]" string => "$(pkg_name)-$(pkg_version)-$(pkg_release).el7.x86_64.rpm";
@@ -542,6 +543,10 @@ bundle agent cfengine_master_software_content
       "dir[centos_5_x86_64]" string => "$(dir[redhat_5_x86_64])";
       "dir[oracle_5_x86_64]" string => "$(dir[redhat_5_x86_64])";
       "dir[SuSE_11_x86_64]" string => "$(dir[redhat_5_x86_64])";
+      "pkg[SuSE_12_x86_64]" string => "$(pkg[redhat_6_x86_64])";
+      "pkg[SuSE_15_x86_64]" string => "$(pkg[redhat_6_x86_64])";
+      "pkg[opensuse_leap_15_x86_64]" string => "$(pkg[redhat_6_x86_64])";
+
 
       # All 32bit rpms use the same package
       "_rpm_dists" slist => { "redhat_5", "redhat_6", "redhat_7",


### PR DESCRIPTION
Ticket: ENT-9209
Changelog: Title
(cherry picked from commit 3dd2f0388474117714b0d2f156e360ada0636722)