### PR TITLE
CFE-2724: Removed quotes from `arglist` attribute in `commands` promises

### DIFF
--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -757,7 +757,11 @@ bundle agent superhub_schema
       "$(cfengine_enterprise_federation:config.bin_dir)/psql_wrapper.sh"
         arglist => {
                      "cfdb",
+@if minimum_version(3.24)
+                     "select superhub_schema('$(sys.key_digest)');",
+@else
                      `"select superhub_schema('$(sys.key_digest)');"`,
+@endif
                    },
         classes => psql_wrapper_exit_codes;
 }
@@ -775,7 +779,11 @@ bundle agent ensure_feeders
       "$(cfengine_enterprise_federation:config.bin_dir)/psql_wrapper.sh"
         arglist => {
                      "cfdb",
+@if minimum_version(3.24)
+                     "select ensure_feeders($(feeders_arg));"
+@else
                      `"select ensure_feeders($(feeders_arg));"`
+@endif
                    },
         classes => psql_wrapper_exit_codes,
         if => isgreaterthan(length(feeders), 0);


### PR DESCRIPTION
Now that whitespaces are preserved in the `arglist` attribute of the `commands` promises, we no longer need to use extra quotes. In fact, these quotes become a part of the argument, causing some methods to fail in the MPF.

Merge together with:
 - https://github.com/cfengine/core/pull/5378
 - https://github.com/cfengine/enterprise/pull/775
