### PR TITLE
ENT-13150: Fixed cfbs name validation error by downcasing Masterfiles

### DIFF
--- a/cfbs.json
+++ b/cfbs.json
@@ -1,5 +1,5 @@
 {
-  "name": "Masterfiles",
+  "name": "masterfiles",
   "description": "Official CFEngine Masterfiles Policy Framework (MPF)",
   "type": "module",
   "provides": {


### PR DESCRIPTION
Additional validation was added to cfbs and adding Masterfiles by
repository URL was erroring:

  Error in cfbs.json for module 'Masterfiles': Module name contains illegal \
  characters (only lowercase ASCII alphanumeric characters are legal)

Ticket: ENT-13150