### PR TITLE
ENT-10960: Adjusted distributed cleanup dependencies policy to only superhub where it is needed

### DIFF
--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -181,6 +181,8 @@ bundle agent config
 bundle agent distributed_cleanup_dependencies
 # @brief warn if python3 and urllib3 required dependencies are not installed
 # if cfengine_mp_fr_enable_distributed_cleanup class is defined
+# Note: these requirements are only needed on superhub to run the distributed cleanup python script.
+#       on feeders only the shell script is run so no python dependencies needed there.
 {
   vars:
     debian|ubuntu|redhat_8|centos_8|redhat_9|rocky_9::
@@ -838,6 +840,7 @@ bundle agent entry
     am_policy_hub.default:cfengine_mp_fr_enable_distributed_cleanup::
       "Distributed Cleanup Dependencies"
         handle => "distributed_cleanup_dependencies",
+        if => "enabled.am_on.am_superhub.!am_paused",
         usebundle => "distributed_cleanup_dependencies";
       "Distributed Cleanup Setup"
         handle => "distributed_cleanup_setup",

--- a/templates/federated_reporting/transfer_distributed_cleanup_items.sh
+++ b/templates/federated_reporting/transfer_distributed_cleanup_items.sh
@@ -6,6 +6,7 @@
 #
 
 set -e
+set -x
 
 # make sure a failure in any part of a pipe sequence is a failure
 set -o pipefail


### PR DESCRIPTION
python3 and urllib3 module are only needed on superhub

Ticket: ENT-10960
Changelog: none

together
https://github.com/cfengine/system-testing/pull/514
https://github.com/cfengine/masterfiles/pull/2786
