### PR TITLE
ENT-10428: Removed push event handling in github actions workflow (3.18)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,6 @@ on:
   pull_request:
     branches: [ master, 3.18.x, 3.15.x ]
 
-  # run this workflow on push/merge activity
-  # pull_request activity won't detect changes
-  # in the upstream branch before we merge
-  push:
-    branches: [ master, 3.18.x, 3.15.x ]
-
-
 jobs:
   style_check:
     uses: ./.github/workflows/style_check.yml


### PR DESCRIPTION
We don't have easy visibility on the results of these events which only occur after we merge pull requests.
We use /merge refs in pull requests so running the actions again on push events (after the merge) don't really provide any additional information.

Pushes/commits to pull requests are handled by the pull_request event so no change there.

See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push

Ticket: ENT-10428
Changelog: none
(cherry picked from commit 030afdc99d8dd3fc6de18290a63095d00a929815)

 Conflicts:
	.github/workflows/ci.yml

But nothing significant in the conflict, the branches were different but we are removing the entire push event handler.