### PR TITLE
CFE-3435: Test expireafter works with custom promise types

### DIFF
--- a/tests/acceptance/30_custom_promise_types/24_expireafter.cf
+++ b/tests/acceptance/30_custom_promise_types/24_expireafter.cf
@@ -1,0 +1,100 @@
+##############################################################################
+#
+#  Test that expireafter works with custom promise types.
+#
+##############################################################################
+
+body common control
+{
+  inputs => { "../default.cf.sub" };
+  bundlesequence  => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+bundle common version_check
+{
+  classes:
+      "compatible_python_version"
+        expression => returnszero(
+          "/usr/bin/python3 -c 'import sys; assert sys.version_info >= (3,6)'",
+          "useshell"
+        );
+
+@if minimum_version(3.22)
+      "supports_expireafter"
+        expression => "any";
+@endif
+}
+
+##############################################################################
+
+bundle agent init
+{
+  files:
+      "$(this.promise_dirname)/cfengine.py"
+        copy_from => local_cp(
+          "$(this.promise_dirname)/../../../modules/promises/cfengine.py"
+        );
+      "$(G.testfile)"
+        delete => tidy;
+}
+
+##############################################################################
+
+body action background {
+  background => "true";
+}
+
+bundle agent test
+{
+  meta:
+      "description" -> { "CFE-3435" }
+        string => "Test that expireafter works with custom promise types";
+
+      "test_skip_unsupported"
+        string => "!supports_expireafter|!compatible_python_version";
+
+  commands:
+      # Note: This sub agent run has to be "identical" to the next
+      # sub agent run, so the slow_append promise inside of it
+      # will have the same promise hash, and thus expireafter will
+      # work.
+      "$(sys.cf_agent) --inform --file $(this.promise_filename).sub"
+        action => background,
+        comment => "I will get killed by the second agent",
+        handle => "unique"; # Handle makes the promise lock unique.
+      "/bin/sleep 90"
+        comment => "I will wait for the first agent to expire";
+      "$(sys.cf_agent) --inform --file $(this.promise_filename).sub"
+        comment => "I will kill the first agent";
+}
+
+##############################################################################
+
+bundle agent check
+{
+  vars:
+      # Note: Here, the conclusion is a bit fuzzy
+      # since both agent runs print this, we don't
+      # know for sure exactly what happened.
+      # We know that if it's printed once, that looks
+      # correct, and if it's printed twice, or 0 times,
+      # it's definitely wrong.
+      "expected"
+        string => "Hello CFEngine!";
+      "actual"
+        string => readfile("$(G.testfile)"),
+        if => fileexists("$(G.testfile)");
+
+  classes:
+      "ok"
+        expression => strcmp("$(expected)", "$(actual)");
+
+  reports:
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+    DEBUG::
+      "Expected '$(expected)', found '$(actual)'";
+}

--- a/tests/acceptance/30_custom_promise_types/24_expireafter.cf.sub
+++ b/tests/acceptance/30_custom_promise_types/24_expireafter.cf.sub
@@ -1,0 +1,35 @@
+##############################################################################
+#
+#  Test that expireafter works with custom promise types.
+#
+##############################################################################
+
+body common control
+{
+  inputs => { "../default.cf.sub" };
+  bundlesequence  => { "test" };
+  version => "1.0";
+}
+
+promise agent slow_append
+{
+  interpreter => "/usr/bin/python3";
+  path => "$(this.promise_dirname)/slow_append_promises.py";
+}
+
+##############################################################################
+
+body action timeout
+{
+  expireafter => "1";
+  ifelapsed => "0";
+}
+
+bundle agent test
+{
+  slow_append:
+      "$(G.testfile)"
+        seconds => "120",
+        content => "Hello CFEngine!",
+        action => timeout;
+}

--- a/tests/acceptance/30_custom_promise_types/slow_append_promises.py
+++ b/tests/acceptance/30_custom_promise_types/slow_append_promises.py
@@ -1,0 +1,72 @@
+#!/usr/bin/python3
+#
+# Sample custom promise type that sleeps for a specified amount of time before
+# creating a file with content.
+#
+# Use it in the policy like this:
+# promise agent slow_append
+# {
+#   interpreter => "/usr/bin/python3";
+#   path => "$(sys.inputdir)/slow_append_promises.py";
+# }
+# bundle agent main
+# {
+#   slow_append:
+#       "/tmp/testfile"
+#         seconds =>  "123.4",
+#         content => "Hello CFEngine!";
+# }
+
+
+import time
+from cfengine import PromiseModule, ValidationError, Result
+
+
+class SlowAppendPromiseTypeModule(PromiseModule):
+    def __init__(self):
+        super().__init__("slow_append_promise_module", "0.0.1")
+
+    def validate_promise(self, promiser, attributes, meta):
+        seconds = attributes.get("seconds")
+        if seconds is None:
+            raise ValidationError(
+                "Missing required attribute 'seconds' for promiser '%s'" % promiser
+            )
+        try:
+            float(seconds)
+        except ValueError:
+            raise ValidationError(
+                "Invalid literal '%s' in attribute 'seconds' for promiser '%s'"
+                % (seconds, promiser)
+            )
+
+        if "content" not in attributes:
+            raise ValidationError(
+                "Missing required attribute 'content' for promiser '%s'" % promiser
+            )
+
+    def evaluate_promise(self, promiser, attributes, meta):
+        seconds = float(attributes["seconds"])
+        content = attributes["content"]
+
+        self.log_debug("Sleeping %.2f seconds" % seconds)
+        time.sleep(seconds)
+
+        try:
+            with open(promiser, "a+") as f:
+                f.write(content)
+            self.log_info("Appended content '%s' to file '%s'" % (content, promiser))
+        except Exception as e:
+            self.log_error(
+                "Failed to append content '%s' to file '%s': %s"
+                % (content, promiser, e)
+            )
+            self.log_error("Promise '%s' not kept" % promiser)
+            return Result.NOT_KEPT
+
+        self.log_verbose("Promise '%s' kept" % promiser)
+        return Result.KEPT
+
+
+if __name__ == "__main__":
+    SlowAppendPromiseTypeModule().start()


### PR DESCRIPTION
Test that expireafter works with custom promise types.

Merge with:
 - https://github.com/cfengine/core/pull/5080