### PR TITLE
Changelog cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,7 +144,7 @@
 	  (CFE-3568)
 	- Made body classes u_kept_successful_command_results inherit_from u_results
 	  (CFE-3917)
-	- Made cmdb update ignore locks (ENT-8847)
+	- Made CMDB update ignore locks (ENT-8847)
 	- Updating host-specific CMDB data files now happens asynchronously
 	  (ENT-7357)
 	- Fixed issue with apt_get package module on Ubuntu 22 (CFE-3976)
@@ -362,7 +362,7 @@
 	  (CFE-3259)
 	- Added inventory of license owner on enterprise hubs (ENT-5337)
 	- Added paths support for opensuse (CFE-3283)
-	- Added use of services promise for FR postgresql reconfig in case of
+	- Added use of services promise for FR PostgreSQL reconfig in case of
 	  systemd (ENT-5420)
 	- Added zypper as default package manager for opensuse (CFE-3284)
 	- Admitted ::1 as a query source on Enterprise hubs (ENT-5531)
@@ -458,7 +458,7 @@
 
 3.15.0b1:
 	- Added continual checking for policy_server state (CFE-3073)
-	- Added monitoring for postgresql lock acquisition times (ENT-4753)
+	- Added monitoring for PostgreSQL lock acquisition times (ENT-4753)
 	- Added support for 'awk' filters in the FR dump-import process (ENT-4839)
 	- Added support for configuring abortclasses and abortbundleclasses via
 	  augments (ENT-4823)
@@ -533,7 +533,7 @@
 	- redhat_pure is no longer defined on Fedora hosts (CFE-3022)
 
 3.13.0:
-	- Add debian 9 to the self upgrade package map (ENT-4255)
+	- Add Debian 9 to the self upgrade package map (ENT-4255)
 	- Add 'system-uuid' to default dmidecode inventory (CFE-2925)
 	- Add inventory of AWS EC2 linux instances (CFE-2924)
 	- Add ubuntu 18 to package map for self upgrade (ENT-4118)
@@ -673,7 +673,7 @@
 	- Add AIX OOTB oslevel inventory (ENT-3117)
 	- Disable package inventory via modules on redhat like systems with unsupported python versions
 	  (CFE-2602)
