### PR TITLE
ENT-11396: Fixed history for default:def.control_common_tls_min_version

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -1231,7 +1231,7 @@ Example definition in augments file:
 
 **History:**
 
-* Added in 3.22.0
+* Added in 3.22.0, 3.21.2
 
 ### Configure users allowed to initiate execution via cf-runagent
 


### PR DESCRIPTION
This has been available since 3.21.2 as well.