### PR TITLE
Added exception for Ubuntu-24 to accept our test gpg key which is "weak" (rsa1024) (3.24)

### DIFF
--- a/tests/acceptance/17_packages/01_init/unsafe/timed/001-prepare-repositories.cf
+++ b/tests/acceptance/17_packages/01_init/unsafe/timed/001-prepare-repositories.cf
@@ -143,26 +143,28 @@ bundle agent signing_keys
 bundle agent apt_config
 {
   classes:
-    !(ubuntu_10|debian_6)::
+    !(ubuntu_10|debian_6|ubuntu_24)::
       "apt_config_ok" expression => "any",
         scope => "namespace";
 
   files:
+    ubuntu_24::
+      "/etc/apt/apt.conf.d/accept-older-pubkeys"
+        comment => "key in 17_packages/resources/gpg use rsa1024 which is not supported on Ubuntu-24.",
+        create => "true",
+        content => 'APT::Key::Assert-Pubkey-Algo ">=rsa1024";',
+        edit_defaults => empty,
+        classes => if_successful("apt_config_ok");
+
     ubuntu_10|debian_6::
       # Work around bug: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=715494
       # Apt cache does not behave correctly if installing more than one package
       # per second.
       "/etc/apt/apt.conf.d/nocache"
         create => "true",
-        edit_line => no_apt_cache,
+        content => 'Dir::Cache::pkgcache "";',
         edit_defaults => empty,
         classes => if_successful("apt_config_ok");
-}
-
-bundle edit_line no_apt_cache
-{
-  insert_lines:
-      'Dir::Cache::pkgcache "";';
 }
 
 bundle agent dpkg_multiarch


### PR DESCRIPTION
Ticket: ENT-13066
Changelog: none
(cherry picked from commit 03c533399dc85d020a8a1a897cb0382e999ab201)
