### PR TITLE
CFE-4221: fix cfe_autorun_inventory_aws_ec2_metadata_cache

### DIFF
--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -660,6 +660,8 @@ bundle agent cfe_autorun_inventory_aws_ec2_metadata_cache
         # depends on a dummy command which does nothing but fires only once a day
         depends_on => { "daily_dummy_job_$(v)" };
 
+      "content" data => parsejson("$(response[content])");
+
   commands:
     _stdlib_path_exists_true::
 
@@ -687,7 +689,7 @@ bundle agent cfe_autorun_inventory_aws_ec2_metadata_cache
         create => "true",
         edit_line => lines_present( "$(response[content])" ),
         edit_defaults => empty,
-        if => regcmp( ".*", "$(response[content][version])" );
+        if => regcmp( ".*", "$(content[version])" );
 
 @if minimum_version(3.11)
       # template_method inline_mustache introduced in 3.11
@@ -697,7 +699,7 @@ bundle agent cfe_autorun_inventory_aws_ec2_metadata_cache
         edit_template_string => "{{{content}}}",
         template_data => @(response),
         create =>   "true",
-        if => regcmp( ".*", "$(response[content][version])" );
+        if => regcmp( ".*", "$(content[version])" );
 @endif
 }
 


### PR DESCRIPTION
Before, the cache file was not created because the variable in the regcmp was not readable.

$(response[content][version]) was not working for me.

cfe_autorun_inventory_aws_ec2_metadata_cache writes $(response[content]) to the cache file and
in cfe_aws_ec2_metadata_from_cache readjson is used to consume the cache file.

So I added a parsejson and now it is working and the cache file get's created.