### PR TITLE
[3.18.x] Aligned systemd service templates with core

### DIFF
--- a/templates/cf-apache.service.mustache
+++ b/templates/cf-apache.service.mustache
@@ -17,4 +17,3 @@ UMask=0177
 
 [Install]
 WantedBy=multi-user.target
-WantedBy=cfengine3.service

--- a/templates/cf-execd.service.mustache
+++ b/templates/cf-execd.service.mustache
@@ -14,4 +14,3 @@ KillMode=process
 
 [Install]
 WantedBy=multi-user.target
-WantedBy=cfengine3.service

--- a/templates/cf-hub.service.mustache
+++ b/templates/cf-hub.service.mustache
@@ -17,4 +17,3 @@ RestartSec=10
 
 [Install]
 WantedBy=multi-user.target
-WantedBy=cfengine3.service

--- a/templates/cf-monitord.service.mustache
+++ b/templates/cf-monitord.service.mustache
@@ -13,4 +13,3 @@ RestartSec=10
 
 [Install]
 WantedBy=multi-user.target
-WantedBy=cfengine3.service

--- a/templates/cf-postgres.service.mustache
+++ b/templates/cf-postgres.service.mustache
@@ -34,4 +34,3 @@ ExecReload={{{vars.sys.bindir}}}/pg_ctl -w -D {{{vars.sys.statedir}}}/pg/data -l
 
 [Install]
 WantedBy=multi-user.target
-WantedBy=cfengine3.service

--- a/templates/cf-runalerts.service.mustache
+++ b/templates/cf-runalerts.service.mustache
@@ -20,5 +20,4 @@ RestartSec=10
 
 [Install]
 WantedBy=multi-user.target
-WantedBy=cfengine3.service
 WantedBy=cf-postgres.service

--- a/templates/cf-serverd.service.mustache
+++ b/templates/cf-serverd.service.mustache
@@ -15,4 +15,3 @@ RestartSec=10
 
 [Install]
 WantedBy=network-online.target
-WantedBy=cfengine3.service


### PR DESCRIPTION
WantedBy=cfengine3.service was removed from systemd service templates for individual components. It was un-necessary as cfengine3.service already wants the individual services.

https://github.com/cfengine/core/pull/5362

Ticket: CFE-3982
Changelog: commit
(cherry picked from commit 4e490e71683a81d8aae8bccb8b16d1b183a4bdd2)