### PR TITLE
[3.18.x] Adapt the cf-serverd.service template to the version from core

### DIFF
--- a/templates/cf-serverd.service.mustache
+++ b/templates/cf-serverd.service.mustache
@@ -1,7 +1,7 @@
 [Unit]
 Description=CFEngine Enterprise file server
 After=syslog.target
-After=network.target
+After=network-online.target
 ConditionPathExists={{{vars.sys.bindir}}}/cf-serverd
 ConditionPathExists={{{vars.sys.workdir}}}/policy_server.dat
 ConditionPathExists={{{vars.sys.default_policy_path}}}
@@ -14,5 +14,5 @@ Restart=always
 RestartSec=10
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=network-online.target
 WantedBy=cfengine3.service


### PR DESCRIPTION
Reflecting the changes from cfengine/core@962bac57c2af.

(cherry picked from commit 7b43827a4cbefc5a1205d288b811cba616c2916d)

Merge together:
https://github.com/cfengine/core/pull/5070
https://github.com/cfengine/masterfiles/pull/2508