### PR TITLE
CFE-4146: Avoided deleting python symlink when sys.bindir is not /var/cfengine/bin

### DIFF
--- a/cfe_internal/update/update_policy.cf
+++ b/cfe_internal/update/update_policy.cf
@@ -139,13 +139,14 @@ bundle agent cfe_internal_setup_python_symlink(symlink_path)
         move_obstructions => "true",
         if => isvariable("python");
 
-      "$(sys.bindir)/python" -> { "CFE-3512" }
+      "$(sys.bindir)/python" -> { "CFE-3512", "CFE-4146" }
         delete => u_tidy,
-        if => islink( "$(sys.bindir)/python" ),
+        if => and( islink( "$(sys.bindir)/python" ),
+                   strcmp( "$(sys.bindir)", "/var/cfengine/bin")),
         comment => concat( "We don't want to leave a python that is potentially in $PATH ",
                            "after having re-named our python symlink that is used for various ",
-                           "modules");
-
+                           "modules. Additionally we want to be cautious that we don't delete ",
+                           "system python symlinks in the event the binary was built for FHS.");
 }
 
 bundle agent cfe_internal_update_policy_cpv


### PR DESCRIPTION
If you build CFEngine with --enable-fhs then sys.bindir is going to be /usr/bin
and cleaning up the cfengine selected python symlink that could have been left
would result in cleaning up the system python symlink instead. This change
scopes the cleanup down to only when sys.bindir is /var/cfengine/bin.

Ticket: CFE-4146
Changelog: Title