### PR TITLE
CFE-4223: do not filter $(sys.bindir) from python path

### DIFF
--- a/cfe_internal/update/update_policy.cf
+++ b/cfe_internal/update/update_policy.cf
@@ -90,9 +90,7 @@ bundle agent cfe_internal_setup_python_symlink(symlink_path)
 {
   vars:
       "path" string => getenv("PATH", 1024);
-      "path_folders" slist => filter("$(sys.bindir)",
-                                     splitstring("$(path)", ":", 128),
-                                     false, true, 128);
+      "path_folders" slist => splitstring("$(path)", ":", 128);
 
     windows::
       "abs_path_folders" -> {"CFE-2309"}


### PR DESCRIPTION
As $(sys.bindir) might point to /usr/bin filtering it can lead to missing an available python executeable.
The orginal reason to do so was to avoid a self referential link (https://github.com/cfengine/masterfiles/commit/d37c6d1929913d8cb9b269ce02ec823ade29b440)
Since the symlink is now named `cfengine-selected-python` (https://github.com/cfengine/masterfiles/commit/a864d5cced81b37cf0f0ed9e61d392bd6ed96194) it is not matched by the regex anymore and therefor not an issue.