### PR TITLE
ENT-12988: Added dmidecode to well known paths for Red Hat (3.21)

### DIFF
--- a/lib/paths.cf
+++ b/lib/paths.cf
@@ -367,6 +367,7 @@ bundle common paths
       "path[df]"            string => "/bin/df";
       "path[diff]"          string => "/usr/bin/diff";
       "path[dig]"           string => "/usr/bin/dig";
+      "path[dmidecode]"     string => "/usr/sbin/dmidecode";
       "path[dmsetup]"       string => "/usr/sbin/dmsetup";
       "path[domainname]"    string => "/bin/domainname";
       "path[echo]"          string => "/bin/echo";


### PR DESCRIPTION
Ticket: ENT-12988