### PR TITLE
ENT-10817: Fixed OS inventory for Amazon Linux 2

### DIFF
--- a/inventory/os.cf
+++ b/inventory/os.cf
@@ -124,5 +124,11 @@ rocky::
    "description" -> { "ENT-8292" }
      string => "Rocky $(sys.os_version_major)",
      meta => { "inventory", "attribute_name=OS" };
+
+amzn_2::
+   "description" -> { "ENT-10817" }
+     string => "Amazon 2",
+     meta => { "inventory", "attribute_name=OS" };
+
 @endif
 }


### PR DESCRIPTION
Prior to this change an Amazon Linux 2 host would have OS set to Unknown Unknown
since both sys.os_name_human and sys.os_version_major resolved to Unknown.

Ticket: ENT-10817
Changelog: Title