### PR TITLE
Fixed location of Mission Portal application logs for log_dir cleanup (3.24)

### DIFF
--- a/controls/def.cf
+++ b/controls/def.cf
@@ -558,7 +558,8 @@ bundle common def
       "log_dir[package_logs]" string => "$(const.dirsep)cfengine_package_logs";
 
     enterprise.am_policy_hub::
-      "log_dir[application]" string => "$(sys.workdir)/httpd/htdocs/application/logs";
+      "log_dir[mission_portal]" string => "$(sys.workdir)/httpd/logs";
+      "log_dir[application]" string => "$(sys.workdir)/httpd/logs/application";
 
     any::
       "cfe_log_dirs" slist => getvalues( log_dir );


### PR DESCRIPTION
This probably should have changed when mission-portal was adjusted: https://github.com/cfengine/mission-portal/pull/312

Also changed from httpd/logs/application to httpd/logs since several other logs are in that directory as well.

Ticket: ENT-12556
Changelog: title
(cherry picked from commit c1078c1a3b98020a08e9696e8314238328736c21)
