### PR TITLE
CFE-4221: Fixed cfe_autorun_inventory_aws_ec2_metadata_cache (3.21)

### DIFF
--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -660,6 +660,8 @@ bundle agent cfe_autorun_inventory_aws_ec2_metadata_cache
         # depends on a dummy command which does nothing but fires only once a day
         depends_on => { "daily_dummy_job_$(v)" };
 
+      "content" data => parsejson("$(response[content])");
+
   commands:
     _stdlib_path_exists_true::
 
@@ -687,7 +689,7 @@ bundle agent cfe_autorun_inventory_aws_ec2_metadata_cache
         create => "true",
         edit_line => lines_present( "$(response[content])" ),
         edit_defaults => empty,
-        if => regcmp( ".*", "$(response[content][version])" );
+        if => regcmp( ".*", "$(content[version])" );
 
 @if minimum_version(3.11)
       # template_method inline_mustache introduced in 3.11
@@ -697,7 +699,7 @@ bundle agent cfe_autorun_inventory_aws_ec2_metadata_cache
         edit_template_string => "{{{content}}}",
         template_data => @(response),
         create =>   "true",
-        if => regcmp( ".*", "$(response[content][version])" );
+        if => regcmp( ".*", "$(content[version])" );
 @endif
 }
 


### PR DESCRIPTION
Before, the cache file was not created because the variable in the regcmp was
not referenceable. default:cfe_autorun_inventory_aws_ec2_metadata_cache.response
is a data container. It's content key is a string, as such, it's not possible to
dereference $(response[content][version]) directly. $(response[content]) must be
extracted into a data container which can be referenced.

Changelog: Fixed cfe_autorun_inventory_aws_ec2_metadata_cache file creation
Ticket: CFE-4221

Signed-off-by: Andreas Gerler <baron@bundesbrandschatzamt.de>
(cherry picked from commit 142468448d1c2b113e7a3ff2a498102d2d600db9)