### PR TITLE
Fixed missing software inventory on RedHat based systems (3.18)

### DIFF
--- a/promises.cf.in
+++ b/promises.cf.in
@@ -98,7 +98,7 @@ body common control
 
       # We only define package_inventory on redhat like systems that have a
       # python version that works with the package module.
-    (redhat|centos|suse|sles|opensuse|amazon_linux).cfe_yum_package_module_supported.!disable_inventory_package_refresh::
+    (redhat|centos|suse|sles|opensuse|amazon_linux).cfe_python_for_package_modules_supported.!disable_inventory_package_refresh::
         package_inventory => { $(package_module_knowledge.platform_default), @(default:package_module_knowledge.additional_inventory)};
 
     aix.!disable_inventory_package_refresh::


### PR DESCRIPTION
A previous fix to add package inventory for AIX and adding ability to influence default package manager and inventory via augments introduced this bug.

The commit was: 87292179415a0d4770281715a850ef49d2991842

There was a typo that used the class cfe_yum_package_module_supported instead of cfe_python_for_package_modules_supported.

The first class is undefined anywhere in policy. The second class it the correct one.

Ticket: ENT-11850
Changelog: none
(cherry picked from commit 8bbae0248c52cbfd63332636823d05c5ed0267f8)
