### PR TITLE
ENT-9948: Removed specific old CFEngine version package module handling for windows (3.21)

### DIFF
--- a/lib/packages.cf
+++ b/lib/packages.cf
@@ -37,13 +37,8 @@ bundle common package_module_knowledge
     slackware::
       "platform_default" string => "slackpkg";
 
-      # CFEngine 3.12.2+ and 3.14+ have new package module on Windows
-    windows.cfengine_3_12.!(cfengine_3_12_0|cfengine_3_12_1)::
-      "platform_default" string => "msiexec";
-@if minimum_version(3.14)
     windows::
       "platform_default" string => "msiexec";
-@endif
 
     alpinelinux::
       "platform_default" string => "apk";

--- a/promises.cf.in
+++ b/promises.cf.in
@@ -104,15 +104,10 @@ body common control
     (debian|redhat|suse|sles|opensuse|amazon_linux)::
           package_module => $(package_module_knowledge.platform_default);
 
-      # CFEngine 3.12.2+ and 3.14+ have new package module on Windows
-    windows.cfengine_3_12.!(cfengine_3_12_0|cfengine_3_12_1)::
-          package_inventory => { $(package_module_knowledge.platform_default) };
-          package_module => $(package_module_knowledge.platform_default);
-@if minimum_version(3.14)
     windows::
           package_inventory => { $(package_module_knowledge.platform_default) };
           package_module => $(package_module_knowledge.platform_default);
-@endif
+
     termux::
           package_module => $(package_module_knowledge.platform_default);
 


### PR DESCRIPTION
This version specific handling of windows package module handling from 3.14 and
prior is no longer relevant as they are no longer supported and were not
supported at the time of this series release.