### PR TITLE
Made agentfacility in body agent control configurable via Augments

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -554,6 +554,28 @@ For example:
 **History:**
 - Introduced 3.13.0, 3.12.1, 3.10.5
 
+### Configure cf-agent syslog facility
+
+To configure the syslog facility used by `cf-agent` configure `agentfacility` by
+setting `default:def.control_agent_agentfacility` via augments to one of the
+allowed values (`LOG_USER`, `LOG_DAEMON`, `LOG_LOCAL0`, `LOG_LOCAL1`,
+`LOG_LOCAL2`, `LOG_LOCAL3`, `LOG_LOCAL4`, `LOG_LOCAL5`, `LOG_LOCAL6`,
+`LOG_LOCAL7`)
+
+```json
+{
+  "variables": {
+    "default:def.control_agent_agentfacility": {
+      "value": "LOG_USER"
+    }
+  }
+}
+```
+
+**History:**
+
+* Added in 3.22.0
+
 ### mailto
 
 The address that `cf-execd` should email agent output to.

--- a/controls/cf_agent.cf
+++ b/controls/cf_agent.cf
@@ -60,4 +60,8 @@ body agent control
 
       # Environment variables based on Distro
 
+    control_agent_agentfacility_configured::
+
+      agentfacility => "$(default:def.control_agent_agentfacility)";
+
 }

--- a/controls/def.cf
+++ b/controls/def.cf
@@ -179,6 +179,10 @@ bundle common def
         comment => "The control body has a variable, so a valid list must be defined or the agent will error",
         if => not( isvariable( $(this.promiser) ));
 
+      "control_agent_agentfacility" -> { "ENT-10209" }
+        string => "",
+        if => not( isvariable ( $(this.promiser) ));
+
       "control_agent_abortbundleclasses" -> { "ENT-4823" }
         slist => { "abortbundle" },
         comment => "The control body has a variable, so a valid list must be defined or the agent will error",
@@ -243,6 +247,13 @@ bundle common def
       # typically the last promise wins.
 
   classes:
+
+      "control_agent_agentfacility_configured" -> { "ENT-10209" }
+        expression => regcmp( "LOG_(USER|DAEMON|LOCAL[0-7])",
+                              $(control_agent_agentfacility) ),
+        comment => concat( "If default:def.control_agent_agentfacility is a",
+                           " valid setting, we want to use it in body agent",
+                           " control for setting agentfacility" );
 
       "_control_agent_environment_vars_validated" -> { "CFE-3927" }
         and => {

--- a/controls/update_def.cf.in
+++ b/controls/update_def.cf.in
@@ -139,7 +139,20 @@ bundle common update_def
                           "true",
                           "false");
 
+      "control_agent_agentfacility" -> { "ENT-10209" }
+        string => "",
+        if => not( isvariable ( "default:def.control_agent_agentfacility" ));
+
+
   classes:
+
+      "control_agent_agentfacility_configured" -> { "ENT-10209" }
+        expression => regcmp( "LOG_(USER|DAEMON|LOCAL[0-7])",
+                              $(control_agent_agentfacility) ),
+        comment => concat( "If default:def.control_agent_agentfacility is a",
+                           " valid setting, we want to use it in body agent",
+                           " control for setting agentfacility" );
+
 
       "control_common_tls_min_version_defined" -> { "ENT-10198" }
         expression => isvariable( "default:def.control_common_tls_min_version"),

--- a/standalone_self_upgrade.cf.in
+++ b/standalone_self_upgrade.cf.in
@@ -16,7 +16,20 @@ body file control
 }
 bundle common def_standalone_self_upgrade
 {
+  vars:
+
+      "control_agent_agentfacility" -> { "ENT-10209" }
+        string => "",
+        if => not( isvariable ( "default:def.control_agent_agentfacility" ));
+
   classes:
+
+      "control_agent_agentfacility_configured" -> { "ENT-10209" }
+        expression => regcmp( "LOG_(USER|DAEMON|LOCAL[0-7])",
+                              $(control_agent_agentfacility) ),
+        comment => concat( "If default:def.control_agent_agentfacility is a",
+                           " valid setting, we want to use it in body agent",
+                           " control for setting agentfacility" );
 
       "control_common_tls_min_version_defined" -> { "ENT-10198" }
         expression => isvariable( "default:def.control_common_tls_min_version"),
@@ -29,6 +42,13 @@ bundle common def_standalone_self_upgrade
         comment => concat( "If default:def.control_common_tls_ciphers is defined then",
                            " it's value will be used for the set of tls ciphers allowed",
                            " for outbound connections. Else the binary default will be used.");
+}
+body agent control
+# @brief Agent controls for standalone self upgrade
+{
+    control_agent_agentfacility_configured::
+
+        agentfacility => "$(default:update_def.control_agent_agentfacility)";
 }
 bundle agent main
 # @brief This bundle drives the self upgrade. It actuates the appropriate

--- a/update.cf
+++ b/update.cf
@@ -153,6 +153,11 @@ body agent control
 {
       ifelapsed => "1";
       skipidentify => "true";
+
+    control_agent_agentfacility_configured::
+
+        agentfacility => "$(default:update_def.control_agent_agentfacility)";
+
 }
 
 #############################################################################


### PR DESCRIPTION
This change allows for the configuration of agentfacility in body agent control
via Augments. Each policy entry (promises.cf via controls/cf_agent.cf, update.cf
and standalone_self_upgrade.cf) have been instrumented to use the value of
default:def.control_agent_agentfacility if the class
control_agent_agentfacility_configured is defined. The class
control_agent_agentfacility_configured is defined in each policy entry (promises.cf via
controls/def.cf, update.cf via controls/update_def.cf, and
standalone_self_upgrade.cf) only if the value of
default:def.control_agent_agentfacility is a valid value (based on current
documentation).

Ticket: ENT-10209
Changelog: Title
(cherry picked from commit 3ef423f82a527ee2b0936fc1a3329407e239b9e5)