### PR TITLE
ENT-8908: Added execute bit for owner on httpd application log dir (3.15)

### DIFF
--- a/cfe_internal/enterprise/CFE_knowledge.cf
+++ b/cfe_internal/enterprise/CFE_knowledge.cf
@@ -164,11 +164,11 @@ bundle agent cfe_internal_setup_knowledge
         file_select => cfe_internal_docroot_api_static_async_query_status_status_perms,
         perms => mog("0660", "root", $(def.cf_apache_group) );
 
-      "$(sys.workdir)/httpd/logs/application/." -> { "ENT-7731", "ENT-2758" }
-      comment => "Ensure permissions for $(sys.workdir)/httpd/logs/application/.",
-      handle => "cfe_internal_setup_knowledge_files_httpd_application_log_dir",
-      create => "true",
-      perms => mog("0640", $(def.cf_apache_user), $(def.cf_apache_group));
+      "$(sys.workdir)/httpd/logs/application/." -> { "ENT-7731", "ENT-2758", "ENT-8908", "CFE-951" }
+        comment => "Ensure permissions for $(sys.workdir)/httpd/logs/application/.",
+        handle => "cfe_internal_setup_knowledge_files_httpd_application_log_dir",
+        create => "true",
+        perms => mog("0740", $(def.cf_apache_user), $(def.cf_apache_group));
 
       "$(sys.workdir)/httpd/logs/application/." -> { "ENT-7730" }
         comment => "Ensure permissions for $(sys.workdir)/httpd/logs/application/.*",


### PR DESCRIPTION
The recent change in default behavior for rxdirs caused Mission Portals
application log directory to lose it's execute bit. Without the execute bit
Mission Portal is unable to list the contents of the directory and fails to
create application log files. This change rectifies the condition.

Ticket: ENT-8908, CFE-951
Changelog: None
(cherry picked from commit 3ea0d6a6bac0451a056032eb28cb2224b7ebc9ac)