### PR TITLE
CFE-4359: Update regex strings to raw to squelch python 3.12 warnings (yum and zypper)

### DIFF
--- a/modules/packages/vendored/yum.mustache
+++ b/modules/packages/vendored/yum.mustache
@@ -145,14 +145,14 @@ def list_updates(online):
             lastline = ""
 
         line = lastline + line
-        match = re.match("^\S+\s+\S+\s+\S+", line)
+        match = re.match(r"^\S+\s+\S+\s+\S+", line)
         if match is None:
             # Keep line
             lastline = line
             continue
 
         lastline = ""
-        match = re.match("^(?P<name>\S+)\.(?P<arch>[^.\s]+)\s+(?P<version>\S+)\s+\S+\s*$", line)
+        match = re.match(r"^(?P<name>\S+)\.(?P<arch>[^.\s]+)\s+(?P<version>\S+)\s+\S+\s*$", line)
         if match is not None:
             sys.stdout.write("Name=" + match.group("name") + "\n")
             sys.stdout.write("Version=" + match.group("version") + "\n")

--- a/modules/packages/vendored/zypper.mustache
+++ b/modules/packages/vendored/zypper.mustache
@@ -180,7 +180,7 @@ def list_updates(online):
 
 # The first char will always be "v" which means there is a new version available on search outputs.
 
-        match = re.match("v\s+\|[^\|]+\|\s+(?P<name>\S+)\s+\|\s+\S+\s+\|\s+(?P<version>\S+)\s+\|\s+(?P<arch>\S+)\s*$", line)
+        match = re.match(r"v\s+\|[^\|]+\|\s+(?P<name>\S+)\s+\|\s+\S+\s+\|\s+(?P<version>\S+)\s+\|\s+(?P<arch>\S+)\s*$", line)
         if match is not None:
             sys.stdout.write("Name=" + match.group("name") + "\n")
             sys.stdout.write("Version=" + match.group("version") + "\n")


### PR DESCRIPTION
Same as https://github.com/cfengine/masterfiles/pull/2853, for yum and zypper