### PR TITLE
ENT-10820: Added self upgrade support for Amazon Linux 2 (3.21)

### DIFF
--- a/standalone_self_upgrade.cf.in
+++ b/standalone_self_upgrade.cf.in
@@ -135,6 +135,11 @@ bundle agent cfengine_software
     solaris|solarisx86::
       "pkg_name" string => "cfengine-nova";
 
+    amzn_2::
+
+      "package_dir"
+        string => "amazon_2_$(pkg_arch)";
+
     (debian|ubuntu).64_bit::
 
       "pkg_arch"
@@ -523,11 +528,12 @@ bundle common cfengine_package_names
       "pkg[SuSE_15_x86_64]" string => "$(pkg[redhat_6_x86_64])";
       "pkg[opensuse_leap_15_x86_64]" string => "$(pkg[redhat_6_x86_64])";
 
-      # Redhat/Centos/Oracle/Rocky 7 use the same package
+      # Redhat/Centos/Oracle/Rocky 7/Amazon 2 use the same package
       "pkg[redhat_7_x86_64]" string => "$(pkg_name)-$(pkg_version)-$(pkg_release).el7.x86_64.rpm";
       "pkg[centos_7_x86_64]" string => "$(pkg[redhat_7_x86_64])";
       "pkg[oracle_7_x86_64]" string => "$(pkg[redhat_7_x86_64])";
       "pkg[rocky_7_x86_64]" string => "$(pkg[redhat_7_x86_64])";
+      "pkg[amazon_2_x86_64]" string => "$(pkg[redhat_7_x86_64])";
 
       # Redhat/Centos/Oracle/Rocky 8 use the same package
       "pkg[redhat_8_x86_64]" string => "$(pkg_name)-$(pkg_version)-$(pkg_release).el8.x86_64.rpm";
@@ -621,11 +627,12 @@ bundle agent cfengine_master_software_content
       "dir[centos_6_x86_64]" string => "$(dir[redhat_6_x86_64])";
       "dir[oracle_6_x86_64]" string => "$(dir[redhat_6_x86_64])";
 
-      # Redhat/Centos/Oracle/Rocky 7 use the same package
+      # Redhat/Centos/Oracle/Rocky 7/Amazon 2 use the same package
       "dir[redhat_7_x86_64]" string => "agent_rhel7_x86_64";
       "dir[centos_7_x86_64]" string => "$(dir[redhat_7_x86_64])";
       "dir[oracle_7_x86_64]" string => "$(dir[redhat_7_x86_64])";
       "dir[rocky_7_x86_64]" string => "$(dir[redhat_7_x86_64])";
+      "dir[amazon_2_x86_64]" string => "$(dir[redhat_7_x86_64])";
 
       # Redhat/Centos/Oracle/Rocky 8 use the same package
       "dir[redhat_8_x86_64]" string => "agent_rhel8_x86_64";


### PR DESCRIPTION
Prior to this change two things did not work:
- The hub would not download the el7 package to an amazon linux 2 directory
- Clients tried to get the package from AmazonLinux_<arch>

With this change:
- The hub downloads the el7 package to the amazon_2_<arch> directory
- The client looks for the package in amazon_2_<arch>.

Ticket: ENT-10820
Changelog: Title
(cherry picked from commit 7d93ed1851c2da5a1aa922ecbf5e34cdcf86edf9)