### PR TITLE
ENT-10959: Improved federation policy handling of cftransport selinux configuration

### DIFF
--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -181,6 +181,8 @@ bundle agent config
 bundle agent distributed_cleanup_dependencies
 # @brief warn if python3 and urllib3 required dependencies are not installed
 # if cfengine_mp_fr_enable_distributed_cleanup class is defined
+# Note: these requirements are only needed on superhub to run the distributed cleanup python script.
+#       on feeders only the shell script is run so no python dependencies needed there.
 {
   vars:
     debian|ubuntu|redhat_8|centos_8|redhat_9|rocky_9::
@@ -849,6 +851,7 @@ bundle agent entry
     am_policy_hub.default:cfengine_mp_fr_enable_distributed_cleanup::
       "Distributed Cleanup Dependencies"
         handle => "distributed_cleanup_dependencies",
+        if => "enabled.am_on.am_superhub.!am_paused",
         usebundle => "distributed_cleanup_dependencies";
       "Distributed Cleanup Setup"
         handle => "distributed_cleanup_setup",

--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -292,9 +292,19 @@ bundle agent transport_user
         };
 
   classes:
+    enabled.selinux_enabled.default:_stdlib_path_exists_semanage::
+        "cftransport_fcontext_missing"
+          expression => not(returnszero("$(default:paths.semanage) fcontext -l | grep '$(home)/.ssh(/.*)?'", "useshell")),
+          if => fileexists("$(home)");
     enabled.selinux_enabled::
         "incorrect_ssh_context"
-          expression => not( or(
+          expression => and( and(
+                               fileexists("$(home)"),
+                               fileexists("$(ssh_auth_keys)"),
+                               fileexists("$(ssh_priv_key)"),
+                               fileexists("$(ssh_pub_key)"),
+                               fileexists("$(ssh_config)")),
+                             or(
                                regcmp(".*[\s:]ssh_home_t[\s:].*",
                                       execresult("ls -Z $(home) | grep .ssh",
                                                  useshell)),
@@ -354,8 +364,9 @@ bundle agent transport_user
 
   commands:
     # _stdlib_path_exists_<command> and paths.<command> are defined is masterfiles/lib/paths.cf
-    selinux_enabled.incorrect_ssh_context.default:_stdlib_path_exists_semanage.default:_stdlib_path_exists_restorecon::
+    selinux_enabled.cftransport_fcontext_missing.default:_stdlib_path_exists_semanage::
       "$(default:paths.semanage) fcontext -a -t ssh_home_t '$(home)/.ssh(/.*)?'";
+    selinux_enabled.incorrect_ssh_context.default:_stdlib_exists_restorecon::
       "$(default:paths.restorecon) -R -F $(home)/.ssh/";
 
     any::


### PR DESCRIPTION
Previously we did not check if the cftransport ssh fcontext was already added.

Now we check before trying to add this fcontext.

Also split up the management of the fcontext from  applying the changes with restorecon.

Ticket: ENT-10959
Changelog: title

with https://github.com/cfengine/system-testing/pull/514
