### PR TITLE
ENT-11959: Fixed modules_presence bundle for Windows agents

### DIFF
--- a/cfe_internal/update/update_policy.cf
+++ b/cfe_internal/update/update_policy.cf
@@ -795,14 +795,15 @@ bundle agent modules_presence
 #              be updated in $(sys.workdir)/modules, including any sub-directories.
 {
   vars:
-    "_vendored_dir" string => "$(this.promise_dirname)/../../modules/packages/vendored/";
-    "_override_dir" string => "$(this.promise_dirname)/../../modules/packages/";
-    "_custom_template_dir" string => "$(this.promise_dirname)/../../modules/mustache/";
+    "_vendored_dir" string => "$(this.promise_dirname)$(const.dirsep)..$(const.dirsep)..$(const.dirsep)modules$(const.dirsep)packages$(const.dirsep)vendored$(const.dirsep)";
+    "_override_dir" string => "$(this.promise_dirname)$(const.dirsep)..$(const.dirsep)..$(const.dirsep)modules$(const.dirsep)packages$(const.dirsep)";
+    "_custom_template_dir" string => "$(this.promise_dirname)$(const.dirsep)..$(const.dirsep)..$(const.dirsep)modules$(const.dirsep)mustache$(const.dirsep)";
     "_vendored_paths" slist => findfiles("$(_vendored_dir)*.mustache");
     "_custom_template_paths" slist => findfiles("$(_custom_template_dir)*.mustache"), if => isdir( "$(_custom_template_dir)" );
     "_package_paths" slist => filter("$(_override_dir)vendored", _package_paths_tmp, "false", "true", 999);
+
     windows::
-      "_package_paths_tmp" slist => findfiles("\Q$(_override_dir)\E*");
+      "_package_paths_tmp" slist => findfiles("$(_override_dir)*");
       "_vendored_modules" slist => maplist(regex_replace("$(this)", "\Q$(_vendored_dir)\E(.*).mustache", "$1", "g"), @(_vendored_paths));
       "_override_modules" slist => maplist(regex_replace("$(this)", "\Q$(_override_dir)\E(.*)", "$1", "g"), @(_package_paths));
       # replace single backslashes in a windows path with double-backslashes
@@ -860,6 +861,8 @@ bundle agent modules_presence
 
   reports:
     DEBUG::
+      "_override_dir: $(_override_dir)";
+      "_package_paths_tmp: $(with)" with => storejson(_package_paths_tmp);
       "_not_vendored_modules_pathname_regex: $(_not_vendored_modules_pathname_regex)";
       "_vendored_modules: $(_vendored_modules)";
       "_override_modules: $(_override_modules)";


### PR DESCRIPTION
With findfiles returning proper back-slashed paths this policy was broken due to _vendored_dir and _override_dir being used with mixed slashed path and used as a replacement string.

Ticket: ENT-11959
Changelog: none
