### PR TITLE
CFE-4452: Made system_log_level configurable via Augments

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -1408,6 +1408,26 @@ Example definition in augments file:
 
 * Added in 3.22.0, 3.21.2
 
+### Configure the minimum log level for system log
+
+When `default:def.control_common_system_log_level` is defined the value controls the minimum log level required for log messages to go to the system log (e.g. syslog, Windows Event Log).
+
+Example definition in augments file:
+
+```json
+{
+  "variables": {
+    "default:def.control_common_system_log_level": {
+      "value": "info",
+      "comment": "We want syslog to recieve messages tha are level info and above."
+    }
+  }
+}
+```
+**History:**
+
+* Added in 3.25.0
+
 ### Configure users allowed to initiate execution via cf-runagent
 
 cf-serverd only allows specified users to request unscheduled execution remotely via cf-runagent.

--- a/controls/def.cf
+++ b/controls/def.cf
@@ -275,6 +275,8 @@ bundle common def
         int => "30",
         if => not( isvariable( "control_agent_maxconnections" ) );
 
+      # Common Controls
+
       # Because in some versions of cfengine bundlesequence in body common
       # control does not support does not support iteration over data containers
       # we must first pick out the bundles into a shallow container that we can
@@ -392,6 +394,11 @@ bundle common def
                            " it's value will be used for allowtlsversion in body server",
                            " control. Else the binary default will be used.");
 
+      "control_common_system_log_level_defined" -> { "CFE-4452" }
+        expression => isvariable( "default:def.control_common_system_log_level" ),
+        comment => concat( "The minimum log level required for log messages to go to the",
+                           " system log (e.g. syslog or Windows Event Log).",
+                           " (critical|error|warning|notice|info)" );
   vars:
 
     debian::

--- a/controls/update_def.cf.in
+++ b/controls/update_def.cf.in
@@ -5,6 +5,12 @@ bundle common update_def
     any::
       "sys_policy_hub_port_exists" expression => isvariable("sys.policy_hub_port");
 
+      "control_common_system_log_level_defined" -> { "CFE-4452" }
+        expression => isvariable( "default:def.control_common_system_log_level" ),
+        comment => concat( "The minimum log level required for log messages to go to the",
+                           " system log (e.g. syslog or Windows Event Log).",
+                           " (critical|error|warning|notice|info)" );
+
   vars:
       "hub_binary_version" -> { "ENT-10664" }
         data => data_regextract(

--- a/promises.cf.in
+++ b/promises.cf.in
@@ -139,6 +139,8 @@ body common control
     control_common_tls_ciphers_defined::
         tls_ciphers => "$(default:def.control_common_tls_ciphers)"; # See also: allowciphers in body server control
 
+    control_common_system_log_level_defined::
+        system_log_level => "$(default:def.control_common_system_log_level)";
 }
 
 bundle common inventory

--- a/standalone_self_upgrade.cf.in
+++ b/standalone_self_upgrade.cf.in
@@ -42,6 +42,13 @@ bundle common def_standalone_self_upgrade
         comment => concat( "If default:def.control_common_tls_ciphers is defined then",
                            " its value will be used for the set of tls ciphers allowed",
                            " for outbound connections. Else the binary default will be used.");
+
+      "control_common_system_log_level_defined" -> { "CFE-4452" }
+        expression => isvariable( "default:def.control_common_system_log_level" ),
+        comment => concat( "The minimum log level required for log messages to go to the",
+                           " system log (e.g. syslog or Windows Event Log).",
+                           " (critical|error|warning|notice|info)" );
+
 }
 body agent control
 # @brief Agent controls for standalone self upgrade
@@ -874,6 +881,9 @@ body common control
 
     (debian|redhat)::
       package_module => $(package_module_knowledge.platform_default);
+
+    control_common_system_log_level_defined::
+        system_log_level => "$(default:def.control_common_system_log_level)";
 }
 
 body depth_search u_recurse_basedir(d)

--- a/update.cf.in
+++ b/update.cf.in
@@ -40,6 +40,9 @@ body common control
 
     control_common_tls_ciphers_defined::
         tls_ciphers => "$(default:def.control_common_tls_ciphers)"; # See also: allowciphers in body server control
+
+    control_common_system_log_level_defined::
+        system_log_level => "$(default:def.control_common_system_log_level)";
 }
 
 #############################################################################


### PR DESCRIPTION
This change exposes the variable default:def.control_common_system_log_level to
be configurable via Augments. This way you can adjust the level of logs that go
to the system log without having to modify vendored policy.

Ticket: CFE-4452
Changelog: Title