### PR TITLE
ENT-9625: Fixed MP Build initial deploy agent run

### DIFF
--- a/cfe_internal/update/cfe_internal_dc_workflow.cf
+++ b/cfe_internal/update/cfe_internal_dc_workflow.cf
@@ -5,6 +5,7 @@ bundle agent cfe_internal_dc_workflow
     am_policy_hub.enterprise.cfengine_internal_masterfiles_update::
       "Masterfiles from VCS"
         usebundle => cfe_internal_update_from_repository,
+        if => fileexists("/opt/cfengine/dc-scripts/params.sh"),
         handle => "cfe_internal_dc_workflow_methods_masterfiles_from_vcs",
         comment => "Update masterfiles from upstream VCS automatically
                     for best OOTB Enterprise experience";


### PR DESCRIPTION
MP Build deploy of an initial project initiates
an agent run vi the runagent socket listened to by cf-execd.

We need to run the agent twice in this case:
first to set the default:cfengine_internal_masterfiles_update class second to run masterfiles-stage.sh

In order to make that second run able to activate bundle cfe_internal_dc_workflow, it must be skipped and not start a lock in the first agent run.

Ticket: ENT-9625
Changelog: none

merge together:
https://github.com/cfengine/mission-portal/pull/1846
https://github.com/cfengine/masterfiles/pull/2548