### PR TITLE
ENT-8107: Removed stale reference to cf-twin (3.18)

### DIFF
--- a/controls/cf_execd.cf
+++ b/controls/cf_execd.cf
@@ -41,7 +41,6 @@ body executor control
       schedule => { @(def.control_executor_schedule_value) };
 
       # The full path and command to the executable run by default (overriding builtin).
-      # cf-twin needs its own safe environment because of the update mechanism
 
     windows::
       exec_command => "$(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated -f \"$(sys.update_policy_path)\" & $(sys.cf_agent) -Dfrom_cfexecd,cf_execd_initiated";


### PR DESCRIPTION
Ticket: ENT-8107
Changelog: None
(cherry picked from commit 6a7de8c4896183b72902302bdef38b62f22f0e71)