### PR TITLE
ENT-10816: Fixed self-upgrade for Debian and Ubuntu aarch64 clients (3.18)

### DIFF
--- a/standalone_self_upgrade.cf.in
+++ b/standalone_self_upgrade.cf.in
@@ -149,6 +149,8 @@ bundle agent cfengine_software
         comment => concat( "On debian hosts it's the CFEngine standard to use 'arm64' in",
                            "the package filename." );
 
+      "package_dir"
+        string => "$(sys.flavor)_arm_64";
 
     (redhat|centos|suse|sles).32_bit::
       "pkg_arch"


### PR DESCRIPTION
CFEngine uses arm_64 instead of aarch64 to identify 64 bit arm builds. Without
this change arm64 client's look for their packages in the wrong directory.

Ticket: ENT-10816
Changelog: Title
(cherry picked from commit 8d3a327510ac2cfd7bdf2b2e19f6f54f128dc658)