### PR TITLE
ENT-11480: Removed hour delay between CFEngine Enterprise PostgreSQL recommendation checks

### DIFF
--- a/cfe_internal/recommendations.cf
+++ b/cfe_internal/recommendations.cf
@@ -145,7 +145,7 @@ bundle agent postgresql_conf_recommendations
       "$(pgsql_conf)"
         edit_line => set_line_based("$(this.bundle).conf", "=", "\s*=\s*", ".*", "\s*#\s*"),
         classes => results( "bundle", "psql_conf_recommendations" ),
-        action => warn_only,
+        action => policy( "warn" ),
         if => fileexists( $(pgsql_conf) );
 
   reports:


### PR DESCRIPTION
This change switches from the warn_only action body to the policy(p) action body
so that the PostgreSQL recommendation checks are consistent and not appearing to
flap being checked only once an hour (since the warn_only action body sets
ifelapsed to 60). This also aligns with other recommendation policies.

Ticket: ENT-11480
Changelog: Title