### PR TITLE
ENT-9698: Ensured manual edits to httpd.conf are reverted (3.18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 	   (CFE-4242, CFE-4245, CFE-4246)
 	- Stopped filtering $(sys.bindir) from dynamically determined python path
 	  (CFE-4223)
+	- Ensured manual edits to httpd.conf are reverted (ENT-9698)
 
 3.18.5:
 	- Adjusted dump.sh for multiple runs in between superhub imports (ENT-10274)

--- a/cfe_internal/enterprise/mission_portal.cf
+++ b/cfe_internal/enterprise/mission_portal.cf
@@ -188,10 +188,12 @@ bundle agent mission_portal_apache_from_stage(config, staged_config)
       comment => "Without an apache config, Mission Mortal and Enterprise API
                   services will not work";
 
-    "$(config)"
+    "$(config)"  -> { "ENT-9686" }
       copy_from => local_dcp( $(staged_config) ),
+      handle => "cfapache_httpd_conf_from_staged",
       if => and( or( "apache_stop_after_new_staged_config_repaired",
-                     not( fileexists( "$(httpd_pid_file)" ) )),
+                     not( fileexists( "$(httpd_pid_file)" ) ),
+                     isnewerthan( $(config), $(staged_config) ) ),
                  returnszero("$(validate_config) > /dev/null 2>&1 ", "useshell")),
       classes => results("bundle", "mission_portal_apache_config"),
       comment => "We make sure that the deployed config is a copy of the staged
@@ -219,6 +221,14 @@ bundle agent mission_portal_apache_from_stage(config, staged_config)
         contain => in_shell,
         comment => concat( "We start apache after the new valid config is in ",
                            "place only if we have stopped apache already.");
+
+      "LD_LIBRARY_PATH=$(sys.workdir)/lib:$LD_LIBRARY_PATH $(sys.workdir)/httpd/bin/apachectl" -> { "ENT-9686" }
+        args => "restart",
+        if => and( "mission_portal_apache_config_repaired",
+                   not( "apache_stop_after_new_staged_config_repaired" ) ),
+        contain => in_shell,
+        comment => "We restart apache after the new valid config is in place";
+
   services:
     systemd_supervised::
       "cf-apache"
@@ -236,6 +246,11 @@ bundle agent mission_portal_apache_from_stage(config, staged_config)
         comment => concat( "We start apache after the new valid config is in ",
                            "place only if we have stopped apache already.");
 
+      "cf-apache" -> { "ENT-9686" }
+        service_policy => "restart",
+        if => and( "mission_portal_apache_config_repaired",
+                   not( "apache_stop_after_new_staged_config_repaired" ) ),
+        comment => "We restart apache after the new valid config is in place";
 
   reports:
     DEBUG|DEBUG_mission_portal_apache_from_stage::


### PR DESCRIPTION
This change ensures that a manual change to httpd.conf is reverted as long as
the staged template render is still valid and that httpd gets re-started as
necessary to ensure it's running with the expected configuration.

Ticket: ENT-9686

Changelog: Title
(cherry picked from commit 6ce87ef79c1b44f062f85e83db04abe90980320e)