### PR TITLE
Changed mission-portal apache restart to graceful to minimize service interruptions (3.21)

### DIFF
--- a/cfe_internal/enterprise/mission_portal.cf
+++ b/cfe_internal/enterprise/mission_portal.cf
@@ -223,7 +223,7 @@ bundle agent mission_portal_apache_from_stage(config, staged_config)
                            "place only if we have stopped apache already.");
 
       "LD_LIBRARY_PATH=$(sys.workdir)/lib:$LD_LIBRARY_PATH $(sys.workdir)/httpd/bin/apachectl" -> { "ENT-9686" }
-        args => "restart",
+        args => "graceful",
         if => and( "mission_portal_apache_config_repaired",
                    not( "apache_stop_after_new_staged_config_repaired" ) ),
         contain => in_shell,

--- a/templates/cf-apache.service.mustache
+++ b/templates/cf-apache.service.mustache
@@ -10,6 +10,7 @@ PartOf=cfengine3.service
 Type=forking
 ExecStart={{{vars.sys.workdir}}}/httpd/bin/apachectl start
 ExecStop={{{vars.sys.workdir}}}/httpd/bin/apachectl stop
+ExecReload={{{vars.sys.workdir}}}/httpd/bin/apachectl graceful
 PIDFile={{{vars.sys.workdir}}}/httpd/httpd.pid
 Restart=always
 RestartSec=10


### PR DESCRIPTION
In our CI system deployment tests we go through test steps quickly.
Fairly often the apache config is updated by policy and a restart is initiated.
By changing to apachectl graceful we should avoid some of the server availability during tests problems we have been seeing.

Ticket: ENT-11526
Changelog: title
(cherry picked from commit f4de8811c58bec4ddd445727fecd2d6b373cc0ff)

with https://github.com/cfengine/core/pull/5482