### PR TITLE
CFE-4359: Update regex strings to raw to squelch warnings introduced with python 3.12 (3.21)

### DIFF
--- a/modules/packages/vendored/apt_get.mustache
+++ b/modules/packages/vendored/apt_get.mustache
@@ -193,12 +193,12 @@ def list_updates(online):
         #                               name                   old version       new version
         #                                 |                         |                 |
         #                         /-------+-------\              /--+--\       /------+-------\
-        match = re.match("^Inst\s+(?P<name>[^\s:]+)(?::\S+)?\s+\[[^]\s]+\]\s+\((?P<version>\S+)" +
+        match = re.match(r"^Inst\s+(?P<name>[^\s:]+)(?::\S+)?\s+\[[^]\s]+\]\s+\((?P<version>\S+)" +
 
         #                repository(ies)      arch (might be optional)
         #                       |               |
         #                    /--+-\   /---------+---------\
-                         "(?:\s+\S+)*?(\s+\[(?P<arch>[^]\s]+)\])?\).*", line)
+                         r"(?:\s+\S+)*?(\s+\[(?P<arch>[^]\s]+)\])?\).*", line)
 
         if match is not None:
             sys.stdout.write("Name=" + match.group("name") + "\n")


### PR DESCRIPTION
(cherry picked from commit c5bc6798b63d9cf8e951df2c81257d4ae92d1ca0)