### PR TITLE
Update the cfengine.py library

### DIFF
--- a/tests/acceptance/30_custom_promise_types/append_promises.py
+++ b/tests/acceptance/30_custom_promise_types/append_promises.py
@@ -23,7 +23,7 @@ class AppendPromiseTypeModule(PromiseModule):
     def __init__(self):
         super().__init__("append_promise_module", "0.0.1")
 
-    def validate_promise(self, promiser, attributes):
+    def validate_promise(self, promiser, attributes, meta):
         if type(promiser) != str:
             raise ValidationError("Promiser must be of type string")
         if not "string" in attributes:
@@ -34,7 +34,7 @@ class AppendPromiseTypeModule(PromiseModule):
         if "always" in attributes and attributes["always"] not in ("true", "false"):
             raise ValidationError("Attribute 'always' must be either 'true' or 'false'")
 
-    def evaluate_promise(self, promiser, attributes):
+    def evaluate_promise(self, promiser, attributes, meta):
         assert "string" in attributes
 
         always = attributes.get("always", "false") == "true"

--- a/tests/acceptance/30_custom_promise_types/bodies.py
+++ b/tests/acceptance/30_custom_promise_types/bodies.py
@@ -29,10 +29,10 @@ class BodiesPromiseTypeModule(PromiseModule):
     def __init__(self):
         super().__init__("bodies_promise_module", "0.0.1")
 
-    def validate_promise(self, promiser, attributes):
+    def validate_promise(self, promiser, attributes, meta):
         pass
 
-    def evaluate_promise(self, promiser, attributes):
+    def evaluate_promise(self, promiser, attributes, meta):
         try:
             with open(promiser, "rw") as f:
                 if (json.dumps(attributes) == f.read()):

--- a/tests/acceptance/30_custom_promise_types/copy_always_info.py
+++ b/tests/acceptance/30_custom_promise_types/copy_always_info.py
@@ -28,10 +28,10 @@ class CopyPromiseTypeModule(PromiseModule):
     def __init__(self):
         super().__init__("copy_promise_module", "0.0.1")
 
-    def validate_promise(self, promiser, attributes):
+    def validate_promise(self, promiser, attributes, meta):
         pass
 
-    def evaluate_promise(self, promiser, attributes):
+    def evaluate_promise(self, promiser, attributes, meta):
         dst = promiser
         src = attributes["from"]
         if os.path.exists(dst) and filecmp.cmp(src, dst):

--- a/tests/acceptance/30_custom_promise_types/copy_promises.py
+++ b/tests/acceptance/30_custom_promise_types/copy_promises.py
@@ -26,10 +26,10 @@ class CopyPromiseTypeModule(PromiseModule):
     def __init__(self):
         super().__init__("copy_promise_module", "0.0.1")
 
-    def validate_promise(self, promiser, attributes):
+    def validate_promise(self, promiser, attributes, meta):
         pass
 
-    def evaluate_promise(self, promiser, attributes):
+    def evaluate_promise(self, promiser, attributes, meta):
         dst = promiser
         src = attributes["from"]
         if os.path.exists(dst) and filecmp.cmp(src, dst):

--- a/tests/acceptance/30_custom_promise_types/json_insert.py
+++ b/tests/acceptance/30_custom_promise_types/json_insert.py
@@ -31,12 +31,12 @@ class JsonInsertPromiseTypeModule(PromiseModule):
     def __init__(self):
         super().__init__("json_insert_promise_module", "0.0.1")
 
-    def validate_promise(self, promiser, attributes):
+    def validate_promise(self, promiser, attributes, meta):
         if ("json_data" not in attributes or
             type(attributes["json_data"]) != dict):
             raise ValidationError("'json_data' attribute of type data required")
 
-    def evaluate_promise(self, promiser, attributes):
+    def evaluate_promise(self, promiser, attributes, meta):
         dst = promiser
         data = attributes["json_data"]
         data_str = json.dumps(data)

--- a/tests/acceptance/30_custom_promise_types/multiline_insert.py
+++ b/tests/acceptance/30_custom_promise_types/multiline_insert.py
@@ -30,13 +30,13 @@ class MultilineInsertPromiseTypeModule(PromiseModule):
     def __init__(self):
         super().__init__("multiline_insert_promise_module", "0.0.1")
 
-    def validate_promise(self, promiser, attributes):
+    def validate_promise(self, promiser, attributes, meta):
         if ("lines" not in attributes or
             type(attributes["lines"]) not in (list, tuple) or
             any(type(item) != str for item in attributes["lines"])):
             raise ValidationError("'lines' attribute of type slist required")
 
-    def evaluate_promise(self, promiser, attributes):
+    def evaluate_promise(self, promiser, attributes, meta):
         dst = promiser
         lines = attributes["lines"]
         lines_str = "\n".join(lines)

--- a/tests/acceptance/30_custom_promise_types/noop_promises.py
+++ b/tests/acceptance/30_custom_promise_types/noop_promises.py
@@ -26,14 +26,14 @@ class NoopPromiseTypeModule(PromiseModule):
     def __init__(self):
         super().__init__("noop_promise_module", "0.0.1")
 
-    def validate_promise(self, promiser, attributes):
+    def validate_promise(self, promiser, attributes, meta):
         if "outcome" in attributes and type(attributes["outcome"]) != str:
             raise ValidationError(
                 "Attribute 'outcome' for promiser '%d' must be of type string"
                 % promiser
             )
 
-    def evaluate_promise(self, promiser, attributes):
+    def evaluate_promise(self, promiser, attributes, meta):
         assert type(promiser) == str
 
         if "outcome" in attributes:


### PR DESCRIPTION
Updated in its upstream repo: cfengine/modules@ba6bae35b8493b0dc8 and the new version adds the 'meta' attribute for
validate/evaluate_promise() that we need to add to all our modules in tests.