### PR TITLE
ENT-9402: Added policy to facilitate migration of ignore_interfaces.rx from inputdir to workdir

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -597,6 +597,47 @@ This [augments file][Augments] is a way to specify that `cf-monitord` should be 
 The following settings are defined in `controls/def.cf` can be set from an
 [augments file][Augments].
 
+### Automatically migrate ignore_interfaces.rx to workdir
+
+`ignore_interfaces.rx` defines regular expressions matching network interfaces that CFEngine should ignore.
+
+Prior to `3.23.0` this file was expected to be found in
+`$(sys.inputdir)/ignore_interfaces.rx`. Beginning with `3.23.0` preference is
+given to `$(sys.workdir)/ignore_interfaces.rx` if it is found and `WARNING` is
+emitted by cfengine if the file is found only in `$(sys.inputdir)`.
+
+When the class `default:mpf_auto_migrate_ignore_interfaces_rx_to_workdir` is
+defined `$(sys.workdir)/ignore_interfaces.rx` is maintained as a copy of
+`$(sys.inputdir)/ignore_interfaces.rx`.
+
+```json
+{
+  "classes": {
+    "default:mpf_auto_migrate_ignore_interfaces_rx_to_workdir": {
+      "class_expressions": "cfengine_3_23|cfengine_3_24",
+      "comment": "Automatically migrate ignore_interfaces.rx to workdir."
+    }
+  }
+}
+```
+
+Additionally, to disable reports about the presence of
+`$(sys.inputdir)/ignore_interfaces.rx` define the class
+`default:mpf_auto_migrate_ignore_interfaces_rx_to_workdir_reports_disabled`.
+When this class is not defined, `cf-agent` will emit reports indicating it's
+presence and state in relation to `$(sys.workdir)/ignore_interfaces.rx`.
+
+```json
+{
+  "classes": {
+    "default:mpf_auto_migrate_ignore_interfaces_rx_to_workdir_reports_disabled": {
+      "class_expressions": "cfengine_3_23|cfengine_3_24",
+      "comment": "We don't want reports about legacy ignore_interfaces.rx to be emitted."
+    }
+  }
+}
+```
+
 ### dmidecode inventory
 
 When dmidecode is present, some key system attributes are inventoried. The

--- a/cfe_internal/recommendations.cf
+++ b/cfe_internal/recommendations.cf
@@ -9,6 +9,66 @@ bundle agent MPF_class_recommendations
         if => "cfengine_internal_purge_policies";
 }
 
+@if minimum_version(3.23.0)
+# The preferred location for ignore_interfaces.rx changed from
+# $(sys.inputdir)/ignore_interfaces.rx to $(sys.workdir)/ignore_interfaces.rx in
+# 3.23.0, versions lower than 3.23.0 only look for the file in inputdir and
+# messages relating to the preferred location change are irrelevant.
+
+bundle agent ignore_interfaces_rx_reccomendations
+# @brief Recommend completing migration of ignore_interfaces.rx from inputdir to workdir
+#
+# @description This bundle identifies the presence of ignore_interfaces.rx in
+# inputdir and emits messages about its presence. Additionally, the file is
+# automatically copied if the file is present in inputdir and the class
+# default:mpf_auto_migrate_ignore_interfaces_rx_to_workdir is defined (not
+# defined by default).
+{
+  meta:
+      "tags" slist => { "cfengine_recommends" };
+
+  classes:
+      "ignore_interfaces_in_workdir" -> { "ENT-9402" }
+        if => fileexists( "$(sys.workdir)/ignore_interfaces.rx" );
+
+      "ignore_interfaces_in_inputdir" -> { "ENT-9402" }
+        if => fileexists( "$(sys.inputdir)/ignore_interfaces.rx" );
+
+  files:
+    default:mpf_auto_migrate_ignore_interfaces_rx_to_workdir.ignore_interfaces_in_inputdir::
+      "$(sys.workdir)/ignore_interfaces.rx" -> { "ENT-9402" }
+        copy_from => local_dcp( "$(sys.inputdir)/ignore_interfaces.rx"),
+        comment => concat( "Excluding interfaces should be done outside of the",
+                           " policy input directory so that it's easier to",
+                           " ignore different interfaces on different hosts.");
+
+    default:cfengine_3::
+      "$(sys.inputdir)/ignore_interfaces.rx" -> { "ENT-9402" }
+        delete => tidy,
+        action => policy( "warn" ),
+        comment => concat( "Excluding interfaces should be done outside of the",
+                           " policy input directory so that it's easier to",
+                           " ignore different interfaces on different hosts.",
+                           " This file should be deleted once it's been migrated",
+                           " to sys.workdir");
+
+  reports:
+
+    ignore_interfaces_in_inputdir.!default:mpf_auto_migrate_ignore_interfaces_rx_to_workdir_reports_disabled::
+      "NOTICE: 'ignore_interfaces.rx' is present in '$(const.dollar)(sys.inputdir)' ('$(sys.inputdir)/ignore_interfaces.rx'). We recommend that it be removed and migrated to '$(const.dollar)(sys.workdir)' ('$(sys.workdir)/ignore_interfaces.rx')"
+        if => not( fileexists( "$(sys.workdir)/ignore_interfaces.rx" ) );
+
+    (ignore_interfaces_in_workdir.ignore_interfaces_in_inputdir).!default:mpf_auto_migrate_ignore_interfaces_rx_to_workdir_reports_disabled::
+      "NOTICE: 'ignore_interfaces.rx' identical in '$(const.dollar)(sys.workdir)' and '$(const.dollar)(sys.inputdir)'. We recommend removing '$(const.dollar)(sys.inputdir)/ignore_interfaces.rx'"
+        if => strcmp( readfile( "$(sys.workdir)/ignore_interfaces.rx"),
+                      readfile( "$(sys.inputdir)/ignore_interfaces.rx") );
+
+      "NOTICE: 'ignore_interfaces.rx' in '$(const.dollar)(sys.workdir)' and '$(const.dollar)(sys.inputdir)' but not identical. We recommend verifying the desired content of '$(const.dollar)(sys.workdir)/ignore_interfaces.rx', correcting it if necessary and removing '$(const.dollar)(sys.inputdir)/ignore_interfaces.rx'"
+        if => not( strcmp( readfile( "$(sys.workdir)/ignore_interfaces.rx"),
+                           readfile( "$(sys.inputdir)/ignore_interfaces.rx") ) );
+
+}
+@endif
 
 bundle agent postgresql_conf_recommendations
 # @brief Recommendations about the configuration of postgresql.conf for CFEngine Enterprise Hubs


### PR DESCRIPTION
Merge together:
- https://github.com/cfengine/core/pull/5357
- https://github.com/cfengine/documentation/pull/3102