### PR TITLE
ENT-9931: Guard against /sys/hypervisor/uuid not being readable

### DIFF
--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -617,6 +617,15 @@ bundle common cfe_autorun_inventory_aws
         scope => "namespace",
         if => isvariable("cfe_autorun_inventory_dmidecode.dmi[bios-vendor]");
 
+@if minimum_version(3.22.0)
+      "sys_hypervisor_uuid_readable" -> { "ENT-9931" }
+        expression => isreadable("/sys/hypervisor/uuid", 1);
+@else
+      "sys_hypervisor_uuid_readable" -> { "ENT-9931" }
+        expression => returnszero("${paths.cat} /sys/hypervisor/uuid 2>/dev/null", "useshell");
+@endif
+
+    !disable_inventory_aws.sys_hypervisor_uuid_readable::
       "ec2_instance" -> { "CFE-2924" }
         expression => regline( "^ec2.*", "/sys/hypervisor/uuid" ),
         scope => "namespace",


### PR DESCRIPTION
On a centos-6 PV instance in Amazon EC2 I see /sys/hypervisor/uuid exists

-r--r--r-- 1 root root 4096 Sep  1 14:30 /sys/hypervisor/uuid

but is not readable even though permissions seem to be ok.

cat: /sys/hypervisor/uuid: No such file or directory

While SELinux is enforced it doesn't seem to be involved since this is a special sysfs filesystem and there are no entries for the failure in the audit log.

Ticket: ENT-9931
Changelog: title
