### PR TITLE
ENT-13066: Removed edit_defaults attribute that does not have effect with content attribute (3.21)

### DIFF
--- a/tests/acceptance/17_packages/01_init/unsafe/timed/001-prepare-repositories.cf
+++ b/tests/acceptance/17_packages/01_init/unsafe/timed/001-prepare-repositories.cf
@@ -153,7 +153,6 @@ bundle agent apt_config
         comment => "key in 17_packages/resources/gpg use rsa1024 which is not supported on Ubuntu-24.",
         create => "true",
         content => 'APT::Key::Assert-Pubkey-Algo ">=rsa1024";',
-        edit_defaults => empty,
         classes => if_successful("apt_config_ok");
 
     ubuntu_10|debian_6::
@@ -163,7 +162,6 @@ bundle agent apt_config
       "/etc/apt/apt.conf.d/nocache"
         create => "true",
         content => 'Dir::Cache::pkgcache "";',
-        edit_defaults => empty,
         classes => if_successful("apt_config_ok");
 }
 


### PR DESCRIPTION
edit_defaults does not have an effect when the content attribute is in use.