### PR TITLE
ENT-9711: runalerts-stamp directory fixes (3.18)

### DIFF
--- a/cfe_internal/enterprise/CFE_knowledge.cf
+++ b/cfe_internal/enterprise/CFE_knowledge.cf
@@ -56,6 +56,16 @@ bundle agent cfe_internal_setup_knowledge
       handle => "cfe_internal_setup_knowledge_dir_doc_root",
       perms => mog("0550", "root", $(def.cf_apache_group) );
 
+      "$(sys.workdir)/httpd/php" -> { "ENT-9703" }
+        comment => "php directory needs to be accessible (execute) to cfapache",
+        handle => "cfe_internal_setup_knowledge_dir_doc_root_php",
+        perms => mog("0550", "root", $(def.cf_apache_group) );
+
+      "$(sys.workdir)/httpd/php/runalerts-stamp" -> { "ENT-9703" }
+        comment => "runalerts-stamp directory needs to be accessible (execute) to cfapache",
+        handle => "cfe_internal_setup_knowledge_dir_doc_root_runalerts_stamp",
+        perms => mog("0550", "root", $(def.cf_apache_group) );
+
       "$(cfe_internal_hub_vars.docroot)/vendor/." -> { "CFE-951" }
         comment => "The vendor directory and sub-directories contains dependencies from the code ignitor framework and the directories need to be searchable by the web server.",
         handle => "cfe_internal_setup_knowledge_dir_doc_root_vendor_dirs",

--- a/cfe_internal/enterprise/CFE_knowledge.cf
+++ b/cfe_internal/enterprise/CFE_knowledge.cf
@@ -56,7 +56,7 @@ bundle agent cfe_internal_setup_knowledge
       handle => "cfe_internal_setup_knowledge_dir_doc_root",
       perms => mog("0550", "root", $(def.cf_apache_group) );
 
-      "$(sys.workdir)/httpd/php" -> { "ENT-9703" }
+      "$(sys.workdir)/httpd/php" -> { "ENT-9703", "cfe_internal_setup_knowledge_dir_doc_root_runalerts_stamp" }
         comment => "php directory needs to be accessible (execute) to cfapache",
         handle => "cfe_internal_setup_knowledge_dir_doc_root_php",
         perms => mog("0550", "root", $(def.cf_apache_group) );

--- a/cfe_internal/enterprise/CFE_knowledge.cf
+++ b/cfe_internal/enterprise/CFE_knowledge.cf
@@ -56,12 +56,14 @@ bundle agent cfe_internal_setup_knowledge
       handle => "cfe_internal_setup_knowledge_dir_doc_root",
       perms => mog("0550", "root", $(def.cf_apache_group) );
 
-      "$(sys.workdir)/httpd/php" -> { "ENT-9703", "cfe_internal_setup_knowledge_dir_doc_root_runalerts_stamp" }
+      "$(sys.workdir)/httpd/php/." -> { "ENT-9703", "cfe_internal_setup_knowledge_dir_doc_root_runalerts_stamp" }
+        create => "true",
         comment => "php directory needs to be accessible (execute) to cfapache",
         handle => "cfe_internal_setup_knowledge_dir_doc_root_php",
         perms => mog("0550", "root", $(def.cf_apache_group) );
 
-      "$(sys.workdir)/httpd/php/runalerts-stamp" -> { "ENT-9703" }
+      "$(sys.workdir)/httpd/php/runalerts-stamp/." -> { "ENT-9703" }
+        create => "true",
         comment => "runalerts-stamp directory needs to be accessible (execute) to cfapache",
         handle => "cfe_internal_setup_knowledge_dir_doc_root_runalerts_stamp",
         perms => mog("0550", "root", $(def.cf_apache_group) );

--- a/templates/cf-runalerts.service.mustache
+++ b/templates/cf-runalerts.service.mustache
@@ -3,6 +3,7 @@ Description=CFEngine Enterprise SQL Alerts
 After=syslog.target
 ConditionPathExists={{{vars.sys.bindir}}}/runalerts.php
 ConditionFileIsExecutable={{{vars.sys.workdir}}}/httpd/php/bin/php
+ConditionPathIsDirectory={{{vars.sys.workdir}}}/httpd/php/runalerts-stamp
 
 PartOf=cfengine3.service
 After=cf-postgres.service


### PR DESCRIPTION
together:
https://github.com/cfengine/buildscripts/pull/1188
https://github.com/cfengine/masterfiles/pull/2569
https://github.com/cfengine/core/pull/5149