### PR TITLE
ENT-12658: Inhibit management of share config.php file when mpf_disable_mission_portal_docroot_sync_from_share_gui is defined

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Prepare Artifacts for Uploading
         run: tar -zcvf /tmp/workspace.tgz ./ && mv /tmp/workspace.tgz ./
       - name: Upload The Workspace as Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: workspace
           path: workspace.tgz

--- a/cfe_internal/enterprise/CFE_hub_specific.cf
+++ b/cfe_internal/enterprise/CFE_hub_specific.cf
@@ -115,19 +115,21 @@ bundle agent update_cli_rest_server_url_config
     "regex_test_pattern" string => ".*localhost:$(cfe_internal_hub_vars.https_port).*";
 
   files:
-   "$(mp_share_config_file)"
-      edit_line => change_cli_rest_server_url_port,
-      if => and(
-        fileexists("$(mp_share_config_file)"),
-        islessthan(countlinesmatching("$(regex_test_pattern)", "$(mp_share_config_file)"), 1)
-        );
+    !mpf_disable_mission_portal_docroot_sync_from_share_gui::
+      "$(mp_share_config_file)"
+         edit_line => change_cli_rest_server_url_port,
+         if => and(
+           fileexists("$(mp_share_config_file)"),
+           islessthan(countlinesmatching("$(regex_test_pattern)", "$(mp_share_config_file)"), 1)
+           );
 
-    "$(mp_config_file)"
-      edit_line => change_cli_rest_server_url_port,
-      if => and(
-        fileexists("$(mp_config_file)"),
-        islessthan(countlinesmatching("$(regex_test_pattern)", "$(mp_config_file)"), 1)
-        );
+    any::
+      "$(mp_config_file)"
+        edit_line => change_cli_rest_server_url_port,
+        if => and(
+          fileexists("$(mp_config_file)"),
+          islessthan(countlinesmatching("$(regex_test_pattern)", "$(mp_config_file)"), 1)
+          );
 }
 
 bundle edit_line change_cli_rest_server_url_port


### PR DESCRIPTION
In preparation for possibly removing the share/GUI folder entirely.

Ticket: ENT-12658
Changelog: title

