### PR TITLE
ENT-10172: Fixed workflow refs for push events

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           repository: cfengine/core
           path: core
-          ref: ${{steps.together.outputs.core}}
+          ref: ${{steps.together.outputs.core || github.base_ref || github.ref}}
       - name: Install CFEngine with cf-remote
         run: |
           pip3 install cf-remote

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           repository: cfengine/core
           path: core
-          ref: ${{steps.together.outputs.core}}
+          ref: ${{steps.together.outputs.core || github.base_ref || github.ref}}
           submodules: recursive
       - name: Install dependencies
         run: sudo apt-get update -y && sudo apt-get install -y libssl-dev libpam0g-dev liblmdb-dev byacc curl libyaml-dev valgrind


### PR DESCRIPTION
When a PR is merged a push event occurs and workflows are triggered.

At this time an empty ref: will default to master instead of the appropriate branch.

So include github.base_ref and github.ref as fallbacks.

Ticket: ENT-10172
Changelog: none