### PR TITLE
ENT-10951: Automatically include $(sys.policy_hub) in acl, allowconnects, allowallconnects

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -822,19 +822,29 @@ control` are stripped before sending. The MPF will use the value of
 
 ### acl
 
-`def.acl` is a list of of network ranges that should be allowed to connect to cf-serverd. It is also used in the default access promises to allow hosts access to policy and modules that should be distributed.
+`def.acl` is a list of of network ranges that should be allowed to connect to `cf-serverd`. It is also used in the default access promises to allow hosts access to policy and modules that should be distributed.
 
 Here is an example setting the acl from augments:
 
-```
+```json
 {
-  "vars": {
-    "acl": [ "24.124.0.0/16", "192.168.33.0/24" ]
+  "variables": {
+    "default:def.acl": {
+      "value": [ "24.124.0.0/16", "192.168.33.0/24" ]
+    }
   }
 }
 ```
 
+**Notes:**
+
+* Unless the class `default:disable_always_accept_policy_server_acl` is defined the value of `$(sys.policy)` server is automatically added to this producing `def.acl_derived` which is used by the default access promises.
+
 **See Also:** [Configure networks allowed to make collect calls (client initiated reporting)](#configure-networks-allowed-to-make-collect_calls-client-initiated-reporting)
+
+**History:**
+
+* Automatic inclusion of `$(sys.policy_hub)` added in 3.23.0
 
 ### Configure hosts that may connect to cf-serverd
 
@@ -849,7 +859,7 @@ For example, this configuration allows any IPv4 client to connect to `cf-serverd
 ```json
 {
   "variables": {
-    "default:def.allowconnects": {
+    "default:def.control_server_allowconnects": {
       "value": [
         "0.0.0.0/0"
       ]
@@ -858,9 +868,15 @@ For example, this configuration allows any IPv4 client to connect to `cf-serverd
 }
 ```
 
+**Notes:**
+
+* The value of `$(sys.policy)` server is automatically included in the value used by `allowconnects` in `body server control` unless the class `default:disable_always_accept_policy_server_allowconnects` is defined.
+* Alternatively define `default:disable_always_accept_policy_server`  to disable this behavior for `allowconnects`, `allowallconnects` and `def.acl` concurrently.
+
 **History:**
 
 * Added in 3.22.0
+* Automatic inclusion of `$(sys.policy_hub)` added in 3.23.0
 
 ### Configure hosts that may make multiple concurrent connections to cf-serverd
 
@@ -876,7 +892,7 @@ For example, this configuration allows any IPv4 client from the `192.168.56.0/24
 ```json
 {
   "variables": {
-    "default:def.allowallconnects": {
+    "default:def.control_server_allowallconnects": {
       "value": [
         "192.168.56.0/24"
       ]
@@ -885,9 +901,15 @@ For example, this configuration allows any IPv4 client from the `192.168.56.0/24
 }
 ```
 
+**Notes:**
+
+* The value of `$(sys.policy_hub)` is automatically included in the value used by `allowallconnects` in `body server control` unless the class `default:disable_always_accept_policy_server_allowallconnects` is defined.
+* Alternatively define `default:disable_always_accept_policy_server` to disable this behavior for `allowconnects`, `allowallconnects` and `def.acl` concurrently.
+
 **History:**
 
 * Added in 3.22.0
+* Automatic inclusion of `$(sys.policy_hub)` added in 3.23.0
 
 ### ignore_missing_bundles
 

--- a/controls/cf_serverd.cf
+++ b/controls/cf_serverd.cf
@@ -10,11 +10,11 @@ body server control
 # @brief Control attributes for cf-serverd
 {
       # List of hosts that may connect (change the ACL in def.cf)
-      allowconnects         => { @(default:def.control_server_allowconnects) };
+      allowconnects         => { @(default:def.control_server_allowconnects_derived) };
 
       # Out of them, which ones should be allowed to have more than one
       # connection established at the same time?
-      allowallconnects      => { @(default:def.control_server_allowallconnects) };
+      allowallconnects      => { @(default:def.control_server_allowallconnects_derived) };
 
       # Out of the hosts in allowconnects, trust new keys only from the
       # following ones.  SEE COMMENTS IN def.cf
@@ -103,7 +103,7 @@ bundle server mpf_default_access_rules()
       shortcut => "masterfiles",
       comment => "Grant access to the policy updates",
       if => isdir( "$(def.dir_masterfiles)/" ),
-      admit => { @(def.acl) };
+      admit => { @(def.acl_derived) };
 
       "$(def.dir_masterfiles)/.no-distrib" -> { "ENT-8079" }
       handle => "prevent_distribution_of_top_level_dot_no_distrib",
@@ -113,35 +113,35 @@ bundle server mpf_default_access_rules()
       handle => "server_access_grant_access_binary",
       comment => "Grant access to binary for cf-runagent",
       if => isdir( "$(def.dir_bin)/" ),
-      admit => { @(def.acl) };
+      admit => { @(def.acl_derived) };
 
       "$(def.dir_data)/"
       handle => "server_access_grant_access_data",
       shortcut => "data",
       comment => "Grant access to data directory",
       if => isdir( "$(def.dir_data)/" ),
-      admit => { @(def.acl) };
+      admit => { @(def.acl_derived) };
 
       "$(def.dir_modules)/"
       handle => "server_access_grant_access_modules",
       shortcut => "modules",
       comment => "Grant access to modules directory",
       if => isdir( "$(def.dir_modules)/" ),
-      admit => { @(def.acl) };
+      admit => { @(def.acl_derived) };
 
       # TODO: Remove after 3.15 is no longer supported (December 18th 2022)
       "$(def.dir_plugins)/" -> { "CFE-3618" }
       handle => "server_access_grant_access_plugins",
       comment => "Grant access to plugins directory",
       if => isdir( "$(def.dir_plugins)/" ),
-      admit => { @(def.acl) };
+      admit => { @(def.acl_derived) };
 
       "$(def.dir_templates)/"
       handle => "server_access_grant_access_templates",
       shortcut => "templates",
       comment => "Grant access to templates directory",
       if => isdir( "$(def.dir_templates)/" ),
-      admit => { @(def.acl) };
+      admit => { @(def.acl_derived) };
 
     policy_server|am_policy_hub::
 
@@ -150,7 +150,7 @@ bundle server mpf_default_access_rules()
         shortcut => "master_software_updates",
         comment => "Grant access for hosts to download cfengine packages for self upgrade",
         if => isdir( "$(sys.workdir)/master_software_updates" ),
-        admit => { @(def.acl) };
+        admit => { @(def.acl_derived) };
 
       "$(sys.statedir)/cf_version.txt" -> { "ENT-10664" }
         handle => "server_access_grant_access_state_cf_version",
@@ -158,7 +158,7 @@ bundle server mpf_default_access_rules()
         comment => concat( "We want remote hosts to default their target binary",
                            " version to that of the hubs binary version, so we",
                            " need to share this state with remote clients." ),
-        admit => { @(def.acl) };
+        admit => { @(def.acl_derived) };
 
 
     enterprise_edition.policy_server::
@@ -230,7 +230,7 @@ bundle server mpf_default_access_rules()
       "$(ha_def.master_hub_location)"
       handle => "server_access_grant_access_policy_server_dat",
       comment => "Grant access to policy_server.dat",
-      admit => { @(def.acl) };
+      admit => { @(def.acl_derived) };
 
       # Hubs keys working in HA configuration are stored in ppkeys_hubs directory.
       # In order to perform failover while active hub is down clients needs to
@@ -240,7 +240,7 @@ bundle server mpf_default_access_rules()
       handle => "server_access_grant_access_to_clients",
       comment => "Grant access to hubs' keys to clients",
       if => isdir("$(ha_def.hubs_keys_location)/"),
-      admit => { @(def.acl) };
+      admit => { @(def.acl_derived) };
 
     windows::
       "c:\program files\cfengine\bin\cf-agent.exe"

--- a/controls/def.cf
+++ b/controls/def.cf
@@ -79,6 +79,22 @@ bundle common def
         if => and(not(isvariable("override_data_acl")), not(isvariable("acl"))),
         meta => { "defvar" };
 
+    !disable_always_accept_policy_server_acl::
+      "acl_derived" -> { "ENT-10951" }
+        slist => {
+                   @(def.acl),
+                   "$(sys.policy_hub)"
+        },
+        comment => "Define an acl for the machines to be granted accesses";
+
+    disable_always_accept_policy_server_acl::
+      "acl_derived" -> { "ENT-10951" }
+        slist => {
+                   @(def.acl)
+        },
+        comment => "Define an acl for the machines to be granted accesses";
+
+    any::
 
       "control_server_allowconnects" -> { "ENT-10212" }
         slist => { "127.0.0.1" , "::1", @(def.acl) },
@@ -87,12 +103,46 @@ bundle common def
                            " allowconnects in body server control if not",
                            " already specified" );
 
+    !disable_always_accept_policy_server_allowconnects::
+      "control_server_allowconnects_derived" -> { "ENT-10951" }
+        slist => { "$(sys.policy_hub)", @(def.control_server_allowconnects) },
+        comment => concat( "We want to define the default setting for",
+                           " allowconnects in body server control if not",
+                           " already specified. Since not explicitly excluded",
+                           " we want the policy server itself to be allowed." );
+
+    disable_always_accept_policy_server_allowconnects::
+      "control_server_allowconnects_derived" -> { "ENT-10951" }
+        slist => { @(def.control_server_allowconnects) },
+        comment => concat( "We want to define the default setting for",
+                           " allowconnects in body server control if not",
+                           " already specified. Since explicitly excluded",
+                           " we don't automatically include the policy server itself." );
+
+    any::
+
       "control_server_allowallconnects" -> { "ENT-10212" }
         slist => { "127.0.0.1" , "::1", @(def.acl) },
         if => not( isvariable( "control_server_allowallconnects" ) ),
         comment => concat( "We want to define the default setting for",
                            " allowallconnects in body server control if not",
                            " already specified" );
+
+    !disable_always_accept_policy_server_allowallconnects::
+      "control_server_allowallconnects_derived" -> { "ENT-10951" }
+        slist => { @(def.control_server_allowallconnects), "$(sys.policy_hub)" },
+        comment => concat( "We want to define the default setting for",
+                           " allowallconnects in body server control if not",
+                           " already specified" );
+
+    disable_always_accept_policy_server_allowallconnects::
+      "control_server_allowallconnects_derived" -> { "ENT-10951" }
+        slist => { @(def.control_server_allowallconnects) },
+        comment => concat( "We want to define the default setting for",
+                           " allowallconnects in body server control if not",
+                           " already specified" );
+
+    any::
 
       # Out of the hosts in allowconnects, trust new keys only from the
       # following ones.  This is open by default for bootstrapping.
@@ -280,6 +330,15 @@ bundle common def
       # typically the last promise wins.
 
   classes:
+
+      "disable_always_accept_policy_server_acl"  -> { "ENT-10951" }
+        expression => "disable_always_accept_policy_server";
+
+      "disable_always_accept_policy_server_allowconnects" -> { "ENT-10951" }
+        expression => "disable_always_accept_policy_server";
+
+      "disable_always_accept_policy_server_allowallconnects" -> { "ENT-10951" }
+        expression => "disable_always_accept_policy_server";
 
       "control_agent_agentfacility_configured" -> { "ENT-10209" }
         expression => regcmp( "LOG_(USER|DAEMON|LOCAL[0-7])",
@@ -572,7 +631,7 @@ bundle common def
 
 
       "mpf_access_rules_collect_calls_admit_ips"
-        slist => { @(def.acl) },
+        slist => { @(def.acl_derived) },
         unless => isvariable(mpf_access_rules_collect_calls_admit_ips);
 
     enterprise_edition.client_initiated_reporting_enabled::


### PR DESCRIPTION
This change more specifically includes the hubs ip address in the default acl, allowconnects and allowallconnects.

sys.policy_hub/16 remains the default for def.acl, but new _derived suffixed variables which are used in the final configuration have been added.

Previously, setting acl, allowconnects, or allowallconnects and omitting the policy server would prevent the policy server from accessing it's own resources. Recovery from this mistake was tedious. Now, the policy server ip address is joined with the configured values for acl, allowconnects, and allowallconnects in the new _derived suffixed variables so that the policy servers IP is always included unless a class disabling the behavior is defined.