### PR TITLE
ENT-11130: Check if cf-apache.service is active to see if it's systemd-managed (3.21)

### DIFF
--- a/cfe_internal/enterprise/mission_portal.cf
+++ b/cfe_internal/enterprise/mission_portal.cf
@@ -164,7 +164,7 @@ bundle agent mission_portal_apache_from_stage(config, staged_config)
 
   classes:
       "systemd_supervised"
-        expression => returnszero("$(paths.systemctl) -q is-enabled cf-apache > /dev/null 2>&1", "useshell"),
+        expression => returnszero("$(paths.systemctl) -q is-active cf-apache > /dev/null 2>&1", "useshell"),
         if => fileexists( $(paths.systemctl) );
 
   vars:


### PR DESCRIPTION
We don't enable the cf-apache.service, it's started by the
cfengine3 umbrella service as its (weak) dependency. So only the
cfengine3 service is enabled normally.

Ticket: ENT-11130
Changelog: None
(cherry picked from commit 21c698ab09075038838328b549e5e166fa95fe50)