### PR TITLE
ENT-10904: Added --quiet to psql commands where needed in federated reporting scripts (3.21)

### DIFF
--- a/templates/federated_reporting/dump.sh
+++ b/templates/federated_reporting/dump.sh
@@ -60,7 +60,7 @@ log "Dumping tables: $CFE_FR_TABLES"
   # in case of 3.12 must copy m_inventory as if it was __inventory
   if [[ "$CFE_VERSION" =~ "3.12." ]]; then
     # pg_dump will not dump the contents of views so we must run the following SQL:
-    "$CFE_BIN_DIR"/psql cfdb -c "COPY (SELECT * FROM m_inventory WHERE values IS NOT NULL) TO STDOUT CSV QUOTE '''' FORCE QUOTE *" |
+    "$CFE_BIN_DIR"/psql cfdb --quiet -c "COPY (SELECT * FROM m_inventory WHERE values IS NOT NULL) TO STDOUT CSV QUOTE '''' FORCE QUOTE *" |
       sed -e 's.^.INSERT INTO __inventory (hostkey, values) VALUES (.' \
           -e 's.$.);.'
   fi

--- a/templates/federated_reporting/import.sh
+++ b/templates/federated_reporting/import.sh
@@ -52,7 +52,7 @@ declare -a hostkeys
 for file in $dump_files; do
   hostkey=$(basename "$file" | cut -d. -f1)
   hostkeys+=($hostkey)
-  if [ -z $("$CFE_BIN_DIR"/psql --csv --tuples-only -U cfapache -d cfdb -c "SELECT hub_id FROM __hubs WHERE hostkey = '$hostkey';") ]; then
+  if [ -z $("$CFE_BIN_DIR"/psql --quiet --csv --tuples-only -U cfapache -d cfdb -c "SELECT hub_id FROM __hubs WHERE hostkey = '$hostkey';") ]; then
     log "No feeder with hostkey $hostkey found in cfdb.__hubs, skipping the dump file $file, consider deleting this file or re-adding the feeder to superhub"
     dump_files=$(echo "$dump_files" | sed "s,\s\?$file,," | xargs)
   else


### PR DESCRIPTION
If an environment has SET commands in psqlrc or ~/.psqlrc then output can include the SET response and break parsing.

Ticket: ENT-10904
Changelog: title
(cherry picked from commit 5cbe98375fed6e9d5d3cfaaff322ae5ed027c54d)
