### PR TITLE
Added setup-feeder option to distributed cleanup script (3.18)

### DIFF
--- a/.github/workflows/style_check.yml
+++ b/.github/workflows/style_check.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   style_check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - name: Style Check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: masterfiles
       - name: Get Togethers
@@ -15,7 +15,7 @@ jobs:
         with:
           myToken: ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout Core
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: cfengine/core
           path: core

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ on:
 
 jobs:
   acceptance_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: masterfiles
       - name: Get Togethers
@@ -15,7 +15,7 @@ jobs:
         with:
           myToken: ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout Core
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: cfengine/core
           path: core

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -3,7 +3,7 @@ on:
 
 jobs:
   valgrind_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This enables an administrator to setup a single feeder.

/opt/cfengine/federation/bin/distributed_cleanup.py --setup-feeder feederhostname

Ticket: ENT-11844
Changelog: title
(cherry picked from commit d60cc27afefc8423462e665983a9123a7a7cb522)
