### PR TITLE
CFE-4342: When failing to detect platform, inventory attribute "OS" now defaults to PRETTY_NAME from os-release as a fallback (3.21)

### DIFF
--- a/inventory/os.cf
+++ b/inventory/os.cf
@@ -130,5 +130,14 @@ amzn_2::
      string => "Amazon 2",
      meta => { "inventory", "attribute_name=OS" };
 
+any::
+  "description"
+    string => "$(sys.os_release[PRETTY_NAME])",
+    if => and(
+      strcmp("$(sys.os_name_human)", "Unknown"),
+      isvariable("sys.os_release[PRETTY_NAME]")
+    ),
+    meta => { "inventory", "attribute_name=OS", "derived-from=sys.os_release" };
+
 @endif
 }


### PR DESCRIPTION
(cherry picked from commit a9f916f3ef01a1ea5464d1b6345b0ed7156c3453)