-	- Make stock policy update more resiliant (CFE-2587)
+	- Make stock policy update more resilient (CFE-2587)
 	- Configure networks allowed to initiate report collection (client initiated reporting) via augments (#910)
 	  (CFE-2624)
 	- apt_get package module: Fix bug which prevented updates
@@ -690,14 +690,14 @@
 	- Add default report collection exclusion based on promise handle
 	  (ENT-3061)
 	- Fix ability to select INI region with metachars (CFE-2519)
-	- Change: Verify transfered files during policy update
+	- Change: Verify transferred files during policy update
 	- Change select_region INI_section to match end of section or end of file
 	  (CFE-2519)
-	- Add class to enable post transfer verrification during policy updates
+	- Add class to enable post transfer verification during policy updates
 	- Add: prunetree bundle to stdlib
-	  The prunetree bundle allws you to delete files and directories up to a
-	  sepcified depth older than a specified number of days
-	- Do not symlink agents to /usr/local/bin on coreos (ENT-3047)
+	  The prunetree bundle allows you to delete files and directories up to a
+	  specified depth older than a specified number of days
+	- Do not symlink agents to /usr/local/bin on CoreOS (ENT-3047)
 	- Add: Ability to set default_repository via augments
 	- Enable settig def.max_client_history_size via augments (CFE-2560)
 	- Change self upgrade now uses standalone policy (ENT-3155)
@@ -718,8 +718,8 @@
 
 3.10.0:
 	- Add: Classes body tailored for use with diff
-	- Change: Session Cookies use HTTPOnly and secure attribtues (ENT-2781)
-	- Change: Verify transfered files during policy update
+	- Change: Session Cookies use HTTPOnly and secure attributes (ENT-2781)
+	- Change: Verify transferred files during policy update
 	- Add: Inventory for system product name (model) (ENT-2780)
 	- Add: Ensure appropriate permissions for SSL files (ENT-760)
 	- Fix rare bug that would sometimes prevent redis-server from launching.
@@ -734,7 +734,7 @@
 	- Change: Enable agent component management policy on systemd hosts
 	  (CFE-2429)
 	- Add: Enterprise appliaction log dir to rotation
-	- Change: re-enable hub process maintainance
+	- Change: re-enable hub process maintenance
 	- Add: edit_line contains_literal_string to stdlib
 	- Fix: Services starting or stopping unnecessarily (CFE-2421)
 	- Allow specifying agent maxconnections via def.json (CFE-2461)
@@ -754,10 +754,10 @@
 	  (CFE-2466)
 
 3.7.0:
-	- Support for user specified overring of framework defaults without modifying
+	- Support for user specified overriding of framework defaults without modifying
 	  policy supplied by the framework itself (see example_def.json)
 	- Support for def.json class augmentation in update policy
-	- Run vacuum operation on postgresql every night as a part of maintenance.
+	- Run vacuum operation on PostgreSQL every night as a part of maintenance.
 	- Add measure_promise_time action body to lib (3.5, 3.6, 3.7, 3.8)
 	- New negative class guard `cfengine_internal_disable_agent_email` so that
 	  agent email can be easily disabled by augmenting def.json
@@ -778,7 +778,7 @@
 	- Relocate services/file_change.cf to cfe_internal/enterprise. This policy is
 	  most useful for a good OOTB experience with CFEngine Enterprise Mission
 	  Portal.
-	- Relocate service_catalogue from promsies.cf to services/main.cf. It is
+	- Relocate service_catalogue from promises.cf to services/main.cf. It is
 	  intended to be a user entry. This name change correlates with the main
 	  bundle being activated by default if there is no bundlesequence specified.
 	- Reduce benchmarks sample history to 1 day.
@@ -793,7 +793,7 @@
 	  processes after upgrade. (Redmine #7185)
 	- Remove Diff reporting on /etc/shadow (Enterprise)
 	- Update policy from promise.cf inputs. There is no reason to include the
-	  update policy into promsies.cf, update.cf is the entry for the update policy
+	  update policy into promises.cf, update.cf is the entry for the update policy
 	- _not_repaired outcome from classes_generic and scoped_classes generic (Redmine: # 7022)
 	- standard_services now restarts the service if it was not already running
 	  when using service_policy => restart with chkconfig (Redmine #7258)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,3 @@
-# Changelog
-Notable changes to the framework should be documented here
-
 3.22.0:
 	- Added inventory for policy version (ENT-9806)
 	- Added condition to runalerts service to require stamp directory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@
 
 3.21.0:
 	- Added inventory for Raspberry Pi and DeviceTree devices (ENT-8628)
- 	- Added policy to enforce proper permissions on Mission Portal ldap directory (ENT-9693)
+	- Added policy to enforce proper permissions on Mission Portal ldap directory (ENT-9693)
 	- Added check to make sure cf-execd is running after attempting self upgrade on Windows
 	- Added exception for ldap directory perms for settings.ldap.php (ENT-9697)
 	  (ENT-9573)
@@ -319,7 +319,7 @@
 
 3.17.0:
 	- Added .csv to the list of file extensions considered by default during
-          policy update (CFE-3425)
+	  policy update (CFE-3425)
 	- Added ability to extend known paths without modifying vendored policy
 	  (CFE-3426)
 	- Added apk package module support for alpinelinux (CFE-3451)
@@ -328,7 +328,7 @@
 	- Added inventory for Timezone and GMT Offset (ENT-6161)
 	- Added inventory for policy servers (ENT-6212)
 	- Added maintenance policy to update health diagnostics failures table on
-          enterprise hubs (ENT-6228)
+	  enterprise hubs (ENT-6228)
 	- Added optional handle duplicates step in federated reporting import
 	  (ENT-6035)
 	- Added replace_uncommented_substrings (ENT-6117)
@@ -422,37 +422,37 @@
 	- Fixed pkgsrc module on Solaris/NetBSD (CFE-3151)
 	- Moved zypper package module errors to the cf-agent output (CFE-3154)
 	- Added new class mpf_enable_cfengine_systemd_component_management to enable
-		component management on systemd hosts. When defined on systemd hosts policy
-		will render systemd unit files in /etc/systemd/system for managed services
-		and that all units are enabled unless explicitly disabled. When this class
-		is not defined on systemd hosts the policy will not actively mange cfengine
-		service units (no change from previous behavior) (CFE-2429)
+	  component management on systemd hosts. When defined on systemd hosts policy
+	  will render systemd unit files in /etc/systemd/system for managed services
+	  and that all units are enabled unless explicitly disabled. When this class
+	  is not defined on systemd hosts the policy will not actively mange cfengine
+	  service units (no change from previous behavior) (CFE-2429)
 	- Fixed detection of service state on FreeBSD (CFE-3167)
 	- Added known paths for true and false on linux
-		(ENT-5060)
+	  (ENT-5060)
 	- Fixed path for restorecon on redhat systems to /sbin/restorecon
 	- Added usermod to known paths for redhat systems
 	- Added policy to manage federated reporting with CFEngine Enterprise
 	- Introduced augments variable `control_hub_query_timeout` to control cf-hub query timeout.
-		 (ENT-3153)
+	  (ENT-3153)
 	- Added OOTB inventory for IPv6 addresses (sans ::1 loopback)
-		(ENT-4987)
+	  (ENT-4987)
 	- Added and transitioned to using master_software_updates shortcut in self upgrade policy
-		(ENT-4953)
+	  (ENT-4953)
 	- Added brief descriptions to bodies and bundles in cfe_internal/CFE_cfengine.cf
-		(CFE-3220)
+	  (CFE-3220)
 	- Added support for SUSE 11, 12 in standalone self upgrade (ENT-5045, ENT-5152)
 	- Changed policy triggering cleanup of __lastseenhostlogs to target only
-		3.12.x, 3.13.x and 3.14.x. From 3.15.0 on the table is absent. (ENT-5052)
+	  3.12.x, 3.13.x and 3.14.x. From 3.15.0 on the table is absent. (ENT-5052)
 	- Fixed agent disabling on systemd systems (CFE-2429, CFE-3416)
 	- Ensured directory for custom action scripts is present (ENT-5070)
 	- Excluded Enterprise federation policy parsing on incompatible versions
-		(CFE-3193)
+	  (CFE-3193)
 	- Extended watchdog for AIX (ENT-4995)
 	- Fixed cleanup of future timestamps from status table
-		(ENT-4331, ENT-4992)
+	  (ENT-4331, ENT-4992)
 	- Fixed re-spawning of cf-execd or cf-monitord after remediating duplicate concurrent processes
-		(CFE-3150)
+	  (CFE-3150)
 	- Replaced /var/cfengine with proper $(sys.*) vars (ENT-4800)
     - Fixed selection of standard_services when used from non-default namespace (ENT-5406)
 
@@ -754,48 +754,48 @@
 	  (CFE-2466)
 
 3.7.0:
- - Support for user specified overring of framework defaults without modifying
-   policy supplied by the framework itself (see example_def.json)
- - Support for def.json class augmentation in update policy
- - Run vacuum operation on postgresql every night as a part of maintenance.
- - Add measure_promise_time action body to lib (3.5, 3.6, 3.7, 3.8)
- - New negative class guard `cfengine_internal_disable_agent_email` so that
-   agent email can be easily disabled by augmenting def.json
- - Relocate def.cf to controls/VER/
- - Relocate update_def to controls/VER
- - Relocate all controls to controls/VER
- - Only load cf_hub and reports.cf on CFEngine Enterprise installs
- - Relocate acls related to report collection from bundle server access_rules
-   to controls/VER/reports.cf into bundle server report_access_rules
- - Re-organize cfe_internal splitting core from enterprise specific policies
-   and loading the appropriate inputs only when necessary
- - Moved update directory into cfe_internal as it is not generally intended to
-   be modified
- - services/autorun.cf moved to lib/VER/ as it is not generally intended to be
-   modified
- - To improve predictibility autorun bundles are activated in lexicographical
-   order
- - Relocate services/file_change.cf to cfe_internal/enterprise. This policy is
-   most useful for a good OOTB experience with CFEngine Enterprise Mission
-   Portal.
- - Relocate service_catalogue from promsies.cf to services/main.cf. It is
-   intended to be a user entry. This name change correlates with the main
-   bundle being activated by default if there is no bundlesequence specified.
- - Reduce benchmarks sample history to 1 day.
- - Update policy no longer generates a keypair if one is not found. (Redmine: #7167)
- - Relocate cfe_internal_postgresql_maintenance bundle to lib/VER/
- - Set postgresql_monitoring_maintenance only for versions 3.6.0 and 3.6.1
- - Move hub specific bundles from lib/VER/cfe_internal.cf into lib/VER/cfe_internal_hub.cf
-   and load them only if policy_server policy if set.
- - Re-organize lib/VER/stdlib.cf from lists into classic array for use with getvalues
- - inform_mode classes changed to DEBUG|DEBUG_$(this.bundle):: (Redmine: #7191)
- - Enabled limit_robot_agents in order to work around multiple cf-execd
-   processes after upgrade. (Redmine #7185)
- - Remove Diff reporting on /etc/shadow (Enterprise)
- - Update policy from promise.cf inputs. There is no reason to include the
-   update policy into promsies.cf, update.cf is the entry for the update policy
- - _not_repaired outcome from classes_generic and scoped_classes generic (Redmine: # 7022)
- - standard_services now restarts the service if it was not already running
-   when using service_policy => restart with chkconfig (Redmine #7258)
- - Fix process_result logic to match the purpose of body process_select
-   days_older_than (Redmine #3009)
+	- Support for user specified overring of framework defaults without modifying
+	  policy supplied by the framework itself (see example_def.json)
+	- Support for def.json class augmentation in update policy
+	- Run vacuum operation on postgresql every night as a part of maintenance.
+	- Add measure_promise_time action body to lib (3.5, 3.6, 3.7, 3.8)
+	- New negative class guard `cfengine_internal_disable_agent_email` so that
+	  agent email can be easily disabled by augmenting def.json
+	- Relocate def.cf to controls/VER/
+	- Relocate update_def to controls/VER
+	- Relocate all controls to controls/VER
+	- Only load cf_hub and reports.cf on CFEngine Enterprise installs
+	- Relocate acls related to report collection from bundle server access_rules
+	  to controls/VER/reports.cf into bundle server report_access_rules
+	- Re-organize cfe_internal splitting core from enterprise specific policies
+	  and loading the appropriate inputs only when necessary
+	- Moved update directory into cfe_internal as it is not generally intended to
+	  be modified
+	- services/autorun.cf moved to lib/VER/ as it is not generally intended to be
+	  modified
+	- To improve predictibility autorun bundles are activated in lexicographical
+	  order
+	- Relocate services/file_change.cf to cfe_internal/enterprise. This policy is
+	  most useful for a good OOTB experience with CFEngine Enterprise Mission
+	  Portal.
+	- Relocate service_catalogue from promsies.cf to services/main.cf. It is
+	  intended to be a user entry. This name change correlates with the main
+	  bundle being activated by default if there is no bundlesequence specified.
+	- Reduce benchmarks sample history to 1 day.
+	- Update policy no longer generates a keypair if one is not found. (Redmine: #7167)
+	- Relocate cfe_internal_postgresql_maintenance bundle to lib/VER/
+	- Set postgresql_monitoring_maintenance only for versions 3.6.0 and 3.6.1
+	- Move hub specific bundles from lib/VER/cfe_internal.cf into lib/VER/cfe_internal_hub.cf
+	  and load them only if policy_server policy if set.
+	- Re-organize lib/VER/stdlib.cf from lists into classic array for use with getvalues
+	- inform_mode classes changed to DEBUG|DEBUG_$(this.bundle):: (Redmine: #7191)
+	- Enabled limit_robot_agents in order to work around multiple cf-execd
+	  processes after upgrade. (Redmine #7185)
+	- Remove Diff reporting on /etc/shadow (Enterprise)
+	- Update policy from promise.cf inputs. There is no reason to include the
+	  update policy into promsies.cf, update.cf is the entry for the update policy
+	- _not_repaired outcome from classes_generic and scoped_classes generic (Redmine: # 7022)
+	- standard_services now restarts the service if it was not already running
+	  when using service_policy => restart with chkconfig (Redmine #7258)
+	- Fix process_result logic to match the purpose of body process_select
+	  days_older_than (Redmine #3009)


### PR DESCRIPTION
- CHANGELOG.md: Removed heading
- CHANGELOG.md: Fixed inconsistent use of tabs and spaces
- CHANGELOG.md: Fixed various typos
