### PR TITLE
ENT-10214: Improved federated reporting dump concurrency with database (3.21)

### DIFF
--- a/templates/federated_reporting/dump.sh
+++ b/templates/federated_reporting/dump.sh
@@ -55,7 +55,7 @@ in_progress_file="$CFE_FR_DUMP_DIR/$CFE_FR_FEEDER_$ts.sql.$CFE_FR_COMPRESSOR_EXT
 
 log "Dumping tables: $CFE_FR_TABLES"
 {
-  "$CFE_BIN_DIR"/pg_dump --column-inserts --data-only $(printf ' -t %s' $CFE_FR_TABLES) cfdb
+  "$CFE_BIN_DIR"/pg_dump --serializable-deferrable --column-inserts --data-only $(printf ' -t %s' $CFE_FR_TABLES) cfdb
 
   # in case of 3.12 must copy m_inventory as if it was __inventory
   if [[ "$CFE_VERSION" =~ "3.12." ]]; then


### PR DESCRIPTION
It was found that with larger numbers of hosts and inventory data even with improvements to update_inventory() procedure in cfdb schema (change in nova) concurrency problems could still occur.

--serializable-deferrable option seems to help as well to cause pg_dump to wait for a consistent state in the database before proceeding with the dump.

Ticket: ENT-10214
Changelog: title
(cherry picked from commit e9fe60941ccaea513c7e607d64fcf6d46e4d3b40)