### PR TITLE
ENT-11523: Improved instructions for disabling recommendations

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -2539,12 +2539,12 @@ Maximum time between automatic WAL checkpoints. If this value is specified witho
 ## Recommendations
 
 The MPF includes policy that inspects the system and makes recommendations about
-the configuration of the system. When `cfengine_recommendations_enabled` is
-defined bundles tagged `cfengine_recommendation` are executed in lexical order.
-`cfengine_recommendations_enabled` is defined by default when
-`cfengine_recommendations_disabled` is **not** defined.
+the configuration of the system. When `default:cfengine_recommendations_enabled` is
+defined bundles tagged `cfengine_recommends` are executed in lexical order.
+`default:cfengine_recommendations_enabled` is defined by default when
+`default:cfengine_recommendations_disabled` is **not** defined.
 
-To disable cfengine recommendations define `cfengine_recommendations_disabled`.
+To disable cfengine recommendations define `default:cfengine_recommendations_disabled`.
 
 This snippet disables recommendations via augments.
 

--- a/cfe_internal/CFE_cfengine.cf
+++ b/cfe_internal/CFE_cfengine.cf
@@ -77,4 +77,7 @@ bundle agent cfe_internal_management
   reports:
     DEBUG|DEBUG_cfe_internal_management::
       "DEBUG $(this.bundle): Should actuate $(bundles)";
+
+    cfengine_recommendation_instruct_disablement::
+      "Note: All recommendations can be disabled by defining 'default:cfengine_recommendations_disabled'";
 }

--- a/cfe_internal/recommendations.cf
+++ b/cfe_internal/recommendations.cf
@@ -4,9 +4,15 @@ bundle agent MPF_class_recommendations
     (policy_server|am_policy_hub).enterprise_edition::
       "tags" slist => { "cfengine_recommends" };
 
+  classes:
+      "cfengine_recommendation_instruct_disablement"
+        expression => "cfengine_recommendation_emitted",
+        scope => "namespace";
+
   reports:
       "`cfengine_internal_purge_policies` no longer has any effect. Please use `cfengine_internal_purge_policies_disabled` instead, to choose where you want to disable purging or remove the class completely if you want purging enabled everywhere (the new default in 3.18+)." -> { "CFE-3662" }
-        if => "cfengine_internal_purge_policies";
+        if => "cfengine_internal_purge_policies",
+        classes => results( "bundle", "cfengine_recommendation_emitted");
 }
 
 bundle agent federated_reporting_superhub_recommendations
@@ -14,10 +20,16 @@ bundle agent federated_reporting_superhub_recommendations
   meta:
       "tags" slist => { "cfengine_recommends" };
 
+  classes:
+      "cfengine_recommendation_instruct_disablement"
+        expression => "cfengine_recommendation_emitted_reached",
+        scope => "namespace";
+
   reports:
     cfengine_enterprise_federation:am_superhub::
       "CFEngine recommends installing gnu parallel on federated reporting superhubs."
-        if => not(isgreaterthan(length(packagesmatching( "parallel", ".*", ".*", ".*")), 0 ));
+        if => not(isgreaterthan(length(packagesmatching( "parallel", ".*", ".*", ".*")), 0 )),
+        classes => results( "bundle", "cfengine_recommendation_emitted");
 
 }
 @if minimum_version(3.21.4)
@@ -50,6 +62,10 @@ bundle agent ignore_interfaces_rx_reccomendations
       "ignore_interfaces_in_inputdir" -> { "ENT-9402" }
         if => fileexists( "$(sys.inputdir)/ignore_interfaces.rx" );
 
+      "cfengine_recommendation_instruct_disablement"
+        expression => "cfengine_recommendation_emitted_reached",
+        scope => "namespace";
+
   files:
     ignore_interfaces_in_workdir_supported.default:mpf_auto_migrate_ignore_interfaces_rx_to_workdir.ignore_interfaces_in_inputdir::
       "$(sys.workdir)/ignore_interfaces.rx" -> { "ENT-9402" }
@@ -73,16 +89,20 @@ bundle agent ignore_interfaces_rx_reccomendations
 
     ignore_interfaces_in_workdir_supported.(ignore_interfaces_in_inputdir.!default:mpf_auto_migrate_ignore_interfaces_rx_to_workdir_reports_disabled)::
       "NOTICE: 'ignore_interfaces.rx' is present in '$(const.dollar)(sys.inputdir)' ('$(sys.inputdir)/ignore_interfaces.rx'). We recommend that it be removed and migrated to '$(const.dollar)(sys.workdir)' ('$(sys.workdir)/ignore_interfaces.rx')"
