### PR TITLE
CFE-4069: Added date to known paths for linux (3.18)

### DIFF
--- a/lib/paths.cf
+++ b/lib/paths.cf
@@ -138,6 +138,7 @@ bundle common paths
       "path[timedatectl]"    string => "/usr/bin/timedatectl";
 
     linux::
+      "path[date]"          string => "/usr/bin/date";
       "path[lsattr]"        string => "/usr/bin/lsattr";
       "path[lsmod]"         string => "/sbin/lsmod";
       "path[tar]"           string => "/bin/tar";


### PR DESCRIPTION
This change makes $(paths.date) available along with its associated classes when
the binary is present.

Ticket: CFE-4069
Changelog: Title
(cherry picked from commit 5df868aaea9a0c921518db3aca89080342fe7a49)