### PR TITLE
CFE-2528: Changed the default for allowallconnects

### DIFF
--- a/controls/def.cf
+++ b/controls/def.cf
@@ -122,7 +122,7 @@ bundle common def
     any::
 
       "control_server_allowallconnects" -> { "ENT-10212" }
-        slist => { "127.0.0.1" , "::1", @(def.acl) },
+        slist => {},
         if => not( isvariable( "control_server_allowallconnects" ) ),
         comment => concat( "We want to define the default setting for",
                            " allowallconnects in body server control if not",


### PR DESCRIPTION
allowallconnects should be for allowing parallel connections.
Let's see if this is really necessary, since cf-agent should
reuse an open connection and this shouldn't be needed, at least
by default.