### PR TITLE
ENT-10481: Added ability to enable backup archives during policy update

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -1691,7 +1691,49 @@ For example:
 }
 ```
 
-**History**: Added in 3.10.1
+**Notes:**
+
+- This applies to `promises.cf`.
+
+
+**History:**
+
+- Introduced in CFEngine 3.10.1
+
+### Configure default repository for file backups during policy update
+
+By default the agent creates a backup of a file before it is edited in the same
+directory as the edited file. This happens during policy update but the backup
+files are culled by default as part of the default sync behavior.
+
+Defining the `default:mpf_update_control_agent_default_repository` class will
+cause these backups to be placed in `$(sys.workdir)/backups`. Customize the
+backup directory by setting `default:update_def.control_agent_default_backup`.
+
+For example:
+
+```
+{
+  "classes": {
+    "default:mpf_update_control_agent_default_repository": {
+      "class_expressions": [ "any::" ]
+    }
+  },
+  "variables": {
+    "default:update_def.control_agent_default_repository": {
+      "value": "/var/cfengine/policy-update-backups"
+    }
+  }
+}
+```
+
+**Notes:**
+
+- This applies to `update.cf`.
+
+**History:**
+
+- Introduced in CFEngine 3.23.0
 
 ### Configure periodic package inventory refresh interval
 

--- a/controls/update_def.cf.in
+++ b/controls/update_def.cf.in
@@ -120,6 +120,15 @@ bundle common update_def
     # enable_cfengine_enterprise_hub_ha is defined below
     # Disabled by default
 
+      # If we want to use the backup repository for update (because the class is
+      # defined) and if the location is not already configured (via Augments),
+      # set a default.
+
+      "control_agent_default_repository" -> { "ENT-10481" }
+        string => "$(sys.workdir)/backups",
+        if => and( "mpf_update_control_agent_default_repository",
+                   not( isvariable( "control_agent_default_repository" ) ) );
+
     enable_cfengine_enterprise_hub_ha::
       "standby_servers" slist => filter("$(sys.policy_hub)", "ha_def.ips", false, true, 10);
       "policy_servers" slist => { "$(sys.policy_hub)", "@(standby_servers)" };

--- a/update.cf
+++ b/update.cf
@@ -158,6 +158,12 @@ body agent control
 
         agentfacility => "$(default:update_def.control_agent_agentfacility)";
 
+    mpf_update_control_agent_default_repository::
+
+      # Location to backup files before they are edited by cfengine
+
+        default_repository => "$(update_def.control_agent_default_repository)";
+
 }
 
 #############################################################################


### PR DESCRIPTION
By default CFEngine creates backups of files when they are modified. These
backups are created by default in the same directory as the file that changed.
Files in $(sys.inputdir) are affected by this as well, but the default policy
update and sync settings result in these backups being culled since they do not
exist at the distribution point.

This change adds the capability to enable backing up files that change in
$(sys.inputdir) to a single location.

Note: A similar setting already exists that applies to promises.cf (normal agent
runs). But it seems undesirable that the same configuration applies to the
update policy, resulting in backups of all changes to policy locally on the
host, hence the introduction of this new configuration option.