### PR TITLE
ENT-10900: Made enterprise federated reporting dump interval configurable via Augments (3.18)

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -1930,6 +1930,27 @@ config when it notices a change in *policy*.
 **History**: Added in 3.11.
 
 ### Federated Reporting
+#### Configure dump interval
+
+By default feeder hubs dump data every `20` minutes. To configure the interval on which feeder hubs dump data define `cfengine_enterprise_federation:config.dump_interval`.
+
+For example:
+
+```json
+{
+  "variables": {
+    "cfengine_enterprise_federation:config.dump_interval": {
+      "value": "60",
+      "comment": "Dump data on feeders every 60 minutes"
+    }
+  }
+}
+```
+
+**History:**
+
+* Added in CFEngine 3.24.0
+
 #### Debug import process
 
 In order to get detailed logs about import failures define the class `default:cfengine_mp_fr_debug_import` on the _superhub_.

--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -42,9 +42,9 @@ bundle agent config
       "path" string => "$(federation_dir)/cfapache/federation-config.json";
       "path_setup_status" string => "$(federation_dir)/cfapache/setup-status.json";
 
-      # TODO: Instrument augments
-      "dump_interval" -> {"ENT-4806"}
+      "dump_interval" -> { "ENT-4806", "ENT-10900" }
         int => "20",
+        if => not( isvariable( "cfengine_enterprise_federation:config.dump_interval" ) ),
         comment => "Dump data on the feeders every 20 minutes";
 
       # TODO: don't hard-code cftransport user


### PR DESCRIPTION
Ticket: ENT-10900
Changelog: Title
(cherry picked from commit 4811105e71c5d509b242f04f1a0b36607669cf86)