### PR TITLE
Allow disabling recommendations using a CMDB class

### DIFF
--- a/controls/def.cf
+++ b/controls/def.cf
@@ -667,7 +667,7 @@ bundle common def
         expression => some( ".+", "def.control_executor_runagent_socket_allow_users" );
 
       "cfengine_recommendations_enabled"
-        expression => "!cfengine_recommendations_disabled";
+        expression => "!cfengine_recommendations_disabled.!data:cfengine_recommendations_disabled";
 
       ### Enable special features policies. Set to "any" to enable.
 


### PR DESCRIPTION
CMDB classes default to the `data` namespace. So if the user adds `cfengine_recommendations_disabled` as a class in their CMDB data for the hub machine, checking the class in the default namespace is not good enough to disable recommendations.