### PR TITLE
ENT-9804: Added Inventory for Policy Version

### DIFF
--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -16,6 +16,10 @@ bundle common inventory_any
         string => "$(data[releaseId])",
         meta => { "inventory", "attribute_name=Policy Release Id" };
 
+      "policy_version" -> { "ENT-9804" }
+        string => "$(default:common_control.version)",
+        meta => { "inventory", "attribute_name=Policy Version" };
+
   reports:
       "DEBUG|DEBUG_$(this.bundle)"::
         "DEBUG $(this.bundle): Inventory Policy Release Id=$(id)";


### PR DESCRIPTION
This change adds inventory for the policy version as defined in body common
control. It's helpful to be able to easily look up what policy version something
is running (assuming a user has not modified the value set during release).