### PR TITLE
ENT-4400: Allowed blob image-src in the Mission Portal CSP rules (3.21.x)

### DIFF
--- a/cfe_internal/enterprise/templates/httpd.conf.mustache
+++ b/cfe_internal/enterprise/templates/httpd.conf.mustache
@@ -210,7 +210,7 @@ LogLevel warn
     object-src 'none'; \
     frame-src 'self'; \
     child-src 'self'; \
-    img-src 'self' data: avatars.githubusercontent.com badges.gitter.im fonts.gstatic.com kiwiirc.com raw.githubusercontent.com; \
+    img-src 'self' data: blob: avatars.githubusercontent.com badges.gitter.im fonts.gstatic.com kiwiirc.com raw.githubusercontent.com; \
     font-src 'self' data: fonts.googleapis.com fonts.gstatic.com; \
     connect-src 'self' fonts.gstatic.com fonts.googleapis.com; \
     manifest-src 'self'; \


### PR DESCRIPTION
Highchart export requires it

Signed-off-by: Ihor Aleksandrychiev <ihor.aleksandrychiev@northern.tech>
(cherry picked from commit 4070af34edfecd70621b9a214826f4e09bc69de8)