### PR TITLE
ENT-9697: Added exception for ldap directory perms for settings.ldap.php (3.18)

### DIFF
--- a/cfe_internal/enterprise/CFE_knowledge.cf
+++ b/cfe_internal/enterprise/CFE_knowledge.cf
@@ -204,6 +204,7 @@ bundle agent cfe_internal_setup_knowledge
         comment => concat( "The ldap directory and it's subdirectories need to be",
                     "executable by cfapache" ),
         depth_search => recurse( "inf" ),
+        file_select => cfe_internal_docroot_perms,
         perms => mog("0550", "root", $(def.cf_apache_group) );
 
 


### PR DESCRIPTION
Cycling permissions were introduced with ENT-9693 enforcing root:root 440 on ldap dir recursively.

Ticket: ENT-9697
Changelog: title
(cherry picked from commit 0160045f572beec2af88187d5e3df2eb84b9b1b6)