### PR TITLE
Stopped enforcing permission management of $(sys.workdir)/share/GUI

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -1945,6 +1945,26 @@ Primarily for developer convenience, this setting allows you to easily disable t
 
 * Added in CFEngine 3.12.0
 
+### Enable permission enforcement for files under WORKDIR/share/GUI
+
+The MPF used to actively enforce permissions of files and directories under `$(sys.workdir)/share/GUI`, to re-enable this active permission enforcement define the class `default:mpf_enforce_workdir_share_gui_perms`.
+
+For example, to define it via Augments for CFEngine Enterprise Hubs:
+
+```json
+{
+  "classes": {
+    "default:mpf_enforce_workdir_share_gui_perms": {
+      "class_expressions": [
+        "enterprise_edition.am_policy_hub::"
+      ]
+    }
+  }
+}
+```
+
+* Added in CFEngine 3.27.0
+
 ### Configure Enterprise Mission Portal Apache SSLProtocol
 
 This directive can be used to control which versions of the SSL/TLS protocol will be accepted in new connections.

--- a/cfe_internal/enterprise/CFE_knowledge.cf
+++ b/cfe_internal/enterprise/CFE_knowledge.cf
@@ -346,12 +346,13 @@ bundle agent cfe_internal_setup_knowledge
                     $(def.cf_apache_user) then users will not be able to change
                     ldap settings.";
 
-
       "$(sys.workdir)/share/GUI/."
+        handle => "cfe_internal_setup_knowledge_files_workdir_share_gui_perms",
         perms => mog("0400", "root", "root" ),
         depth_search => recurse_basedir("inf"),
-        comment => "No Mission Portal code in share needs to be accessed by
-                    anyone";
+        comment => concat( "No Mission Portal code in share needs to be accessed",
+                           " by anyone" ),
+        if => "mpf_enforce_workdir_share_gui_perms";
 
       "$(sys.workdir)/." -> { "ENT-3299" }
         perms => mog("755", "root", "root"),


### PR DESCRIPTION
This does not apply to CFEngine community, but in CFEngine Enterprise there are
many files in this directory. Actively enforcing just permissions on these files
has been observed to take 3-10 seconds. Removing this enforcement improves
efficiency at the expense of little risk.

Ticket: ENT-13171