### PR TITLE
ENT-10960: Fixed distributed_cleanup policy for feeders and rhel-8 superhubs (3.18)

### DIFF
--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -185,10 +185,12 @@ bundle agent distributed_cleanup_dependencies
 #       on feeders only the shell script is run so no python dependencies needed there.
 {
   vars:
-    debian|ubuntu|redhat_8|centos_8::
+    debian|ubuntu::
       "packages" slist => { "python3", "python3-urllib3" };
+    redhat_8|centos_8::
+        "packages" slist => { "python36", "python3-urllib3" };
 
-    centos_7::
+    redhat_7|centos_7::
       "packages" slist => { "python3" };
 
   classes:
@@ -218,7 +220,6 @@ bundle agent distributed_cleanup_dependencies
       "$(packages)"
         policy => "present",
         classes => default:results("bundle", "cfengine_mp_fr_distributed_cleanup_packages"),
-        action => default:policy ( "warn" ),
         package_module => default:yum;
 
   reports:
@@ -852,12 +853,12 @@ bundle agent entry
         usebundle => "distributed_cleanup_dependencies";
       "Distributed Cleanup Setup"
         handle => "distributed_cleanup_setup",
-        depends_on => { "transport_user", "data_transport", "distributed_cleanup_dependencies" },
+        depends_on => { "transport_user", "data_transport" },
         usebundle => "distributed_cleanup_setup";
       "Distributed Federated Host Cleanup"
         handle => "distributed_cleanup",
         if => "enabled.am_on.am_superhub.!am_paused",
-        depends_on => { "imported_data", "distributed_cleanup_setup" },
+        depends_on => { "imported_data", "distributed_cleanup_setup", "distributed_cleanup_dependencies" },
         usebundle => distributed_cleanup_run;
 
   reports:


### PR DESCRIPTION
Only superhub needs distributed_cleanup_dependencies bundle run.
rhel-8 has special package name for python3, python36.

Ticket: ENT-10960
Changelog: title

Co-authored-by: Nick Anderson <nick@cmdln.org>
(cherry picked from commit 4d956c055a97fe0936fa345d96f862475f93d828)

 Conflicts:
	cfe_internal/enterprise/federation/federation.cf

3.18.x does not support rhel-9
