### PR TITLE
ENT-10442: Switch together-javascript-action to main to avoid dependency update work

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
         with:
           path: masterfiles
       - name: Get Togethers
-        uses: cfengine/together-javascript-action@v1.7
+        uses: cfengine/together-javascript-action@main
         id: together
         with:
           myToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -10,7 +10,7 @@ jobs:
         with:
           path: masterfiles
       - name: Get Togethers
-        uses: cfengine/together-javascript-action@v1.7
+        uses: cfengine/together-javascript-action@main
         id: together
         with:
           myToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We control the code, so no need to be "careful" here.

Ticket: ENT-10442
Changelog: none
