### PR TITLE
CFE-4222: Removed considerations for old versions from bundle agent cfe_autorun_inventory_aws_ec2_metadata_cache (3.18)

### DIFF
--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -670,23 +670,12 @@ bundle agent cfe_autorun_inventory_aws_ec2_metadata_cache
   files:
     ec2_instance.!(disable_inventory_aws|disable_inventory_aws_ec2_metadata)::
 
-    cfengine_3_10::
-      "$(cache)"
-        create => "true",
-        edit_line => lines_present( "$(response[content])" ),
-        edit_defaults => empty,
-        if => regcmp( ".*", "$(content[version])" );
-
-@if minimum_version(3.11)
-      # template_method inline_mustache introduced in 3.11
-    !cfengine_3_10::
       "$(cache)"
         template_method => "inline_mustache",
         edit_template_string => "{{{content}}}",
         template_data => @(response),
         create =>   "true",
         if => regcmp( ".*", "$(content[version])" );
-@endif
 }
 
 bundle agent cfe_aws_ec2_metadata_from_cache


### PR DESCRIPTION
CFEngine 3.10 and 3.11 are long out of support, no need to carry this
considerations forward.

Ticket: CFE-4222
Changelog: Title
(cherry picked from commit c42cce1215e5684a28920f2c19fbda8c6ec6793b)