### PR TITLE
ENT-11763: Inventory view is now refreshed in cf-reactor instead of through policy

### DIFF
--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -3,7 +3,7 @@ on:
 
 jobs:
   valgrind_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/cfe_internal/enterprise/CFE_hub_specific.cf
+++ b/cfe_internal/enterprise/CFE_hub_specific.cf
@@ -599,7 +599,9 @@ bundle agent cfe_internal_exported_report_location
 
 bundle agent cfe_internal_refresh_inventory_view
 # @brief Refresh list of inventory variables every 5 minutes
+# @note Beginning with 3.24.0 the inventory view refresh is handled by cf-reactor.
 {
+@if before_version(3.24.0)
   meta:
 
     (policy_server|am_policy_hub).enterprise_edition::
@@ -613,12 +615,11 @@ bundle agent cfe_internal_refresh_inventory_view
       "$(sys.workdir)/httpd/php/bin/php"
         args => "$(cfe_internal_hub_vars.public_docroot)/index.php cli_tasks inventory_refresh",
         contain => silent,
-@if minimum_version(3.15.0)
         inform => "false",
-@endif
         comment => "This refreshes the variables shown in the Mission Portal Inventory.",
         handle  => "mpf_fresh_inventory_view",
         if => isdir( "$(cfe_internal_hub_vars.docroot)/api/modules/inventory" );
+@endif
 }
 
 bundle agent cfe_internal_refresh_hosts_view

--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -706,20 +706,28 @@ body contain cfpostgres_user
 
 bundle agent exported_data
 # @brief Run script to dump pg data on feeder hub
+# @note Since version 3.24.0, the inventory view is automatically refreshed by
+# cf-reactor whenever inventory is updated. Hence, you can assume that the
+# inventory is refreshed. However, there is one exception; if the previous
+# refresh happened too recently, the following one will be delayed.
 {
+@if before_version(3.24.0)
   methods:
     am_feeder.!am_paused::
       "Refresh Inventory"
         usebundle => "default:cfe_internal_refresh_inventory_view",
         handle => "fr_inventory_refresh",
         comment => "Use standard inventory refresh so that we don't run it twice";
+@endif
 
   commands:
     am_feeder.!am_paused::
       "/bin/bash"
         arglist => {"$(cfengine_enterprise_federation:config.bin_dir)/dump.sh"},
         contain => default:in_shell,
+@if before_version(3.24.0)
         depends_on => { "fr_inventory_refresh" },
+@endif
         comment => "Refresh Inventory must be completed before dumping data";
 }
 


### PR DESCRIPTION
Since version 3.24.0, the inventory view is automatically refreshed by
cf-reactor whenever inventory is updated. Hence, there is no need to do
this in policy.

Ticket: ENT-11763
Changelog: Title
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>

Merge together with https://github.com/cfengine/nova/pull/2233

**TODO:**
- [x] Manual testing