### PR TITLE
ENT-10623: Marked 30_custom_promise_types/24_expireafter as flakey fail for aarch64 debian_11

### DIFF
--- a/tests/acceptance/30_custom_promise_types/24_expireafter.cf
+++ b/tests/acceptance/30_custom_promise_types/24_expireafter.cf
@@ -51,6 +51,9 @@ bundle agent test
       "description" -> { "CFE-3435" }
         string => "Test that expireafter works with custom promise types";
 
+      "test_flakey_fail"
+        string => "aarch64.debian_11",
+        meta => { "ENT-10623" };
       "test_skip_unsupported"
         string => "!supports_expireafter|!compatible_python_version";
 


### PR DESCRIPTION
Ticket: ENT-10623
Changelog: none
