### PR TITLE
ENT-9697: Removed no longer needed settings.ldap.php permissions promise

### DIFF
--- a/cfe_internal/enterprise/CFE_knowledge.cf
+++ b/cfe_internal/enterprise/CFE_knowledge.cf
@@ -204,6 +204,7 @@ bundle agent cfe_internal_setup_knowledge
         comment => concat( "The ldap directory and it's subdirectories need to be",
                     "executable by cfapache" ),
         depth_search => recurse( "inf" ),
+        file_select => cfe_internal_docroot_perms,
         perms => mog("0550", "root", $(def.cf_apache_group) );
 
 


### PR DESCRIPTION
Handled by a higher level ldap directory promise now.

Ticket: ENT-9697
Changelog: title