### PR TITLE
ENT-10917: Fixed history for default:def.cfe_enterprise_mission_portal_apache_sslprotocol (3.18)

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -1543,7 +1543,7 @@ This directive can be used to control which versions of the SSL/TLS protocol wil
 
 **History:**
 
-- Added in CFEngine 3.23.0, 3.22.3, 3.18.6
+* Added in CFEngine 3.23.0, 3.21.3, 3.18.6
 
 ### Bundlesequence
 


### PR DESCRIPTION
This removes the reference for 3.22.3 which never existed and sets 3.21.3 appropriately.

Ticket: ENT-10917
Changelog: None
(cherry picked from commit 0e537cfe323d516f2b1707c39580b030096cf622)