### PR TITLE
Redacted old, useless comment

### DIFF
--- a/promises.cf.in
+++ b/promises.cf.in
@@ -134,8 +134,6 @@ bundle common inventory
 #
 # Inventory bundles are simply common bundles loaded before anything
 # else in promises.cf
-#
-# Tested to work properly against 3.5.x
 {
   classes:
       "other_unix_os" expression => "!(windows|macos|linux|freebsd|aix)";


### PR DESCRIPTION
I don't think that the fact that this was tested on 3.5.x at some point is
really useful. In fact, at this point reading a random snippet it sends me down
a thought path that the policy is quite old, perhaps from the 3.6 era. So, I
think it's best to simply redact this.

(cherry picked from commit 48e4ee55c61e80125db857bb65002e447a3c7ec7)