### PR TITLE
CFE-4359: Update regex strings to raw to squelch warnings introduced with python 3.12 (3.18)

### DIFF
--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -3,7 +3,7 @@ on:
 
 jobs:
   valgrind_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/modules/packages/vendored/apt_get.mustache
+++ b/modules/packages/vendored/apt_get.mustache
@@ -193,12 +193,12 @@ def list_updates(online):
         #                               name                   old version       new version
         #                                 |                         |                 |
         #                         /-------+-------\              /--+--\       /------+-------\
-        match = re.match("^Inst\s+(?P<name>[^\s:]+)(?::\S+)?\s+\[[^]\s]+\]\s+\((?P<version>\S+)" +
+        match = re.match(r"^Inst\s+(?P<name>[^\s:]+)(?::\S+)?\s+\[[^]\s]+\]\s+\((?P<version>\S+)" +
 
         #                repository(ies)      arch (might be optional)
         #                       |               |
         #                    /--+-\   /---------+---------\
-                         "(?:\s+\S+)*?(\s+\[(?P<arch>[^]\s]+)\])?\).*", line)
+                         r"(?:\s+\S+)*?(\s+\[(?P<arch>[^]\s]+)\])?\).*", line)
 
         if match is not None:
             sys.stdout.write("Name=" + match.group("name") + "\n")

--- a/modules/packages/vendored/yum.mustache
+++ b/modules/packages/vendored/yum.mustache
@@ -145,14 +145,14 @@ def list_updates(online):
             lastline = ""
 
         line = lastline + line
-        match = re.match("^\S+\s+\S+\s+\S+", line)
+        match = re.match(r"^\S+\s+\S+\s+\S+", line)
         if match is None:
             # Keep line
             lastline = line
             continue
 
         lastline = ""
-        match = re.match("^(?P<name>\S+)\.(?P<arch>[^.\s]+)\s+(?P<version>\S+)\s+\S+\s*$", line)
+        match = re.match(r"^(?P<name>\S+)\.(?P<arch>[^.\s]+)\s+(?P<version>\S+)\s+\S+\s*$", line)
         if match is not None:
             sys.stdout.write("Name=" + match.group("name") + "\n")
             sys.stdout.write("Version=" + match.group("version") + "\n")

--- a/modules/packages/vendored/zypper.mustache
+++ b/modules/packages/vendored/zypper.mustache
@@ -180,7 +180,7 @@ def list_updates(online):
 
 # The first char will always be "v" which means there is a new version avaialble on search outputs.
 
-        match = re.match("v\s+\|[^\|]+\|\s+(?P<name>\S+)\s+\|\s+\S+\s+\|\s+(?P<version>\S+)\s+\|\s+(?P<arch>\S+)\s*$", line)
+        match = re.match(r"v\s+\|[^\|]+\|\s+(?P<name>\S+)\s+\|\s+\S+\s+\|\s+(?P<version>\S+)\s+\|\s+(?P<arch>\S+)\s*$", line)
         if match is not None:
             sys.stdout.write("Name=" + match.group("name") + "\n")
             sys.stdout.write("Version=" + match.group("version") + "\n")


### PR DESCRIPTION
This back port is needed for Ubuntu 24 to pass CI (see ENT-11309)

Back ported from https://github.com/cfengine/masterfiles/pull/2873

[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline&build=10885)](https://ci.cfengine.com/job/pr-pipeline/10885/)