### PR TITLE
ENT-9924: Added cf-hub to the list of components documented as being influenced by mpf_augments_control_enabled (3.18)

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -1078,7 +1078,7 @@ While the agent itsef will reload its config upon notice of policy change this
 bundle specifically handles changes to variables used in the MPF which may come
 from external data sources which are unknown to the components themselves.
 
-Currently only `cf-serverd` and `cf-monitord` are handled. `cf-execd` is
+Currently only `cf-serverd`, `cf-monitord`, and `cf-hub` are handled. `cf-execd` is
 **NOT** automatically restarted.
 
 To enable this functionality define the class **`mpf_augments_control_enabled`**


### PR DESCRIPTION
Ticket: ENT-9924
Changelog: None
(cherry picked from commit dadfb77087a383a49ad8a9a3e27b0c0ea9eb0aea)