### PR TITLE
CFE-4056: Made proc inventory configurable via Augments

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -554,6 +554,35 @@ For example:
 **History:**
 - Introduced 3.13.0, 3.12.1, 3.10.5
 
+### Configure proc inventory
+
+By default the MPF inventories `consoles`, `cpuinfo`, `modules`, `partitions`, and `version` from `/proc`.
+This can be adjusted by defining `default:cfe_autorun_inventory_proc.basefiles`.
+
+For example:
+
+```json
+{
+  "variables": {
+    "default:cfe_autorun_inventory_proc.basefiles": {
+      "value": [
+        "consoles",
+        "cpuinfo",
+        "version"
+      ],
+      "comment": "We do not need the extra variables this produces since we get the info differently",
+      "tags": [
+        "Custom override MPF default"
+      ]
+    }
+  }
+}
+```
+
+**History:**
+
+* Added 3.21.0
+
 ### mailto
 
 The address that `cf-execd` should email agent output to.

--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -361,7 +361,21 @@ bundle agent cfe_autorun_inventory_proc
 # `ifconfig`.
 {
   vars:
-      "basefiles" slist => { "consoles", "cpuinfo", "modules", "partitions", "version" };
+      # To override this set of base files, define default:cfe_autorun_inventory_proc.basefiles via augments.
+      # {
+      #   "variables": {
+      #                  "default:cfe_autorun_inventory_proc.basefiles" : {
+      #                          "value": [ "consoles", "cpuinfo", "version" ],
+      #                          "comment": "We do not need the extra variables this produces since we get the info differently",
+      #                          "tags": [ "inventory", "attribute_name=My Inventory" ]
+      #                  }
+      #   }
+      # }
+
+      "basefiles" -> { "CFE-4056" }
+        slist => { "consoles", "cpuinfo", "modules", "partitions", "version" },
+        unless => isvariable( "$(this.namespace):$(this.bundle).basefiles" );
+
       "files[$(basefiles)]" string => "$(inventory_control.proc)/$(basefiles)";
 
     _have_proc_consoles::


### PR DESCRIPTION
Ticket: CFE-4056
Changelog: Title

Example stock:
```
[root@hub ~]# rm -f /var/cfengine/data/host_specific.json; cf-agent -K --show-evaluated-vars=default:cfe_autorun_inventory_proc | head 
Variable name                            Variable value                                               Meta tags                                Comment                                 
default:cfe_autorun_inventory_proc.basefiles  {"consoles","cpuinfo","modules","partitions","version"}     source=promise                                                                   
default:cfe_autorun_inventory_proc.console_count 2                                                            source=promise                                                                   
default:cfe_autorun_inventory_proc.console_idx  {"0","1"}                                                   source=promise                                                                   
default:cfe_autorun_inventory_proc.consoles[0][0] ttyS0                                                        source=function,function=buildlinearray                                          
default:cfe_autorun_inventory_proc.consoles[0][1] -W-                                                          source=function,function=buildlinearray                                          
default:cfe_autorun_inventory_proc.consoles[0][2] (EC                                                          source=function,function=buildlinearray                                          
default:cfe_autorun_inventory_proc.consoles[0][3] p                                                            source=function,function=buildlinearray                                          
default:cfe_autorun_inventory_proc.consoles[0][4] a)                                                           source=function,function=buildlinearray                                          
default:cfe_autorun_inventory_proc.consoles[0][5] 4:64                                                         source=function,function=buildlinearray  
```

Example using this new feature:

```
[root@hub ~]# cat /var/cfengine/data/host_specific.json  | python -m json.tool
{
    "classes": {},
    "variables": {
        "default:cfe_autorun_inventory_proc.basefiles": {
            "comment": "",
            "name": "default:cfe_autorun_inventory_proc.basefiles",
            "tags": [],
            "value": [
                "cpuinfo"
            ]
        }
    }
}
[root@hub ~]# cf-agent -K --show-evaluated-vars=default:cfe_autorun_inventory_proc | head
Variable name                            Variable value                                               Meta tags                                Comment                                 
default:cfe_autorun_inventory_proc.basefiles  {"cpuinfo"}                                                 source=cmdb                                                                      
default:cfe_autorun_inventory_proc.cpuinfo[address sizes] 46 bits physical, 48 bits virtual                            source=promise                                                                   
default:cfe_autorun_inventory_proc.cpuinfo[apicid] 1                                                            source=promise                                                                   
default:cfe_autorun_inventory_proc.cpuinfo[bogomips] 5836.79                                                      source=promise                                                                   
default:cfe_autorun_inventory_proc.cpuinfo[cache size] 24576 KB                                                     source=promise                                                                   
default:cfe_autorun_inventory_proc.cpuinfo[cache_alignment] 64                                                           source=promise                                                                   
default:cfe_autorun_inventory_proc.cpuinfo[clflush size] 64                                                           source=promise                                                                   
default:cfe_autorun_inventory_proc.cpuinfo[core id] 0                                                            source=promise                                                                   
default:cfe_autorun_inventory_proc.cpuinfo[cpu MHz] 2918.398                                                     source=promise                                                       

```
