### PR TITLE
CFE-4178: Made package cache refresh for common_knowledge.list_update_ifelapsed configurable

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -1368,6 +1368,11 @@ For example:
 
 ### Configure periodic package inventory refresh interval
 
+Note that there are currently two implementations of packages promises, package
+modules and package methods. Each maintain their own cache of packages installed
+and updates available.
+
+#### For package modules
 CFEngine refreshes software inventory when it makes changes via packages
 promises. Additionally, by default, CFEngine refreshes it's
 internal cache of packages installed (during each agent run) and package updates that
@@ -1392,6 +1397,49 @@ especially with public repositories or you may be banned for abuse.
 
 * Added in 3.15.0, 3.12.3
 * 3.17.0 decreased `package_module_query_installed_ifelapsed` from `60` to `0`
+
+#### For package methods
+
+CFEngine refreshes it's cache of information about packages installed and
+updates available when it evaluates packages promises if the cache has not been
+updated in the number of minutes stored in `package_list_update_ifelapsed` of
+the package method in use. Many package methods in the standard library use the
+value of `default:common_knowledge.list_updates_ifelapsed` for this value which
+can be customized via Augments.
+
+```json
+{
+  "variables": {
+    "default:common_knowledge.list_update_ifelapsed": {
+      "value": "0"
+    }
+  }
+}
+```
+
+**Notes:**
+
+* Unlike *many* variables that can be customized via Augments this variable is
+  **not** in the `default:def` bundle scope. Customizing it requires CFEngine
+  3.18.0 or newer which support targeting any namespace or variable.
+
+**See also:**
+
+* [package methods][lib/packages.cf]: ```pip```,
+  ```npm```, ```npm_g```, ```brew```, ```apt```, ```apt_get```,
+  ```apt_get_permissive```, ```apt_get_release```, ```dpkg_version```,
+  ```rpm_version``` , ```yum```, ```yum_rpm```, ```yum_rpm_permissive```,
+  ```yum_rpm_enable_repo``` , ```yum_group```, ```rpm_filebased```, ```ips```,
+  ```smartos```, ```opencsw```, ```emerge```, ```pacman```, ```zypper```,
+  ```generic```
+
+* [package bundles][lib/packages.cf]: ```package_latest```,
+  ```package_specific_present```, ```package_specific_absent```,
+  ```package_specific_latest```, ```package_specific```
+
+**History:**
+
+* Added in 3.22.0
 
 ### Enable logging of Enterprise License utilization
 

--- a/lib/packages.cf
+++ b/lib/packages.cf
@@ -210,7 +210,15 @@ bundle common common_knowledge
 # This common bundle defines general things about platforms.
 {
   vars:
-      "list_update_ifelapsed" string => "240";
+
+      # This variable can be customized via augments:
+      # { "variables": { "default:common_knowledge.list_update_ifelapsed": { "value": "0" } } }
+      "list_update_ifelapsed"
+        string => "240",
+        if => not( isvariable( "list_update_ifelapsed" )),
+        comment => concat( "The number of minutes to wait before updating the",
+                           " package cache. Note this controls both the software",
+                           " installed and the software updates available.");
 }
 
 bundle common debian_knowledge


### PR DESCRIPTION
This change makes the number of minutes to wait between package cache updates
for some package_method bodies configurable via augments.

The package_method bodies affected by this include:
- body package_method pip(flags)
- body package_method npm(dir)
- body package_method npm_g
- body package_method brew(user)
- body package_method apt
- body package_method apt_get
- body package_method apt_get_permissive
- body package_method apt_get_release(release)
- body package_method dpkg_version(repo)
- body package_method rpm_version(repo)
- body package_method yum
- body package_method yum_rpm
- body package_method yum_rpm_permissive
- body package_method yum_rpm_enable_repo(repoid)
- body package_method yum_group
- body package_method rpm_filebased(path)
- body package_method ips
- body package_method smartos
- body package_method opencsw
- body package_method emerge
- body package_method pacman
- body package_method zypper
- body package_method generic

Additionally note that the package related bundles use the package_method bodies
mentioned above and are similarly influenced.

- bundle agent package_present(package)
- bundle agent package_latest(package)
- bundle agent package_specific_present(packageorfile, package_version, package_arch)
- bundle agent package_specific_absent(packageorfile, package_version, package_arch)
- bundle agent package_specific_latest(packageorfile, package_version, package_arch),
- bundle agent package_specific(package_name, desired, package_version, package_arch)