### PR TITLE
Moved standard library paths bundle from common to agent type to simplify SELinux policy

### DIFF
--- a/cfe_internal/enterprise/CFE_hub_specific.cf
+++ b/cfe_internal/enterprise/CFE_hub_specific.cf
@@ -15,7 +15,7 @@
 ##################################################################
 
 @if minimum_version(3.12.0)
-bundle common cfe_hub_specific_file_control
+bundle agent cfe_hub_specific_file_control
 {
   vars:
     "inputs" slist => { "$(this.promise_dirname)/federation/federation.cf" };
@@ -27,7 +27,7 @@ body file control
 }
 @endif
 
-bundle common cfe_internal_hub_vars
+bundle agent cfe_internal_hub_vars
 # @brief Set hub specific variables
 {
   classes:

--- a/inventory/any.cf
+++ b/inventory/any.cf
@@ -1,4 +1,4 @@
-bundle common inventory_any
+bundle agent inventory_any
 # @brief Do inventory for any OS
 #
 # This common bundle is for any OS work not handled by specific
@@ -593,7 +593,7 @@ bundle agent cfe_autorun_inventory_cpuinfo
       "$(const.t) CPU physical cores: $(cpuinfo_physical_cores)";
 }
 
-bundle common cfe_autorun_inventory_aws
+bundle agent cfe_autorun_inventory_aws
 # @brief inventory AWS EC2 instances
 #
 # Provides:

--- a/lib/paths.cf
+++ b/lib/paths.cf
@@ -1,6 +1,6 @@
 # Paths bundle (used by other bodies)
 
-bundle common paths
+bundle agent paths
 # @brief Defines an array `path` with common paths to standard binaries and
 # directories as well as classes for defined and existing paths.
 #


### PR DESCRIPTION
This should simplify selinux policy where we want the agent to have broad access but other components like serverd, execd, hub to have more limited access.

The paths bundle checks for the existence of many commands and this operation can cause SELinux AVCs.

Ticket: ENT-12954
Changelog: title
