### PR TITLE
CFE-4450: Allow passing environment variables to package managers

### DIFF
--- a/modules/packages/vendored/apt_get.mustache
+++ b/modules/packages/vendored/apt_get.mustache
@@ -295,8 +295,17 @@ def package_arguments_builder(is_apt_install):
         elif line.startswith("options="):
             global apt_get_options
             option =  line.split("=", 1)[1].rstrip()
+
             if option:
-              apt_get_options.append(option)
+                if option.startswith("env:"):
+                    env_option = option.split(":", 1)[1]
+                    env_var = env_option.split("=", 1)
+                    if len(env_var) == 2:
+                        env_name = env_var[0]
+                        env_value = env_var[1]
+                        os.environ[env_name] = env_value
+                else:
+                    apt_get_options.append(option)
 
     if name:
         args.extend(one_package_argument(name, arch, version, is_apt_install))

--- a/modules/packages/vendored/yum.mustache
+++ b/modules/packages/vendored/yum.mustache
@@ -115,6 +115,13 @@ def list_updates(online):
                 yum_options.append(option)
             elif option.startswith("enablerepo=") or option.startswith("disablerepo="):
                 yum_options.append("--" + option)
+            elif option.startswith("env:"):
+                env_option = option.split(":", 1)[1]
+                env_var = env_option.split("=", 1)
+                if len(env_var) == 2:
+                    env_name = env_var[0]
+                    env_value = env_var[1]
+                    os.environ[env_name] = env_value
 
     online_flag = []
     if not online:
@@ -229,6 +236,13 @@ def package_arguments_builder(is_yum_install):
                 yum_options.append(option)
             elif option.startswith("enablerepo=") or option.startswith("disablerepo="):
                 yum_options.append("--" + option)
+            elif option.startswith("env:"):
+                env_option = option.split(":", 1)[1]
+                env_var = env_option.split("=", 1)
+                if len(env_var) == 2:
+                    env_name = env_var[0]
+                    env_value = env_var[1]
+                    os.environ[env_name] = env_value
         if line.startswith("Name="):
             if name:
                 # Each new "Name=" triggers a new entry.

--- a/modules/packages/vendored/zypper.mustache
+++ b/modules/packages/vendored/zypper.mustache
@@ -275,6 +275,21 @@ def package_arguments_builder(is_zypper_install):
         elif line.startswith("Architecture="):
             arch = line.split("=", 1)[1].rstrip()
 
+        elif line.startswith("options="):
+            global zypper_options
+            option =  line.split("=", 1)[1].rstrip()
+
+            if option:
+                if option.startswith("env:"):
+                    env_option = option.split(":", 1)[1]
+                    env_var = env_option.split("=", 1)
+                    if len(env_var) == 2:
+                        env_name = env_var[0]
+                        env_value = env_var[1]
+                        os.environ[env_name] = env_value
+                else:
+                    zypper_options.append(option)
+
     if name:
         single_list, multi_list = one_package_argument(name, arch, version, is_zypper_install)
         single_cmd_args += single_list
@@ -404,6 +419,18 @@ def file_install():
         if line.startswith("File="):
             found = True
             cmd_line.append(line.split("=", 1)[1].rstrip())
+
+        elif line.startswith("options="):
+            global zypper_options
+            option =  line.split("=", 1)[1].rstrip()
+            if option:
+                if option.startswith("env:"):
+                    env_option = option.split(":", 1)[1]
+                    env_var = env_option.split("=", 1)
+                    if len(env_var) == 2:
+                        env_name = env_var[0]
+                        env_value = env_var[1]
+                        os.environ[env_name] = env_value
 
     if not found:
         return 0


### PR DESCRIPTION
Allow passing options to the package managers modules through `env:NAME=VERSION` options.

Taking the easiest path. If it is considered acceptable I'll add a test case and documentation.