### PR TITLE
ENT-10672: Fixed apache listening on port 80 by default

### DIFF
--- a/cfe_internal/enterprise/templates/httpd.conf.mustache
+++ b/cfe_internal/enterprise/templates/httpd.conf.mustache
@@ -5,7 +5,7 @@ ServerSignature Off
 ServerTokens ProductOnly
 ServerName {{{vars.sys.fqhost}}}
 ServerRoot "{{{vars.sys.workdir}}}/httpd"
-{{#classes.cfe_enterprise_disable_plain_http}}
+{{^classes.cfe_enterprise_disable_plain_http}}
 # ENT-10411
 Listen 80
 {{/classes.cfe_enterprise_disable_plain_http}}


### PR DESCRIPTION
The condition was inverted. It should be enabled by default unless the class to
disable it is defined.

Ticket: ENT-10672
Changelog: Title