### PR TITLE
ENT-10646: Squashed common error logged by Apache related to IPv6 (3.18)

### DIFF
--- a/cfe_internal/enterprise/templates/httpd.conf.mustache
+++ b/cfe_internal/enterprise/templates/httpd.conf.mustache
@@ -7,7 +7,10 @@ ServerName {{{vars.sys.fqhost}}}
 ServerRoot "{{{vars.sys.workdir}}}/httpd"
 {{^classes.cfe_enterprise_disable_plain_http}}
 # ENT-10411
-Listen 80
+# ENT-10646 - Listen 80 often causes IPv6 related errors, specifying ipv4 squashes them.
+#   Unclear why the same is not an issue for 443
+#   To enable listening on ipv6 add Listen [::]:80
+Listen 0.0.0.0:80
 {{/classes.cfe_enterprise_disable_plain_http}}
 
 PidFile "{{{vars.mission_portal_apache_from_stage.httpd_pid_file}}}"


### PR DESCRIPTION
Apache often logs errors related to IPv6, e.g.:

No route to host: AH00056: connect to listener on [::]:80

Specifying IPv4 when listening on port 80 prevents this excessive noise.

Ticket: ENT-10646
Changelog: Title
(cherry picked from commit b936079c03621b556ac800181e886cf4feb95033)