### PR TITLE
Fixed some ArchLinux missing paths

### DIFF
--- a/lib/paths.cf
+++ b/lib/paths.cf
@@ -181,7 +181,7 @@ bundle common paths
       "path[tr]"       string => "/usr/bin/tr";
       "path[yum]"      string => "/usr/bin/yum";
 
-    archlinux::
+    archlinux|manjaro::
 
       "path[awk]"               string => "/usr/bin/awk";
       "path[bc]"                string => "/usr/bin/bc";


### PR DESCRIPTION
Simple PR to add a few missing paths for basic system commands for ArchLinux