### PR TITLE
Fixed location of Mission Portal application logs for log_dir cleanup

### DIFF
--- a/controls/def.cf
+++ b/controls/def.cf
@@ -565,7 +565,8 @@ bundle common def
       "log_dir[package_logs]" string => "$(const.dirsep)cfengine_package_logs";
 
     enterprise.am_policy_hub::
-      "log_dir[application]" string => "$(sys.workdir)/httpd/htdocs/application/logs";
+      "log_dir[mission_portal]" string => "$(sys.workdir)/httpd/logs";
+      "log_dir[application]" string => "$(sys.workdir)/httpd/logs/application";
 
     any::
       "cfe_log_dirs" slist => getvalues( log_dir );


### PR DESCRIPTION
This probably should have changed when mission-portal was adjusted: https://github.com/cfengine/mission-portal/pull/312

Ticket: ENT-12556
Changelog: title
