### PR TITLE
CFE-4069: Added date to known paths for linux

### DIFF
--- a/lib/paths.cf
+++ b/lib/paths.cf
@@ -138,6 +138,7 @@ bundle common paths
       "path[timedatectl]"    string => "/usr/bin/timedatectl";
 
     linux::
+      "path[date]"          string => "/usr/bin/date";
       "path[lsattr]"        string => "/usr/bin/lsattr";
       "path[lsmod]"         string => "/sbin/lsmod";
       "path[tar]"           string => "/bin/tar";


### PR DESCRIPTION
This change makes $(paths.date) available along with its associated classes when
the binary is present.

Ticket: CFE-4069
Changelog: Title