### PR TITLE
CFE-4365: Cleaned up unnecessary temporary variable

### DIFF
--- a/lib/autorun.cf
+++ b/lib/autorun.cf
@@ -8,10 +8,8 @@ bundle agent autorun
 {
   vars:
     services_autorun|services_autorun_bundles::
-      "bundles" slist => bundlesmatching(".*", "autorun");
-
       "sorted_bundles"
-        slist => sort("bundles", "lex"),
+        slist => sort( bundlesmatching(".*", "autorun"), "lex"),
         comment => "Lexicographically sorted bundles for predictable order";
 
   methods:


### PR DESCRIPTION
This change uses nested function calling to avoid definition of a variable that
is otherwise unused.

Ticket: CFE-4365
Changelog: None