### PR TITLE
ENT-8933: Disabled explicit setting for SSLCompression for Mission Portal Apache

### DIFF
--- a/cfe_internal/enterprise/templates/httpd.conf.mustache
+++ b/cfe_internal/enterprise/templates/httpd.conf.mustache
@@ -147,7 +147,11 @@ LogLevel warn
 
   # TLS Compression should be disabled to avoid CRIME
   # https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2012-4929
-  SSLCompression off
+  # SSLCompression off
+  # As part of security hardening we minimize the features provided by OpenSSL.
+  # Case in point, we build openssl 3 without support for compression. As such,
+  # we do not explicitly disable SSL Compression beginning with CFEngine
+  # Enteprprise 3.21.0 as apache is unable to then validate the configuration.
 
   # This is not explicitly enabled to allow the requesting client the first
   # choice of support ciphers


### PR DESCRIPTION
merge together:
- https://github.com/cfengine/buildscripts/pull/1160

As part of SSL minification we stopped building support for compression. Apache
won't validate the configuration when the library does not support the
setting so it must not be active.

Ticket: ENT-8933
Changelog: Title