### PR TITLE
CFE-4543: Made protocol_version configurable via Augments (3.24)

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -1306,6 +1306,38 @@ Example definition in augments file:
 }
 ```
 
+### Specify the CFEngine protocol version to use
+
+By default CFEngine will negotiate the newest protocol version available. Configuring `protocol_version` will restrict the protocol to the specified version.
+
+```json
+{
+  "variables": {
+    "default:def.control_common_protocol_version": {
+      "value": "filestream"
+      }
+  }
+}
+```
+
+**Notes:**
+
+- Valid values for `protocol_version` can be extracted from the syntax-description output of `cf-promises`.
+
+  For example:
+
+  ```command
+  cf-promises --syntax-description=json | jq -r '.bodyTypes.common.attributes.protocol_version.range'
+  ```
+
+  ```output
+  (1|classic|2|tls|3|cookie|4|filestream|latest)
+  ```
+
+**History:**
+
+- Added in CFEngine 3.27.0, 3.24.3
+
 ### Configure the ciphers used by cf-serverd
 
 When `default:def.control_server_allowciphers` is defined `cf-serverd` will use the ciphers specified instead of the binary defaults.

--- a/controls/def.cf
+++ b/controls/def.cf
@@ -392,6 +392,13 @@ bundle common def
                            " it's value will be used for allowtlsversion in body server",
                            " control. Else the binary default will be used.");
 
+      "control_common_protocol_version_defined" -> { "CFE-4543" }
+        expression => isvariable( "default:def.control_common_protocol_version" ),
+        comment => concat( "Defines the protocol version to use for all outgoing",
+                           " connections.",
+                           # It's challenging to keep this aligned with the core agent code
+                           # cf-promises --syntax-description=json | jq -r '.bodyTypes.common.attributes.protocol_version.range'
+                           " (1|classic|2|tls|3|cookie|4|filestream|latest)" );
   vars:
 
     debian::

--- a/controls/update_def.cf.in
+++ b/controls/update_def.cf.in
@@ -5,6 +5,14 @@ bundle common update_def
     any::
       "sys_policy_hub_port_exists" expression => isvariable("sys.policy_hub_port");
 
+      "control_common_protocol_version_defined" -> { "CFE-4543" }
+        expression => isvariable( "default:def.control_common_protocol_version" ),
+        comment => concat( "Defines the protocol version to use for all outgoing",
+                           " connections.",
+                           # It's challenging to keep this aligned with the core agent code
+                           # cf-promises --syntax-description=json | jq -r '.bodyTypes.common.attributes.protocol_version.range'
+                           " (1|classic|2|tls|3|cookie|4|filestream|latest)" );
+
   vars:
       "hub_binary_version" -> { "ENT-10664" }
         data => data_regextract(

--- a/promises.cf.in
+++ b/promises.cf.in
@@ -139,6 +139,8 @@ body common control
     control_common_tls_ciphers_defined::
         tls_ciphers => "$(default:def.control_common_tls_ciphers)"; # See also: allowciphers in body server control
 
+    control_common_protocol_version_defined::
+      protocol_version => "$(default:def.control_common_protocol_version)";
 }
 
 bundle common inventory

--- a/standalone_self_upgrade.cf.in
+++ b/standalone_self_upgrade.cf.in
@@ -42,6 +42,14 @@ bundle common def_standalone_self_upgrade
         comment => concat( "If default:def.control_common_tls_ciphers is defined then",
                            " its value will be used for the set of tls ciphers allowed",
                            " for outbound connections. Else the binary default will be used.");
+
+      "control_common_protocol_version_defined" -> { "CFE-4543" }
+        expression => isvariable( "default:def.control_common_protocol_version" ),
+        comment => concat( "Defines the protocol version to use for all outgoing",
+                           " connections.",
+                           # It's challenging to keep this aligned with the core agent code
+                           # cf-promises --syntax-description=json | jq -r '.bodyTypes.common.attributes.protocol_version.range'
+                           " (1|classic|2|tls|3|cookie|4|filestream|latest)" );
 }
 body agent control
 # @brief Agent controls for standalone self upgrade
@@ -874,6 +882,9 @@ body common control
 
     (debian|redhat)::
       package_module => $(package_module_knowledge.platform_default);
+
+    control_common_protocol_version_defined::
+        protocol_version => "$(default:def.control_common_protocol_version)";
 }
 
 body depth_search u_recurse_basedir(d)

--- a/update.cf.in
+++ b/update.cf.in
@@ -40,6 +40,9 @@ body common control
 
     control_common_tls_ciphers_defined::
         tls_ciphers => "$(default:def.control_common_tls_ciphers)"; # See also: allowciphers in body server control
+
+    control_common_protocol_version_defined::
+        protocol_version => "$(default:def.control_common_protocol_version)";
 }
 
 #############################################################################


### PR DESCRIPTION
This change implements easy configuration of `protocol_version` in body common control for the standard MPF entries.

Ticket: CFE-4543