### PR TITLE
ENT-9402: Refactored ignore_interfaces.rx policy for backport

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -614,18 +614,18 @@ The following settings are defined in `controls/def.cf` can be set from an
 
 Prior to `3.23.0` this file was expected to be found in
 `$(sys.inputdir)/ignore_interfaces.rx`. Beginning with `3.23.0` preference is
-given to `$(sys.workdir)/ignore_interfaces.rx` if it is found and `WARNING` is
+given to `$(sys.workdir)/ignore_interfaces.rx` if it is found. A `WARNING` is
 emitted by cfengine if the file is found only in `$(sys.inputdir)`.
 
 When the class `default:mpf_auto_migrate_ignore_interfaces_rx_to_workdir` is
-defined `$(sys.workdir)/ignore_interfaces.rx` is maintained as a copy of
-`$(sys.inputdir)/ignore_interfaces.rx`.
+defined (not defined by default) `$(sys.workdir)/ignore_interfaces.rx` is
+maintained as a copy of `$(sys.inputdir)/ignore_interfaces.rx`.
 
 ```json
 {
   "classes": {
     "default:mpf_auto_migrate_ignore_interfaces_rx_to_workdir": {
-      "class_expressions": "cfengine_3_23|cfengine_3_24",
+      "class_expressions": [ "cfengine_3_23|cfengine_3_24::" ],
       "comment": "Automatically migrate ignore_interfaces.rx to workdir."
     }
   }
@@ -642,12 +642,16 @@ presence and state in relation to `$(sys.workdir)/ignore_interfaces.rx`.
 {
   "classes": {
     "default:mpf_auto_migrate_ignore_interfaces_rx_to_workdir_reports_disabled": {
-      "class_expressions": "cfengine_3_23|cfengine_3_24",
+      "class_expressions": [ "cfengine_3_23|cfengine_3_24::" ],
       "comment": "We don't want reports about legacy ignore_interfaces.rx to be emitted."
     }
   }
 }
 ```
+
+**History:**
+
+- Introduced `default:mpf_auto_migrate_ignore_interfaces_rx_to_workdir` and `default:mpf_auto_migrate_ignore_interfaces_rx_to_workdir_reports_disabled` in 3.23.0, 3.21.4
 
 ### dmidecode inventory
 

--- a/cfe_internal/CFE_cfengine.cf
+++ b/cfe_internal/CFE_cfengine.cf
@@ -59,7 +59,7 @@ bundle agent cfe_internal_management
       "bundles" slist => getindices(policy);
 
       "recommendation_bundles"
-        slist => sort( bundlesmatching( "cfengine_recommendations" ), lex);
+        slist => sort( bundlesmatching( ".*", "cfengine_recommends" ), lex);
 
   methods:
 

--- a/cfe_internal/recommendations.cf
+++ b/cfe_internal/recommendations.cf
@@ -9,12 +9,10 @@ bundle agent MPF_class_recommendations
         if => "cfengine_internal_purge_policies";
 }
 
-@if minimum_version(3.23.0)
+@if minimum_version(3.21.4)
 # The preferred location for ignore_interfaces.rx changed from
 # $(sys.inputdir)/ignore_interfaces.rx to $(sys.workdir)/ignore_interfaces.rx in
-# 3.23.0, versions lower than 3.23.0 only look for the file in inputdir and
-# messages relating to the preferred location change are irrelevant.
-
+# 3.23.0 and 3.21.4. Versions lower than 3.23.0 and 3.21.4 only look for the file in inputdir.
 bundle agent ignore_interfaces_rx_reccomendations
 # @brief Recommend completing migration of ignore_interfaces.rx from inputdir to workdir
 #
@@ -28,6 +26,13 @@ bundle agent ignore_interfaces_rx_reccomendations
       "tags" slist => { "cfengine_recommends" };
 
   classes:
+      "ignore_interfaces_in_workdir_supported"
+        and => { cf_version_minimum( "3.21.4" ),
+                 not( cf_version_at( "3.22" ) ) },
+        comment => concat( "CFEngine doesn't look for ignore_interfaces.rx in",
+                           " workdir except for versions greater than or equal",
+                           "to 3.21.4." );
+
       "ignore_interfaces_in_workdir" -> { "ENT-9402" }
         if => fileexists( "$(sys.workdir)/ignore_interfaces.rx" );
 
@@ -35,14 +40,15 @@ bundle agent ignore_interfaces_rx_reccomendations
         if => fileexists( "$(sys.inputdir)/ignore_interfaces.rx" );
 
   files:
-    default:mpf_auto_migrate_ignore_interfaces_rx_to_workdir.ignore_interfaces_in_inputdir::
+    ignore_interfaces_in_workdir_supported.default:mpf_auto_migrate_ignore_interfaces_rx_to_workdir.ignore_interfaces_in_inputdir::
       "$(sys.workdir)/ignore_interfaces.rx" -> { "ENT-9402" }
         copy_from => local_dcp( "$(sys.inputdir)/ignore_interfaces.rx"),
         comment => concat( "Excluding interfaces should be done outside of the",
                            " policy input directory so that it's easier to",
                            " ignore different interfaces on different hosts.");
 
-    default:cfengine_3::
+    ignore_interfaces_in_workdir_supported::
+
       "$(sys.inputdir)/ignore_interfaces.rx" -> { "ENT-9402" }
         delete => tidy,
         action => policy( "warn" ),
@@ -54,11 +60,11 @@ bundle agent ignore_interfaces_rx_reccomendations
 
   reports:
 
-    ignore_interfaces_in_inputdir.!default:mpf_auto_migrate_ignore_interfaces_rx_to_workdir_reports_disabled::
+    ignore_interfaces_in_workdir_supported.(ignore_interfaces_in_inputdir.!default:mpf_auto_migrate_ignore_interfaces_rx_to_workdir_reports_disabled)::
       "NOTICE: 'ignore_interfaces.rx' is present in '$(const.dollar)(sys.inputdir)' ('$(sys.inputdir)/ignore_interfaces.rx'). We recommend that it be removed and migrated to '$(const.dollar)(sys.workdir)' ('$(sys.workdir)/ignore_interfaces.rx')"
         if => not( fileexists( "$(sys.workdir)/ignore_interfaces.rx" ) );
 
-    (ignore_interfaces_in_workdir.ignore_interfaces_in_inputdir).!default:mpf_auto_migrate_ignore_interfaces_rx_to_workdir_reports_disabled::
+    ignore_interfaces_in_workdir_supported.(ignore_interfaces_in_workdir.ignore_interfaces_in_inputdir).!default:mpf_auto_migrate_ignore_interfaces_rx_to_workdir_reports_disabled::
       "NOTICE: 'ignore_interfaces.rx' identical in '$(const.dollar)(sys.workdir)' and '$(const.dollar)(sys.inputdir)'. We recommend removing '$(const.dollar)(sys.inputdir)/ignore_interfaces.rx'"
         if => strcmp( readfile( "$(sys.workdir)/ignore_interfaces.rx"),
                       readfile( "$(sys.inputdir)/ignore_interfaces.rx") );


### PR DESCRIPTION
This change restricts the policy from running for CFEngine versions where
ignore_interfaces.rx can not be read from WORKDIR.

Ticket: ENT-9402
Changelog: None