### PR TITLE
ENT-10918: Fixed support for automatically installing semanage on el9 for federated reporting

### DIFF
--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -183,7 +183,7 @@ bundle agent distributed_cleanup_dependencies
 # if cfengine_mp_fr_enable_distributed_cleanup class is defined
 {
   vars:
-    debian|ubuntu|redhat_8|centos_8::
+    debian|ubuntu|redhat_8|centos_8|redhat_9|rocky_9::
       "packages" slist => { "python3", "python3-urllib3" };
 
     centos_7::
@@ -242,7 +242,7 @@ bundle agent semanage_installed
                   warn or fix based.";
     debian_6|debian_7|debian_8|ubuntu_12|ubuntu_14|ubuntu_16|rhel_5::
       "semanage_package" string => "policycoreutils";
-    debian_9|debian_10|ubuntu_18|redhat_8|centos_8::
+    debian_9|debian_10|ubuntu_18|redhat_8|centos_8|redhat_9|rocky_9::
       "semanage_package" string => "policycoreutils-python-utils";
     redhat_6|centos_6|redhat_7|centos_7::
       "semanage_package" string => "policycoreutils-python";


### PR DESCRIPTION
This change let's rocky 9 and redhat 9 hosts know which package contains
semanage so that it can be automatically installed for managing permissions in
federated reporting.

Ticket: ENT-10918
Changelog: Title