### PR TITLE
CFE-4242: Removed jq dependency in lib/testing.cf and fixed tap output (3.21)

### DIFF
--- a/lib/testing.cf
+++ b/lib/testing.cf
@@ -198,7 +198,18 @@ bundle agent testing_generic_report(format, outfile)
     tap::
       "tap_tests" data => mergedata(tests_passed, tests_failed, tests_skipped, tests_todo);
 
-      "tap_results" data => mapdata("json_pipe", "$(def.jq) 'sort_by(.test_offset) | .[] | [(.test_offset|tostring), .tap_message ] | join(\" \") '", tap_tests);
+      "tap_results" data => parsejson(string_mustache(
+        concat(
+          '[',
+          '{{#-top-}}',
+          '{{#fail_message?}}not ok{{/fail_message?}}',
+          '"',
+          '{{^fail_message?}}ok {{/fail_message?}}',
+          '{{test_offset}} {{test_message}}',
+          '",',
+          '{{/-top-}}',
+          ']'),
+        tap_tests));
 
     tap.inform_mode::
       "tap_tests_info" string => format("%S", tap_tests);


### PR DESCRIPTION
Makes it easier to use as we don't package jq.

Output in files used to be <test number> ok|not ok <message>
which is not correct according to https://testanything.org/
It should be ok|not ok <test number> <message>

So that is fixed as well.

Before change:
tap_results: [
  "1 not ok Test one"
]

tap file output
1..1
1 not ok Test one

After change:
tap_results: [
  "not ok 1 Test one"
]

tap file output
1..1
not ok 1 Test one

Ticket: CFE-4242
Changelog: title
(cherry picked from commit a2090d52c29f978aa81893e2e04360114f047b92)
