### PR TITLE
ENT-12116: Added trailing /. to files promises targeting local_software_dir (3.21)

### DIFF
--- a/cfe_internal/update/update_bins.cf
+++ b/cfe_internal/update/update_bins.cf
@@ -262,7 +262,7 @@ bundle agent cfe_internal_update_bins
         comment => "Ensure the local software directory exists for new binaries
                     to be downloaded to";
 
-      "$(local_software_dir)"
+      "$(local_software_dir)/."
       comment => "Copy binary updates from master source on policy server",
       handle => "cfe_internal_update_bins_files_pkg_copy",
       copy_from => u_pcp("$(master_software_location)/$(package_dir)", @(update_def.policy_servers)),

--- a/standalone_self_upgrade.cf.in
+++ b/standalone_self_upgrade.cf.in
@@ -259,7 +259,7 @@ bundle agent cfengine_software_cached_locally
       # NOTE This is pegged to the single upstream policy hub, it won't fail
       # over to a secondary for copying the binarys to update.
 
-      "$(local_software_dir)"
+      "$(local_software_dir)/."
         comment => "Copy binary updates from master source on policy server",
         handle => "cfe_internal_update_bins_files_pkg_copy",
         copy_from => u_dsync( "$(master_software_location)/$(package_dir)", $(sys.policy_hub) ),


### PR DESCRIPTION
The trailing /. is how we can explicitly indicate that a directory is desired in
CFEngine. Without a trailing ./ CFEngine could get confused and create a single
file instead of a directory.

Ticket: ENT-12116
Changelog: Title