### PR TITLE
ENT-9535: Prevented management of runagent socket users when no users are listed (3.18)

### DIFF
--- a/controls/def.cf
+++ b/controls/def.cf
@@ -511,7 +511,7 @@ bundle common def
       "_have_control_agent_files_single_copy" -> { "CFE-3622"}
         expression => isvariable( "def.control_agent_files_single_copy" );
       "_have_control_executor_runagent_socket_allow_users"
-        expression => isvariable( "def.control_executor_runagent_socket_allow_users" );
+        expression => some( ".+", "def.control_executor_runagent_socket_allow_users" );
 
       "cfengine_recommendations_enabled"
         expression => "!cfengine_recommendations_disabled";


### PR DESCRIPTION
This changes the guard for setting runagent socket ownership (which uses ACLs)
for the case when the list of runagent socket users is not an empty list. This
allows for disablement by simply setting an empty list via augments.

Ticket: ENT-9535
Changelog: Title
(cherry picked from commit c8de0d254345c8bb37c22caacd13ae812c527c62)