### PR TITLE
ENT-9601: Added flakey fail for 17_packages/12_new/timed/installed-list-cached.cf test on aarch64.debian_11 (3.21)

### DIFF
--- a/tests/acceptance/17_packages/12_new/timed/installed-list-cached.cf
+++ b/tests/acceptance/17_packages/12_new/timed/installed-list-cached.cf
@@ -10,6 +10,10 @@ bundle agent init
 {
   meta:
     "test_skip_needs_work" string => "solaris|suse";
+    "test_flakey_fail"
+      string => "aarch64.debian_11",
+      meta => { "ENT-9601" };
+
   files:
     test_pass_1::
       "$(sys.workdir)/modules/packages/test_module"


### PR DESCRIPTION
Ticket: ENT-9601
Changelog: none
(cherry picked from commit 46ac75658a6130924a8dca098100c492cbfaf5ac)
