### PR TITLE
ENT-11809: Allow access for cfapache to read host_specific.json

### DIFF
--- a/cfe_internal/update/update_policy.cf
+++ b/cfe_internal/update/update_policy.cf
@@ -321,6 +321,14 @@ bundle agent cfe_internal_update_cmdb
 @endif
 }
 
+body acl u_acl_cmdb_host_specific_json
+# @brief Allow read access for user cfapache
+# Mission Portal needs read access to these files (See ticket ENT-11809)
+{
+  acl_method => "append";
+  aces => { "user:cfapache:r" };
+}
+
 bundle agent cfe_internal_update_cmdb_data_distribution
 # @brief Ensure data is ready for agents to download
 {
@@ -390,6 +398,7 @@ bundle agent cfe_internal_update_cmdb_data_distribution
       # Write out the data for each host that had a data change
       "$(sys.workdir)/cmdb/$(_i)/host_specific.json"
         create => "true", # CFE-2329, ENT-4792
+        acl => u_acl_cmdb_host_specific_json, # ENT-11809
         template_data => mergedata("_get_cmdb_data_response_d[data][$(_i)]" ), # mergedata() is necessary in order to pick out a substructure, parsejson() is insufficient because expanding a key results in iteration of /values/ under that key
         template_method => "inline_mustache",
         edit_template_string => string_mustache( "{{$-top-}}", "_get_cmdb_data_response_d[data][$(_i)]" ),


### PR DESCRIPTION
Allowed read access for cfapache to `$(sys.workdir)/cmdb/SHA=*/host_specific.json` through ACLs.

Ticket: ENT-11809
Changelog: Commit
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>

**TODO:**
 - [x] Manual testing - read file as cfapache user
 - [ ] Pass CI - [![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline&build=10894)](https://ci.cfengine.com/job/pr-pipeline/10894/)