### PR TITLE
ENT-10274: Adjusted dump.sh for multiple runs in between superhub imports

### DIFF
--- a/templates/federated_reporting/dump.sh
+++ b/templates/federated_reporting/dump.sh
@@ -82,7 +82,7 @@ if [ -n "$CFE_FR_SUPERHUB_HOSTKEYS" ]; then
   log "Linking for superhub(s): $CFE_FR_SUPERHUB_HOSTKEYS"
   for superhub_hostkey in $CFE_FR_SUPERHUB_HOSTKEYS; do
     mkdir -p "$CFE_FR_TRANSPORT_DIR/$superhub_hostkey"
-    ln "$CFE_FR_TRANSPORT_DIR/$CFE_FR_FEEDER.sql.$CFE_FR_COMPRESSOR_EXT" "$CFE_FR_TRANSPORT_DIR/$superhub_hostkey/"
+    ln -f "$CFE_FR_TRANSPORT_DIR/$CFE_FR_FEEDER.sql.$CFE_FR_COMPRESSOR_EXT" "$CFE_FR_TRANSPORT_DIR/$superhub_hostkey/"
     chown -R "$CFE_FR_FEEDER_USERNAME" "$CFE_FR_TRANSPORT_DIR/$superhub_hostkey"
   done
   log "Linking for superhub(s): DONE"


### PR DESCRIPTION
If the dump procedure happens to run either via cf-execd or via manual cf-agent -KI runs more often than the superhub attempts to import the ln command could fail.

In this case, adding -f (force) makes sense as the end result is the same and what we want: the feeder dump is linked to the proper place for each superhub.

Ticket: ENT-10274
Changelog: title