### PR TITLE
Made package cache refresh for common_knowledge.list_update_ifelapsed configurable

### DIFF
--- a/lib/packages.cf
+++ b/lib/packages.cf
@@ -210,7 +210,16 @@ bundle common common_knowledge
 # This common bundle defines general things about platforms.
 {
   vars:
-      "list_update_ifelapsed" string => "240";
+
+      # This variable can be customized via augments:
+      # { "variables": { "default:common_knowledge.list_update_ifelapsed": { "value": "0" } } }
+      "list_update_ifelapsed"
+        string => "240",
+        if => not( isvariable( "list_update_ifelapsed" )),
+        comment => concat( "The number of minutes to wait before updating the",
+                           " package cache. Note this controls both the software",
+                           " installed and the software updates available."),
+        meta => { "defcustom" };
 }
 
 bundle common debian_knowledge


### PR DESCRIPTION
This change makes the number of minutes to wait between package cache updates
for some package_method bodies configurable via augments.

The package_method bodies affected by this include:
- body package_method pip(flags)
- body package_method npm(dir)
- body package_method npm_g
- body package_method brew(user)
- body package_method apt
- body package_method apt_get
- body package_method apt_get_permissive
- body package_method apt_get_release(release)
- body package_method dpkg_version(repo)
- body package_method rpm_version(repo)
- body package_method yum
- body package_method yum_rpm
- body package_method yum_rpm_permissive
- body package_method yum_rpm_enable_repo(repoid)
- body package_method yum_group
- body package_method rpm_filebased(path)
- body package_method ips
- body package_method smartos
- body package_method opencsw
- body package_method emerge
- body package_method pacman
- body package_method zypper
- body package_method generic

Additionally note that the package related bundles use the package_method bodies
mentioned above and are similarly influenced.

- bundle agent package_present(package)
- bundle agent package_latest(package)
- bundle agent package_specific_present(packageorfile, package_version, package_arch)
- bundle agent package_specific_absent(packageorfile, package_version, package_arch)
- bundle agent package_specific_latest(packageorfile, package_version, package_arch),
- bundle agent package_specific(package_name, desired, package_version, package_arch)

This change introduces a new tag, defcustom to identify variables that expect to
be influenced by Augments.