### PR TITLE
ENT-9711: Updated reference to explicitly create runalerts-stamp directory

### DIFF
--- a/cfe_internal/enterprise/CFE_knowledge.cf
+++ b/cfe_internal/enterprise/CFE_knowledge.cf
@@ -56,12 +56,14 @@ bundle agent cfe_internal_setup_knowledge
       handle => "cfe_internal_setup_knowledge_dir_doc_root",
       perms => mog("0550", "root", $(def.cf_apache_group) );
 
-      "$(sys.workdir)/httpd/php" -> { "ENT-9703", "cfe_internal_setup_knowledge_dir_doc_root_runalerts_stamp" }
+      "$(sys.workdir)/httpd/php/." -> { "ENT-9703", "cfe_internal_setup_knowledge_dir_doc_root_runalerts_stamp" }
+        create => "true",
         comment => "php directory needs to be accessible (execute) to cfapache",
         handle => "cfe_internal_setup_knowledge_dir_doc_root_php",
         perms => mog("0550", "root", $(def.cf_apache_group) );
 
-      "$(sys.workdir)/httpd/php/runalerts-stamp" -> { "ENT-9703" }
+      "$(sys.workdir)/httpd/php/runalerts-stamp/." -> { "ENT-9703" }
+        create => "true",
         comment => "runalerts-stamp directory needs to be accessible (execute) to cfapache",
         handle => "cfe_internal_setup_knowledge_dir_doc_root_runalerts_stamp",
         perms => mog("0550", "root", $(def.cf_apache_group) );

--- a/templates/cf-runalerts.service.mustache
+++ b/templates/cf-runalerts.service.mustache
@@ -3,6 +3,7 @@ Description=CFEngine Enterprise SQL Alerts
 After=syslog.target
 ConditionPathExists={{{vars.sys.bindir}}}/runalerts.php
 ConditionFileIsExecutable={{{vars.sys.workdir}}}/httpd/php/bin/php
+ConditionPathIsDirectory={{{vars.sys.workdir}}}/httpd/php/runalerts-stamp
 
 PartOf=cfengine3.service
 After=cf-postgres.service


### PR DESCRIPTION
Without /. a file will be created. Without create => true no action is promised.

Ticket: ENT-9711
Changelog: None

together:
https://github.com/cfengine/masterfiles/pull/2564
https://github.com/cfengine/core/pull/5136