### PR TITLE
ENT-9931: Redirected all output when checking /sys/hypervisor/uuid with cat (3.18)

### DIFF
--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -608,7 +608,7 @@ bundle common cfe_autorun_inventory_aws
         expression => isreadable("/sys/hypervisor/uuid", 1);
 @else
       "sys_hypervisor_uuid_readable" -> { "ENT-9931" }
-        expression => returnszero("${paths.cat} /sys/hypervisor/uuid 2>/dev/null", "useshell");
+        expression => returnszero("${paths.cat} /sys/hypervisor/uuid 2>&1 >/dev/null", "useshell");
 @endif
 
     !disable_inventory_aws.sys_hypervisor_uuid_readable::


### PR DESCRIPTION
This will only occur in pre 3.22.0 versions of CFEngine.

In 3.22.0 and after the isreadable() function is used.

Problem found with our no-noise-test showing the output of the uuid.

Ticket: ENT-9931
Changelog: none
(cherry picked from commit 38c4ff3072208bfd27cfda09dfdf0ad493408cfc)