-        if => not( fileexists( "$(sys.workdir)/ignore_interfaces.rx" ) );
+        if => not( fileexists( "$(sys.workdir)/ignore_interfaces.rx" ) ),
+        classes => results( "bundle", "cfengine_recommendation_emitted");
 
     ignore_interfaces_in_workdir_supported.(ignore_interfaces_in_workdir.ignore_interfaces_in_inputdir).!default:mpf_auto_migrate_ignore_interfaces_rx_to_workdir_reports_disabled::
       "NOTICE: 'ignore_interfaces.rx' identical in '$(const.dollar)(sys.workdir)' and '$(const.dollar)(sys.inputdir)'. We recommend removing '$(const.dollar)(sys.inputdir)/ignore_interfaces.rx'"
         if => strcmp( readfile( "$(sys.workdir)/ignore_interfaces.rx"),
-                      readfile( "$(sys.inputdir)/ignore_interfaces.rx") );
+                      readfile( "$(sys.inputdir)/ignore_interfaces.rx") ),
+
+        classes => results( "bundle", "cfengine_recommendation_emitted");
 
       "NOTICE: 'ignore_interfaces.rx' in '$(const.dollar)(sys.workdir)' and '$(const.dollar)(sys.inputdir)' but not identical. We recommend verifying the desired content of '$(const.dollar)(sys.workdir)/ignore_interfaces.rx', correcting it if necessary and removing '$(const.dollar)(sys.inputdir)/ignore_interfaces.rx'"
         if => not( strcmp( readfile( "$(sys.workdir)/ignore_interfaces.rx"),
-                           readfile( "$(sys.inputdir)/ignore_interfaces.rx") ) );
+                           readfile( "$(sys.inputdir)/ignore_interfaces.rx") ) ),
+        classes => results( "bundle", "cfengine_recommendation_emitted");
 
 }
 @endif
@@ -141,6 +161,11 @@ bundle agent postgresql_conf_recommendations
                    not( isvariable( "conf[maintenance_work_mem]" ) ),
                    not( isvariable( "conf[effective_cache_size]" )));
 
+  classes:
+      "cfengine_recommendation_instruct_disablement"
+        expression => "cfengine_recommendation_emitted_reached",
+        scope => "namespace";
+
   files:
       "$(pgsql_conf)"
         edit_line => set_line_based("$(this.bundle).conf", "=", "\s*=\s*", ".*", "\s*#\s*"),
@@ -152,9 +177,12 @@ bundle agent postgresql_conf_recommendations
     psql_conf_recommendations_not_kept::
       "CFEngine Recommended Settings:";
       "shared_buffers = $(conf[shared_buffers])"
-        if => isvariable( "conf[shared_buffers]" );
+        if => isvariable( "conf[shared_buffers]" ),
+        classes => results( "bundle", "cfengine_recommendation_emitted");
       "effective_cache_size = $(conf[effective_cache_size])"
-        if => isvariable( "conf[effective_cache_size]" );
+        if => isvariable( "conf[effective_cache_size]" ),
+        classes => results( "bundle", "cfengine_recommendation_emitted");
       "maintenance_work_mem = $(conf[maintenance_work_mem])"
-        if => isvariable( "conf[maintenance_work_mem]" );
+        if => isvariable( "conf[maintenance_work_mem]" ),
+        classes => results( "bundle", "cfengine_recommendation_emitted");
 }


### PR DESCRIPTION
This change introduces a reports promise (`R: Note: Recommendations can be disabled by defining 'default:cfengine_recommendations_disabled'`) that is activated if any of the existing recommendations are emitted.

For example:

```
root@hub:~/cfbs# cf-agent -Kf update.cf; cf-agent -K
 warning: edit_line warning promised: - #shared_buffers = 128MB                 # min 128kB
 warning: edit_line warning promised: - #effective_cache_size = 4GB
 warning: Should edit file '/var/cfengine/state/pg/data/postgresql.conf', but only warning promised
 warning: Warnings encountered when actuating files promise '/var/cfengine/state/pg/data/postgresql.conf'
R: CFEngine Recommended Settings:
R: shared_buffers = 4850MB
R: effective_cache_size = 13590MB
 warning: Method 'postgresql_conf_recommendations' invoked repairs, but only warnings promised
R: Note: All recommendations can be disabled by defining 'default:cfengine_recommendations_disabled'
root@hub:~/cfbs# cf-agent -K --define default:cfengine_recommendations_disabled
root@hub:~/cfbs#
```

It also clarifies the documentation a bit more, explicitly calling out the `default` namespace.