### PR TITLE
ENT-9931: Fixed /sys/hypervisor/uuid is readable test for pre 3.22.0 versions

### DIFF
--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -622,7 +622,7 @@ bundle common cfe_autorun_inventory_aws
         expression => isreadable("/sys/hypervisor/uuid", 1);
 @else
       "sys_hypervisor_uuid_readable" -> { "ENT-9931" }
-        expression => returnszero("${paths.cat} /sys/hypervisor/uuid 2>&1 >/dev/null", "useshell");
+        expression => returnszero("${paths.cat} /sys/hypervisor/uuid >/dev/null 2>&1", "useshell");
 @endif
 
     !disable_inventory_aws.sys_hypervisor_uuid_readable::


### PR DESCRIPTION
The 2>&1 and >/dev/null were in the wrong order.

Ticket: ENT-9931
Changelog: none
