### PR TITLE
 ENT-11472: Added CSP HTTP Header to MP apache config (3.21)

### DIFF
--- a/cfe_internal/enterprise/templates/httpd.conf.mustache
+++ b/cfe_internal/enterprise/templates/httpd.conf.mustache
@@ -202,6 +202,23 @@ LogLevel warn
     Header always set X-Frame-Options DENY
     Header always set X-Content-Type-Options nosniff
 
+    Header always set Content-Security-Policy \
+    "frame-ancestors 'self'; \
+    default-src 'self'; \
+    script-src 'self' 'unsafe-inline'; \
+    style-src 'self' 'unsafe-inline' fonts.googleapis.com; \
+    object-src 'none'; \
+    frame-src 'self'; \
+    child-src 'self'; \
+    img-src 'self' avatars.githubusercontent.com badges.gitter.im fonts.gstatic.com kiwiirc.com raw.githubusercontent.com; \
+    font-src 'self' data: fonts.googleapis.com fonts.gstatic.com; \
+    connect-src 'self' fonts.gstatic.com fonts.googleapis.com; \
+    manifest-src 'self'; \
+    base-uri 'self'; \
+    form-action 'self'; \
+    media-src 'self'; \
+    worker-src 'self';"
+
     <FilesMatch "\.(cgi|shtml|phtml|php)$">
         SSLOptions +StdEnvVars
     </FilesMatch>


### PR DESCRIPTION
Ticket: ENT-11472
Changelog: None
Signed-off-by: Mikita Pilinka <mikita.pilinka@northern.tech>

(cherry picked from commit b99e9a3cd4da10917e288ff1f1c5b2b2ad3a95ec)