### PR TITLE
ENT-9095: Updated filename conventions for AIX and Solaris packages

### DIFF
--- a/cfe_internal/update/update_bins.cf
+++ b/cfe_internal/update/update_bins.cf
@@ -87,14 +87,14 @@ bundle agent cfe_internal_update_bins
 
     (solarisx86|solaris).enterprise::
 
-      "novapkg"                 string => "CFEcfengine-nova",
+      "novapkg"                 string => "cfengine-nova",
       comment => "Name convention of Nova package on Solaris",
       handle => "cfe_internal_update_bins_vars_novapkg_solaris",
       if => "nova_edition";
 
     aix.enterprise::
 
-      "novapkg"                 string => "cfengine.cfengine-nova",
+      "novapkg"                 string => "cfengine-nova",
       comment => "Name convention of Nova package on AIX",
       handle => "cfe_internal_update_bins_vars_novapkg_aix",
       if => "nova_edition";
@@ -602,12 +602,9 @@ body package_method u_generic(repo)
       package_name_convention    => "$(name)-$(version).bff";
       package_delete_convention  => "$(name)";
 
-      package_add_command        => "/usr/bin/rm -f $(repo)/.toc && /usr/sbin/geninstall -IqacgXNY -d $(repo) cfengine.cfengine-nova$";
-      package_update_command     => "/usr/bin/rm -f $(repo)/.toc && /usr/sbin/geninstall -IqacgXNY -d $(repo) cfengine.cfengine-nova$";
+      package_add_command        => "/usr/bin/rm -f $(repo)/.toc && /usr/sbin/geninstall -IqacgXNY -d $(repo) cfengine-nova$";
+      package_update_command     => "/usr/bin/rm -f $(repo)/.toc && /usr/sbin/geninstall -IqacgXNY -d $(repo) cfengine-nova$";
 
-      # package_add_command        => "/bin/sh -c /usr/sbin/inutoc $(repo) && /usr/sbin/installp -qacgXNYd $(repo) cfengine.cfengine-nova$";
-      # package_update_command     => "/bin/sh -c /usr/sbin/inutoc $(repo) && /usr/sbin/installp -qacgXNYd $(repo) cfengine.cfengine-nova$";
-
-      package_delete_command     => "/usr/sbin/installp -ug cfengine.cfengine-nova$";
+      package_delete_command     => "/usr/sbin/installp -ug cfengine-nova$";
 
 }

--- a/standalone_self_upgrade.cf.in
+++ b/standalone_self_upgrade.cf.in
@@ -93,12 +93,11 @@ bundle agent cfengine_software
       "pkg_edition_path" string => "community_binaries/Community-$(pkg_version)";
 
     aix::
-      "pkg_name" string => "cfengine.cfengine-nova";
+      "pkg_name" string => "cfengine-nova";
       "pkg_arch" string => "default";
 
-      # TODO ENT-3187
     solaris|solarisx86::
-      "pkg_name" string => "CFE.cfengine-nova";
+      "pkg_name" string => "cfengine-nova";
 
     (debian|ubuntu).64_bit::
 
@@ -975,9 +974,9 @@ body package_method u_generic(repo)
       # Redirecting the output to '/dev/null' below makes sure 'geninstall' has
       # its stdout open even if the 'cf-agent' process that started it
       # terminates (e.g. gets killed).
-        package_add_command        => "/usr/bin/rm -f $(repo)/.toc && /usr/sbin/geninstall -IacgXNY -d $(repo) cfengine.cfengine-nova > /dev/null$";
-        package_update_command     => "/usr/bin/rm -f $(repo)/.toc && /usr/sbin/geninstall -IacgXNY -d $(repo) cfengine.cfengine-nova > /dev/null$";
-        package_delete_command     => "/usr/sbin/installp -ug cfengine.cfengine-nova$";
+        package_add_command        => "/usr/bin/rm -f $(repo)/.toc && /usr/sbin/geninstall -IacgXNY -d $(repo) cfengine-nova > /dev/null$";
+        package_update_command     => "/usr/bin/rm -f $(repo)/.toc && /usr/sbin/geninstall -IacgXNY -d $(repo) cfengine-nova > /dev/null$";
+        package_delete_command     => "/usr/sbin/installp -ug cfengine-nova$";
 
       # Internal version comparison model doesn't work for W.X.Y.Z
         package_version_less_command => "$(sys.bindir)/rpmvercmp '$(v1)' lt '$(v2)'";

--- a/tests/unit/mock_lslpp_Lc
+++ b/tests/unit/mock_lslpp_Lc
@@ -232,7 +232,7 @@ bos.txt:bos.txt.tfs.data:7.1.0.0: : :C: :Text Formatting Services Data: : : : : 
 bos.wpars:bos.wpars:7.1.3.30: : :C: :AIX Workload Partitions : : : : : : :1:0:/:1441
 cdrtools.base:cdrtools.base:1.9.0.9: : :C: :CD/DVD recorder: : : : : : :1:0:/:
 cdrtools.man.en_US:cdrtools.man.en_US:1.9.0.9: : :C: :CD/DVD recorder man page documentation: : : : : : :1:0:/:
-cfengine.cfengine-nova:cfengine.cfengine-nova:3.7.0.0: : :C: :Cfengine Nova, Data Center Automation: : : : : : :0:0:/:
+cfengine-nova:cfengine-nova:3.7.0.0: : :C: :Cfengine Nova, Data Center Automation: : : : : : :0:0:/:
 clic.rte:clic.rte.kernext:4.10.0.1: : :C: :CryptoLite for C Kernel: : : : : : :1:0:/:
 clic.rte:clic.rte.lib:4.10.0.1: : :C: :CryptoLite for C Library: : : : : : :1:0:/:
 devices.artic960:devices.artic960.diag:7.1.0.0: : :C: :IBM ARTIC960 Adapter Diagnostics : : : : : : :1:0:/:1140


### PR DESCRIPTION
Solaris packages are no longer prefixed with 'cfengine.' and AIX packages are no
longer prefixed with 'CFE.'.

Ticket: ENT-9095
Changelog: Title