### PR TITLE
Fixed history for default:def.control_common_tls_min_version

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -1205,7 +1205,7 @@ Example definition in augments file:
 
 **History:**
 
-* Added in 3.22.0
+* Added in 3.22.0, 3.21.2
 
 ### Configure users allowed to initiate execution via cf-runagent
 


### PR DESCRIPTION
This has been available since 3.21.2 as well.

Ticket: ENT-11396
Changelog: None
(cherry picked from commit 32e88add639372d0c8d7a6e396b04e96cfbc2ff6)