### PR TITLE
ENT-12531: Allowed images from raw.github.com (3.21)

### DIFF
--- a/cfe_internal/enterprise/templates/httpd.conf.mustache
+++ b/cfe_internal/enterprise/templates/httpd.conf.mustache
@@ -210,7 +210,7 @@ LogLevel warn
     object-src 'none'; \
     frame-src 'self'; \
     child-src 'self'; \
-    img-src 'self' data: blob: avatars.githubusercontent.com badges.gitter.im fonts.gstatic.com kiwiirc.com raw.githubusercontent.com; \
+    img-src 'self' data: blob: avatars.githubusercontent.com badges.gitter.im fonts.gstatic.com kiwiirc.com raw.githubusercontent.com raw.github.com; \
     font-src 'self' data: fonts.googleapis.com fonts.gstatic.com; \
     connect-src 'self' fonts.gstatic.com fonts.googleapis.com; \
     manifest-src 'self'; \


### PR DESCRIPTION
README files in build module repos often contain images, sometimes those images
are served from raw.github.com. This change allows those images to be displayed
within the Build app in Mission Portal.

Ticket: ENT-12531
Changelog: Title
(cherry picked from commit 7b77602ce9fe17d763b596cfa298ed6551b5beb5)

Merge together: https://github.com/cfengine/buildscripts/pull/1564