### PR TITLE
ENT-10248: Fixed suse package_inventory defaults (3.21)

### DIFF
--- a/inventory/linux.cf
+++ b/inventory/linux.cf
@@ -65,9 +65,20 @@ bundle common inventory_linux
       "has_proc_1_cmdline" expression => fileexists("/proc/1/cmdline"),
       comment => "Check if we can read /proc/1/cmdline";
 
+      "inventory_have_python_symlink" expression => fileexists("$(sys.bindir)/cfengine-selected-python");
+
     has_proc_1_cmdline::
       "systemd" expression => strcmp(lastnode($(proc_1_process), "/"), "systemd"),
       comment => "Check if (the link target of) /proc/1/cmdline is systemd";
+
+    inventory_have_python_symlink::
+      "cfe_python_for_package_modules_supported" -> { "CFE-2602", "CFE-3512", "ENT-10248" }
+        comment => concat( "Here we see if the version of python found is",
+                           " acceptable ( 3.x or 2.4 or greater ) for package",
+                           " modules. We use this guard to prevent errors",
+                           " related to missing python modules."),
+        expression => returnszero("$(sys.bindir)/cfengine-selected-python -V 2>&1 | grep ^Python | cut -d' ' -f 2 | ( IFS=. read v1 v2 v3 ; [ $v1 -ge 3 ] || [ $v1 -eq 2 -a $v2 -ge 4 ] )",
+                                  useshell);
 }
 
 bundle monitor measure_entropy_available

--- a/inventory/redhat.cf
+++ b/inventory/redhat.cf
@@ -15,12 +15,4 @@ bundle common inventory_redhat
       meta => { "inventory", "attribute_name=none" };
 
       "inventory_redhat_have_python_symlink" expression => fileexists("$(sys.bindir)/cfengine-selected-python");
-
-    inventory_redhat_have_python_symlink::
-      "cfe_yum_package_module_supported" -> { "CFE-2602", "CFE-3512" }
-        comment => "Here we see if the version of python found is acceptable for
-                    the yum package module. We use this guard to prevent errors
-                    related to missing python modules.",
-        expression => returnszero("$(sys.bindir)/cfengine-selected-python -V 2>&1 | grep ^Python | cut -d' ' -f 2 | ( IFS=. read v1 v2 v3 ; [ $v1 -ge 3 ] || [ $v1 -eq 2 -a $v2 -ge 4 ] )",
-                                  useshell);
 }

--- a/promises.cf.in
+++ b/promises.cf.in
@@ -93,13 +93,8 @@ body common control
       # modules in which you MUST provide package modules used to generate
       # software inventory reports. You can also provide global default package module
       # instead of specifying it in all package promises.
-    (debian).!disable_inventory_package_refresh::
+    (debian|redhat|centos|suse|sles|opensuse|amazon_linux).cfe_python_for_package_modules_supported.!disable_inventory_package_refresh::
           package_inventory => { $(package_module_knowledge.platform_default) };
-
-      # We only define pacakge_invetory on redhat like systems that have a
-      # python version that works with the package module.
-    (redhat|centos|suse|sles|opensuse|amazon_linux).cfe_yum_package_module_supported.!disable_inventory_package_refresh::
-        package_inventory => { $(package_module_knowledge.platform_default) };
 
     (debian|redhat|suse|sles|opensuse|amazon_linux)::
           package_module => $(package_module_knowledge.platform_default);


### PR DESCRIPTION
Before, only redhat or redhat_derived systems were having package_inventory defined. This caused no software inventory to be reported to an enterprise hub for suse systems.

Previously a check was added for the yum package module written in python that the python version must be 3.x or greater than 2.4.

In this change we have refactored to check the python version for all linux cases of package_inventory.

This check seems sufficient for apt_get, yum and zypper, the three package modules written in python.

Ticket: ENT-10248
Changelog: title
(cherry picked from commit 4ef65dec482fc4fe29cea7d0a04a1474d90eed4e)