### PR TITLE
prepare.sh: Enabled setting release and version via env vars

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -14,17 +14,38 @@ fi
 
 cd "$(dirname $0)"
 
-echo "Running determine-version.sh ..."
-rm -f CFVERSION
-misc/determine-version.sh .CFVERSION > CFVERSION \
-    || echo "Unable to auto-detect CFEngine version, continuing"
+# Prefer EXPLICIT_VERSION variable over running the shell script,
+# this means you can set it explicitly, for example from CFEngine Build steps:
+if [ -z $EXPLICIT_VERSION ]
+then
+  echo "Running determine-version.sh ..."
+  rm -f CFVERSION
+  misc/determine-version.sh .CFVERSION > CFVERSION \
+      || echo "Unable to auto-detect CFEngine version, continuing"
+else
+  echo "Using version number from env: EXPLICIT_VERSION=$EXPLICIT_VERSION"
+  echo $EXPLICIT_VERSION > CFVERSION
+fi
 
-echo "Running determine-release.sh ..."
-rm -f CFRELEASE
-misc/determine-release.sh CFRELEASE \
-    || { echo "Unable to auto-detect CFEngine release, continuing"; echo 1 >CFRELEASE; }
+# Same for release, can be overriden explicitly from env var:
+if [ -z $EXPLICIT_RELEASE ]
+then
+  echo "Running determine-release.sh ..."
+  rm -f CFRELEASE
+  misc/determine-release.sh CFRELEASE \
+      || { echo "Unable to auto-detect CFEngine release, continuing"; echo 1 >CFRELEASE; }
+else
+  echo "Using release number from env: EXPLICIT_RELEASE=$EXPLICIT_RELEASE"
+  echo $EXPLICIT_RELEASE > CFRELEASE
+fi
 
-version=$(cat CFVERSION)
+# CFVERSION file may look like this: 3.18.4-2 and this matches a tag
+# However, for the version variable here, used to put into policy files
+# we don't want the -2 part. That part should go into the other variable
+# called release:
+version=$(cat CFVERSION | awk -F"-" '{print $1}')
+# The code above should already have parsed tags / env var and put the correct
+# thing or default in CFRELEASE, no need to do more awk here:
 release=$(cat CFRELEASE)
 prefix="/var/cfengine/"
 

--- a/prepare.sh
+++ b/prepare.sh
@@ -47,7 +47,7 @@ version=$(cat CFVERSION | awk -F"-" '{print $1}')
 # The code above should already have parsed tags / env var and put the correct
 # thing or default in CFRELEASE, no need to do more awk here:
 release=$(cat CFRELEASE)
-prefix="/var/cfengine/"
+prefix="/var/cfengine"
 
 templates=$(find . -name .git -prune -o -name '*.in' -print)
 for template in $templates; do


### PR DESCRIPTION
This makes it easier to "fix" masterfiles modules with wrong
version numbers. Can for example happen if there is something
non-standard with tags or .CFVERSION files. In such cases,
these env vars can be set from CFEngine Build steps, when
running the prepare.sh script, to force the correct version number.
