### PR TITLE
CFE-4223: Stopped filtering $(sys.bindir) from dynamically determined python path (3.21)

### DIFF
--- a/cfe_internal/update/update_policy.cf
+++ b/cfe_internal/update/update_policy.cf
@@ -90,9 +90,7 @@ bundle agent cfe_internal_setup_python_symlink(symlink_path)
 {
   vars:
       "path" string => getenv("PATH", 1024);
-      "path_folders" slist => filter("$(sys.bindir)",
-                                     splitstring("$(path)", ":", 128),
-                                     false, true, 128);
+      "path_folders" slist => splitstring("$(path)", ":", 128);
 
     windows::
       "abs_path_folders" -> {"CFE-2309"}


### PR DESCRIPTION
As $(sys.bindir) might point to /usr/bin filtering it can lead to missing
an avaiable python executable. The filter was originally in place to avoid
creation of a self-referential link where /var/cfengine/bin/python would link to
itself. That symlink name has since been changed to
/var/cfengine/bin/cfengine-selected-python so it is no longer a concern

Ticket: CFE-4223
Changelog: Title
(cherry picked from commit de5e41cbc7fe39feb9c441b40253f97313625916)