### PR TITLE
CFE-4453: Added missing trailing slash to .no-distrib directory in MPF

### DIFF
--- a/controls/cf_serverd.cf
+++ b/controls/cf_serverd.cf
@@ -105,7 +105,7 @@ bundle server mpf_default_access_rules()
       if => isdir( "$(def.dir_masterfiles)/" ),
       admit => { @(def.acl_derived) };
 
-      "$(def.dir_masterfiles)/.no-distrib" -> { "ENT-8079" }
+      "$(def.dir_masterfiles)/.no-distrib/" -> { "ENT-8079" }
       handle => "prevent_distribution_of_top_level_dot_no_distrib",
       deny => { "0.0.0.0/0" };
 


### PR DESCRIPTION
I believe this has no functional difference, but it's an important hint at least
to the policy reader that it is a directory.

Unlike other access rules I left off the condition to only add the access rule
if the directory exists so that if it is created there will not be a window of
time for which clients would be able to get files from the directory.

If the directory does not exist there are info level logs that are emitted, but
that seems acceptable since we do not log info from cf-serverd by default. There
is apparently no issue making an access promise for a directory that does not
exist, I see it listed in the cf-serverd access summary from verbose logging.

Ticket: CFE-4453
Changelog: None