### PR TITLE
CFE-4415: Fix shell typo in nimclient module script (3.21)

### DIFF
--- a/modules/packages/vendored/nimclient.mustache
+++ b/modules/packages/vendored/nimclient.mustache
@@ -146,7 +146,7 @@ done
 # This is not well developed as I don't have continuous access to aix and nim
 # nor am I an expert
 CFENGINE_TEST_NIMCLIENT_MOCK=false
-if [ -n "$CFENGINE_TEST_NIMCLIENT_MOCK"  = "true" ]; then
+if [ "$CFENGINE_TEST_NIMCLIENT_MOCK" = "true" ]; then
     list_installed_packages() {
         cat ../../tests/unit/mock_lslpp_Lc
      }


### PR DESCRIPTION
CFE-4415

(cherry picked from commit aa6861607396db946f9efd91e72708070d5002de)
