### PR TITLE
ENT-12990: Removed duplicate well known paths for ls and lsof on opensuse

### DIFF
--- a/lib/paths.cf
+++ b/lib/paths.cf
@@ -533,8 +533,6 @@ bundle common paths
       "path[logger]"        string => "/usr/bin/logger";
 
     opensuse::
-      "path[ls]"        string => "/usr/bin/ls";
-      "path[lsof]"      string => "/usr/bin/lsof";
       "path[awk]"       string => "/usr/bin/awk";
       "path[cat]"       string => "/usr/bin/cat";
       "path[cksum]"     string => "/usr/bin/cksum";


### PR DESCRIPTION
Ticket: ENT-12990