### PR TITLE
ENT-10657: Separated default self upgrade binary version from policy version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -239,13 +239,12 @@ dnl Now make the Makefiles
 dnl ######################################################################
 
 AC_CONFIG_FILES([Makefile
-                controls/update_def.cf
-                promises.cf
-                standalone_self_upgrade.cf
                 tests/Makefile
                 tests/acceptance/Makefile
                 tests/unit/Makefile
 ])
+
+AC_CONFIG_COMMANDS([render_templates],[./render-templates.sh])
 
 AC_OUTPUT
 

--- a/controls/update_def.cf.in
+++ b/controls/update_def.cf.in
@@ -7,7 +7,7 @@ bundle common update_def
   vars:
     any::
 
-      "current_version" string => "@VERSION@";
+      "current_version" string => "@DEFAULT_SELF_UPGRADE_BINARY_VERSION@";
       "current_release" string => "@RELEASE@";
 
       # MPF Controls

--- a/prepare.sh
+++ b/prepare.sh
@@ -14,45 +14,8 @@ fi
 
 cd "$(dirname $0)"
 
-# Prefer EXPLICIT_VERSION variable over running the shell script,
-# this means you can set it explicitly, for example from CFEngine Build steps:
-if [ -z $EXPLICIT_VERSION ]
-then
-  echo "Running determine-version.sh ..."
-  rm -f CFVERSION
-  misc/determine-version.sh .CFVERSION > CFVERSION \
-      || echo "Unable to auto-detect CFEngine version, continuing"
-else
-  echo "Using version number from env: EXPLICIT_VERSION=$EXPLICIT_VERSION"
-  echo $EXPLICIT_VERSION > CFVERSION
-fi
-
-# Same for release, can be overriden explicitly from env var:
-if [ -z $EXPLICIT_RELEASE ]
-then
-  echo "Running determine-release.sh ..."
-  rm -f CFRELEASE
-  misc/determine-release.sh CFRELEASE \
-      || { echo "Unable to auto-detect CFEngine release, continuing"; echo 1 >CFRELEASE; }
-else
-  echo "Using release number from env: EXPLICIT_RELEASE=$EXPLICIT_RELEASE"
-  echo $EXPLICIT_RELEASE > CFRELEASE
-fi
-
-# CFVERSION file may look like this: 3.18.4-2 and this matches a tag
-# However, for the version variable here, used to put into policy files
-# we don't want the -2 part. That part should go into the other variable
-# called release:
-version=$(cat CFVERSION | awk -F"-" '{print $1}')
-# The code above should already have parsed tags / env var and put the correct
-# thing or default in CFRELEASE, no need to do more awk here:
-release=$(cat CFRELEASE)
-prefix="/var/cfengine"
-
-templates=$(find . -name .git -prune -o -name '*.in' -print)
-for template in $templates; do
-  sed -e "s|@VERSION@|$version|g" -e "s|@RELEASE@|$release|g" -e "s|@prefix@|$prefix|g" $template > ${template%%.in}
-done
+templates=$(find . -name .git -prune -o -name '*.cf.in' -print)
+./render-templates.sh
 
 find . -name .git -prune -o -type f -print | xargs chmod u=rw,g=-,o=-
 find . -name .git -prune -o -type d -print | xargs chmod u=rwx,g=-,o=-

--- a/render-templates.sh
+++ b/render-templates.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+set -e
+
+cd "$(dirname $0)"
+
+# Prefer EXPLICIT_VERSION variable over running the shell script,
+# this means you can set it explicitly, for example from CFEngine Build steps:
+if [ -z $EXPLICIT_VERSION ]
+then
+  echo "Running determine-version.sh ..."
+  rm -f CFVERSION
+  misc/determine-version.sh .CFVERSION > CFVERSION \
+      || echo "Unable to auto-detect CFEngine version, continuing"
+else
+  echo "Using version number from env: EXPLICIT_VERSION=$EXPLICIT_VERSION"
+  echo $EXPLICIT_VERSION > CFVERSION
+fi
+
+# Same for release, can be overriden explicitly from env var:
+if [ -z $EXPLICIT_RELEASE ]
+then
+  echo "Running determine-release.sh ..."
+  rm -f CFRELEASE
+  misc/determine-release.sh CFRELEASE \
+      || { echo "Unable to auto-detect CFEngine release, continuing"; echo 1 >CFRELEASE; }
+else
+  echo "Using release number from env: EXPLICIT_RELEASE=$EXPLICIT_RELEASE"
+  echo $EXPLICIT_RELEASE > CFRELEASE
+fi
+
+# CFVERSION file may look like this: 3.18.4-2 and this matches a tag
+# However, for the version variable here, used to put into policy files
+# we don't want the -2 part. That part should go into the other variable
+# called release:
+version=$(cat CFVERSION | awk -F"-" '{print $1}')
+version_without_commit=$(cat CFVERSION | awk -F'a.' '{print $1}')
+# The code above should already have parsed tags / env var and put the correct
+# thing or default in CFRELEASE, no need to do more awk here:
+release=$(cat CFRELEASE)
+prefix="/var/cfengine"
+
+templates=$(find . -name .git -prune -o -name '*.cf.in' -print)
+for template in $templates; do
+  sed -e "s|@VERSION@|$version|g" -e "s|@RELEASE@|$release|g" -e "s|@prefix@|$prefix|g" -e "s|@DEFAULT_SELF_UPGRADE_BINARY_VERSION@|$version_without_commit|g" $template > ${template%%.in}
+done

--- a/standalone_self_upgrade.cf.in
+++ b/standalone_self_upgrade.cf.in
@@ -118,7 +118,7 @@ bundle agent cfengine_software
 
       # Default desired CFEngine software
       "pkg_name" string => ifelse( isvariable( "def.cfengine_software_pkg_name" ), $(def.cfengine_software_pkg_name), "cfengine-nova");
-      "pkg_version" string => ifelse( isvariable( "def.cfengine_software_pkg_version" ), $(def.cfengine_software_pkg_version), "@VERSION@");
+      "pkg_version" string => ifelse( isvariable( "def.cfengine_software_pkg_version" ), $(def.cfengine_software_pkg_version), "@DEFAULT_SELF_UPGRADE_BINARY_VERSION@");
       "pkg_release" string => ifelse( isvariable( "def.cfengine_software_pkg_release" ), $(def.cfengine_software_pkg_release), "@RELEASE@");
       "pkg_arch" string => ifelse( isvariable( "def.cfengine_software_pkg_arch" ), $(def.cfengine_software_pkg_arch), "x86_64");
       "package_dir" string => ifelse( isvariable( "def.cfengine_software_pkg_dir" ), $(def.cfengine_software_pkg_dir), "$(sys.flavour)_$(sys.arch)");


### PR DESCRIPTION
This improves the behavior for adding masterfiles as a module via repository
URL.

Prior to this change the policy version and default binary version to target for
self upgrade were the same. To align them you either had to explicitly set the
version which becomes a lie about the actual policy version or you would end up
targeting upgrades to a version of binaries that did not exist including the
commit sha of the masterfiles version built from.

With this change, if you simply cfbs add https://github.com/cfengine/masterfiles
or cfbs add https://github.com/cfengine/masterfiles@COMMIT at a commit that was
not a release the policy version attribute in body common control will get a
version with the commit sha and the default binary versions will come from
.CFVERION which should be the current or next release which is the intention of
the default.

TODOs:
- Is more needed for autogen.sh?
- Tidy other version alignments (update.cf/current_version).


Ticket: ENT-10657
Changelog: Title