### PR TITLE
ENT-11395: Fixed history for default:def.control_common_tls_ciphers

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -1288,7 +1288,7 @@ Example definition in augments file:
 
 **History:**
 
-* Added in 3.22.0
+* Added in 3.22.0, 3.21.2
 
 ### Configure the minimum TLS version used by cf-agent
 


### PR DESCRIPTION
This has been available since 3.21.2

Ticket: ENT-11395
Changelog: None