### PR TITLE
Added opensuse class to lib/packages.cf policy (3.18)

### DIFF
--- a/lib/packages.cf
+++ b/lib/packages.cf
@@ -1809,7 +1809,7 @@ body package_method generic
 #     "mypackage" package_method => generic, package_policy => "add";
 # ```
 {
-    suse|sles::
+    suse|sles|opensuse::
       package_changes => "bulk";
       package_list_command => "$(rpm_knowledge.call_rpm) -qa --queryformat \"$(rpm_knowledge.rpm_output_format)\"";
       # set it to "0" to avoid caching of list during upgrade
@@ -1984,12 +1984,12 @@ bundle agent package_absent(package)
       package_policy => "delete",
       package_method => yum_rpm_permissive;
 
-    suse|sles::
+    suse|sles|opensuse::
       "$(package)"
       package_policy => "delete",
       package_method => zypper;
 
-    !debian.!redhat.!(suse|sles)::
+    !debian.!redhat.!(suse|sles|opensuse)::
       "$(package)"
       package_policy => "delete",
       package_method => generic;
@@ -2021,12 +2021,12 @@ bundle agent package_present(package)
       package_policy => "add",
       package_method => yum_rpm_permissive;
 
-    suse|sles::
+    suse|sles|opensuse::
       "$(package)"
       package_policy => "add",
       package_method => zypper;
 
-    !debian.!redhat.!(suse|sles)::
+    !debian.!redhat.!(suse|sles|opensuse)::
       "$(package)"
       package_policy => "add",
       package_method => generic;
@@ -2060,13 +2060,13 @@ bundle agent package_latest(package)
       package_version => "999999999",
       package_method => yum_rpm_permissive;
 
-    suse|sles::
+    suse|sles|opensuse::
       "$(package)"
       package_policy => "addupdate",
       package_version => "999999999",
       package_method => zypper;
 
-    !debian.!redhat.!(suse|sles)::
+    !debian.!redhat.!(suse|sles|opensuse)::
       "$(package)"
       package_policy => "addupdate",
       package_method => generic;
@@ -2235,7 +2235,7 @@ bundle agent package_specific(package_name, desired, package_version, package_ar
       package_architectures => { $(package_arch) },
       package_method => yum_rpm;
 
-    suse|sles::
+    suse|sles|opensuse::
 
       "$(package_name)"
       package_policy => $(desired),
@@ -2261,13 +2261,13 @@ bundle agent package_specific(package_name, desired, package_version, package_ar
       package_version => $(package_version),
       package_method => solaris_install($(solaris_admin_file));
 
-    !filebased.!debian.!redhat.!(suse|sles)::
+    !filebased.!debian.!redhat.!(suse|sles|opensuse)::
 
       "$(package_name)"
       package_policy => $(desired),
       package_method => generic;
 
   reports:
-    "(DEBUG|DEBUG_$(this.bundle)).filebased.!(suse|sles).!debian.!redhat.!aix.!solaris_pkgadd"::
+    "(DEBUG|DEBUG_$(this.bundle)).filebased.!(suse|sles|opensuse).!debian.!redhat.!aix.!solaris_pkgadd"::
       "DEBUG $(this.bundle): sorry, can't do file-based installs on $(sys.os)";
 }


### PR DESCRIPTION
Using opensuse leap 15 I get only the opensuse class.
In order to use default package_method generic we must add the opensuse class guard there.
Other policy in lib/packages.cf has been adjusted in a similar way.

Ticket: none
Changelog: none
(cherry picked from commit 482bb20141078e65c6bf904ff206c093f4cf89a4)
