### PR TITLE
ENT-10480: Added ability to extend without overriding filename patterns to copy during policy update (3.18)

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -456,7 +456,7 @@ For example:
 
 - Introduced 3.19.0, 3.18.1
 
-### Files considered for copy during policy updates
+### Override files considered for copy during policy updates
 
 The default update policy only copies files that match regular expressions
 listed in ```def.input_name_patterns```.
@@ -481,6 +481,35 @@ bootstrap the
 embedded
 [failsafe policy](https://github.com/cfengine/core/blob/master/libpromises/failsafe.cf) is
 used and it decides which files should be copied.
+
+### Extend files considered for copy during policy updates
+
+The default update policy only copies files that match regular expressions
+listed in `default:def.input_name_patterns`. The variable
+`default:update_def.input_name_patterns` allows the definition of additional
+filename patterns without having to maintain the full set of defaults.
+
+This [augments file][Augments] additionally ensures that files ending in
+`.tpl`, `.md`, and `.org` are also copied.
+
+```json
+{
+    "variables": {
+        "default:update_def.input_name_patterns_extra": {
+          "value": [ ".*\\.tpl", ".*\\.md", ".*\\.org" ],
+          "comment": "We use classic CFEngine templates suffixed with .tpl so they should be copied along with documentation."
+        }
+    }
+}
+```
+
+**Note:** This filter does **not** apply to bootstrap operations. During
+bootstrap the embedded
+[failsafe policy](https://github.com/cfengine/core/blob/master/libpromises/failsafe.cf)
+is used and it decides which files should be copied.
+
+**History:**
+  - Introduced in CFEngine 3.23.0
 
 ### Configuring component management
 

--- a/cfe_internal/update/update_policy.cf
+++ b/cfe_internal/update/update_policy.cf
@@ -534,7 +534,8 @@ body file_select u_cf3_files
 body file_select u_input_files
 # @brief Select files by extension that we should include when updating inputs
 {
-      leaf_name => { @(update_def.input_name_patterns) };
+      leaf_name => { @(update_def.input_name_patterns),
+                     @(update_def.input_name_patterns_extra) };
       file_result => "leaf_name";
 }
 

--- a/controls/update_def.cf.in
+++ b/controls/update_def.cf.in
@@ -66,6 +66,11 @@ bundle common update_def
                            not(isvariable("input_name_patterns"))),
         meta => { "defvar" };
 
+      "input_name_patterns_extra" -> { "ENT-10480" }
+        slist => {},
+        comment => "Additional filename patterns to copy during policy update.",
+        if => not( isvariable( "input_name_patterns_extra" ) );
+
       # the permissions for your masterfiles files (not dirs), which will propagate to inputs
       "masterfiles_perms_mode_not_dir" -> { "CFE-951" }
         string => "0600",


### PR DESCRIPTION
This change adds the ability to extend the default list of filename patterns to
copy during policy update. Prior to this you could only re-define the list of
filename patterns which adds a maintenance burden of tracking the upstream
defaults through policy framework upgrades.