### PR TITLE
ENT-10960: Adjusted distributed cleanup dependencies policy to only superhub where it is needed (3.18)

### DIFF
--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -181,6 +181,8 @@ bundle agent config
 bundle agent distributed_cleanup_dependencies
 # @brief warn if python3 and urllib3 required dependencies are not installed
 # if cfengine_mp_fr_enable_distributed_cleanup class is defined
+# Note: these requirements are only needed on superhub to run the distributed cleanup python script.
+#       on feeders only the shell script is run so no python dependencies needed there.
 {
   vars:
     debian|ubuntu|redhat_8|centos_8::
@@ -846,6 +848,7 @@ bundle agent entry
     am_policy_hub.default:cfengine_mp_fr_enable_distributed_cleanup::
       "Distributed Cleanup Dependencies"
         handle => "distributed_cleanup_dependencies",
+        if => "enabled.am_on.am_superhub.!am_paused",
         usebundle => "distributed_cleanup_dependencies";
       "Distributed Cleanup Setup"
         handle => "distributed_cleanup_setup",


### PR DESCRIPTION
python3 and urllib3 module are only needed on superhub

Ticket: ENT-10960
Changelog: none
(cherry picked from commit 13b60c5ba76ff37f9a5130a6a9824973a27fae5e)
(cherry picked from commit b83eaea0119bcaaaeb15beb58698925155502354)
