### PR TITLE
ENT-11178: Fixed policy compatibility with 3.15.x, disabled aws ec2 inventory for versions less than 3.18.0 (3.18.x)

### DIFF
--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -642,6 +642,7 @@ bundle agent cfe_autorun_inventory_aws_ec2_metadata
 bundle agent cfe_autorun_inventory_aws_ec2_metadata_data
 # @brief Retrieve metadata from AWS API, preferring IMDSV2
 {
+@if minimum_version(3.18.0)
   vars:
     ec2_instance.!(disable_inventory_aws|disable_inventory_aws_ec2_metadata)::
       "base_url" string => "http://169.254.169.254/latest";
@@ -663,6 +664,7 @@ bundle agent cfe_autorun_inventory_aws_ec2_metadata_data
         string => execresult( "$(imdsv1_cmd)", noshell ),
         if => and( not( isvariable( imdsv1_cmd_result ) ),
                    not( validjson( "$(imdsv2_cmd_result)" ) ) );
+@endif
 }
 
 bundle agent cfe_autorun_inventory_aws_ec2_metadata_cache
@@ -670,6 +672,7 @@ bundle agent cfe_autorun_inventory_aws_ec2_metadata_cache
 #
 # Provides cache of ec2 instance metadata for inventory
 {
+@if minimum_version(3.18.0)
   vars:
       "cache"     string => "$(sys.statedir)/aws_ec2_metadata";
 
@@ -685,6 +688,7 @@ bundle agent cfe_autorun_inventory_aws_ec2_metadata_cache
     imdsv2_result_valid::
       "$(cache)"
         content => "$(cfe_autorun_inventory_aws_ec2_metadata_data.imdsv2_cmd_result)";
+@endif
 }
 
 bundle agent cfe_aws_ec2_metadata_from_cache


### PR DESCRIPTION
This change aims to fix policy compatibility between 3.18.x and 3.15.x by
guarding the policy with a macro to prevent agents older than 3.18.0 from
evaluating policy which uses features the agent is not capable of.

While 3.15.x has been out of support since December 31st 2022 we strive to minimize
any pain in upgrading. The change that introduced this issue extended ec2
metadata to support and prefer imdsv2 uses a function, validjson() and an
attribute, content which were first introduced in 3.16.0.

Ticket: ENT-11178
Changelog: Title