### PR TITLE
ENT-9778: Fixed body perms system_owned to account for Windows (3.18)

### DIFF
--- a/lib/files.cf
+++ b/lib/files.cf
@@ -1742,7 +1742,6 @@ body perms system_owned(mode)
 # ```
 {
       mode   => "$(mode)";
-      owners => { "root" };
 
 #+begin_ENT-951
 # Remove after 3.20 is not supported
@@ -1751,6 +1750,19 @@ body perms system_owned(mode)
         rxdirs => "false";
 @endif
 #+end
+
+    !windows::
+        owners => { "root" };
+
+    windows::
+
+      # NOTE: Setting owners will generate an error if the policy is not being
+      # executed as the user who's ownership is being targeted. While it seems
+      # that should typically be Administrator or SYSTEM, both are reported to
+      # result in errors by users, thus owners is currently omitted for Windows.
+
+      # ENT-9778
+      groups => { "Administrators" };
 
     freebsd|openbsd|netbsd|darwin::
       groups => { "wheel" };


### PR DESCRIPTION
This change accounts for windows in the system_owned perms body.

Note: There is a limitation not being able to set file ownership to users other
than the executing user. Since users report said errors when this targets
Administrator or SYSTEM, the owner for Windows is explicitly excluded.