### PR TITLE
ENT-8824: Skip great package test on RHEL-9

### DIFF
--- a/tests/acceptance/17_packages/10_new/unsafe/the_great_package_test.cf
+++ b/tests/acceptance/17_packages/10_new/unsafe/the_great_package_test.cf
@@ -30,10 +30,13 @@ body common control
 bundle agent init
 {
   meta:
+      # RHEL 9 may have similar issues as RHEL 8 and also issues where rpm -U --force
+      # has different behavior than previous releases: erases other architecture
+      # packages where earlier releases did not, so fails many tests.
       # RHEL 8 has broken DNF (upgrading a 32bit package also installs a 64bit
       # package)
-      "test_soft_fail" string => "rhel_8",
-        meta  => {"CFE-rhbz"};
+      "test_soft_fail" string => "rhel_8|rhel_9",
+        meta  => {"CFE-rhbz", "CFE-4096"};
 
   # For setting up the cfengine-selected-python symlink we want to
   # target $(sys.bindir) as that will be in the test WORKDIR.

--- a/tests/acceptance/17_packages/10_new/unsafe/the_great_package_test_generator.py
+++ b/tests/acceptance/17_packages/10_new/unsafe/the_great_package_test_generator.py
@@ -116,10 +116,13 @@ body common control
 bundle agent init
 {
   meta:
+      # RHEL 9 may have similar issues as RHEL 8 and also issues where rpm -U --force
+      # has different behavior than previous releases: erases other architecture
+      # packages where earlier releases did not, so fails many tests.
       # RHEL 8 has broken DNF (upgrading a 32bit package also installs a 64bit
       # package)
-      "test_soft_fail" string => "rhel_8",
-        meta  => {"CFE-rhbz"};
+      "test_soft_fail" string => "rhel_8|rhel_9",
+        meta  => {"CFE-rhbz", "CFE-4096"};
 
   # For setting up the cfengine-selected-python symlink we want to
   # target $(sys.bindir) as that will be in the test WORKDIR.


### PR DESCRIPTION
Has issues with rpm -U --force behavior being
different than previous releases. As well as
possibly the same issues as rhel-8 had when we
chose to skip this test on rhel-8.

Fix this in CFE-4096

Ticket: ENT-8824
Changelog: none

merge together:
https://github.com/cfengine/buildscripts/pull/1137
https://github.com/cfengine/system-testing/pull/462
https://github.com/cfengine/masterfiles/pull/2529
https://github.com/cfengine/core/pull/5111