### PR TITLE
GH actions: Fixed valgrind typo (valgring) (3.18)

### DIFF
--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -2,7 +2,7 @@ on:
   workflow_call
 
 jobs:
-  valgring_tests:
+  valgrind_tests:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout


### PR DESCRIPTION
(cherry picked from commit ee456bdb8e6f629f5482f77c9bbcb9a544588447)