### PR TITLE
ENT-9933: Added guards against using regline() in cases where a file may not exist

### DIFF
--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -635,7 +635,8 @@ bundle agent postgres_config
                                      "\s*=\s*",
                                      ".*",
                                      ""),
-        classes => default:results( "bundle", "postgresql_conf" );
+        classes => default:results( "bundle", "postgresql_conf" ),
+        if => fileexists( "$(sys.statedir)/pg/data/postgresql.conf" );
 
   commands:
     am_superhub.postgresql_conf_repaired.!systemd::

--- a/cfe_internal/update/update_policy.cf
+++ b/cfe_internal/update/update_policy.cf
@@ -325,6 +325,11 @@ bundle agent cfe_internal_update_cmdb
 bundle agent cfe_internal_update_cmdb_data_distribution
 # @brief Ensure data is ready for agents to download
 {
+  classes:
+
+      "_have_cmdb_next_request_state_file" -> { "ENT-9933" }
+        expression => fileexists( "$(_cmdb_next_request_state_file)" );
+
   vars:
     !bootstrap_mode.(policy_server.enterprise_edition)::
 
@@ -333,6 +338,7 @@ bundle agent cfe_internal_update_cmdb_data_distribution
       "_cmdb_next_request_state_file"
         string => "$(sys.statedir)/cmdb_next_request_from.dat";
 
+    !bootstrap_mode.(policy_server.enterprise_edition._have_cmdb_next_request_state_file)::
       # If we have the timestamp from a previous response we use it, else we start from 0
       "_cmdb_previous_next_request_from"
         string => readfile( $(_cmdb_next_request_state_file), inf ),
@@ -342,6 +348,7 @@ bundle agent cfe_internal_update_cmdb_data_distribution
         string => "0",
         unless => regline( "^\d+$", $(_cmdb_next_request_state_file) );
 
+    !bootstrap_mode.(policy_server.enterprise_edition)::
       # We need a script to call that should return the API response
       "_get_cmdb_data_bin" string => "$(sys.workdir)/httpd/htdocs/scripts/get_cmdb.php";
       "_get_cmdb_data_cmd" string => "/var/cfengine/httpd/php/bin/php $(_get_cmdb_data_bin) $(_cmdb_previous_next_request_from)";

--- a/lib/bundles.cf
+++ b/lib/bundles.cf
@@ -60,7 +60,8 @@ bundle agent cronjob(commands,user,hours,mins)
       # entering duplicate entries.
 
       "present_with_potentially_different_spacing"
-        expression => regline( "^$(e_mins)\s+$(e_hours)\s+\*\s+\*\s+\*\s+$(e_commands)", "$(crontab)/$(user)");
+        expression => regline( "^$(e_mins)\s+$(e_hours)\s+\*\s+\*\s+\*\s+$(e_commands)", "$(crontab)/$(user)"),
+        if => fileexists( "$(crontab)/$(user)" );
 
   files:
 


### PR DESCRIPTION
regline() may throw an error in the event that the probed file does not exist,
as observed in CI in 3.18.x error: In function "regline", error reading from file. (getline: No such file or directory)

To avoid those errors this change guards against use of regline() in case of a
nonexistent at a high level. This instrumentation was not made deep inside
edit_line bundles as it may be useful to surface the potential error in some cases.

Ticket: ENT-9933
Changelog: Title