### PR TITLE
ENT-13172: Stopped automatic mirroring of WORKDIR/share/GUI to Mission Portal docroot

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -1925,16 +1925,17 @@ memory related probes on policy servers:
 
 * Added in 3.10.2, 3.11.0
 
-### Configure Enterprise Mission Portal Docroot
+### Configure Enterprise Mission Portal Docroot sync
 
-Primarily for developer convenience, this setting allows you to easily disable the enforcement that the webapp consists of the packaged files in the docroot used for Mission Portal.
+This setting allows you to enable the enforcement that the Mission Portal web
+application docroot consists of only packaged files.
 
 ```json
 {
   "classes": {
-    "default:mpf_disable_mission_portal_docroot_sync_from_share_gui": {
-      "regular_expressions": [
-        "any"
+    "default:mpf_enable_mission_portal_docroot_sync_from_share_gui": {
+      "class_expressions": [
+        "enterprise_edition.am_policy_hub::"
       ]
     }
   }
@@ -1943,7 +1944,15 @@ Primarily for developer convenience, this setting allows you to easily disable t
 
 **History:**
 
-* Added in CFEngine 3.12.0
+* Added `default:mpf_disable_mission_portal_docroot_sync_from_share_gui` to
+  explicitly disable synchronization of the active docroot from share/GUI in
+  CFEngine 3.12.0
+
+* Removed `default:mpf_enable_mission_portal_docroot_sync_from_share_gui` in
+  CFEngine 3.27.0
+
+* Added `default:mpf_enable_mission_portal_docroot_sync_from_share_gui` in
+  CFEngine 3.27.0
 
 ### Configure Enterprise Mission Portal Apache SSLProtocol
 

--- a/cfe_internal/enterprise/CFE_knowledge.cf
+++ b/cfe_internal/enterprise/CFE_knowledge.cf
@@ -42,12 +42,12 @@ bundle agent cfe_internal_setup_knowledge
 
   files:
 
-    !mpf_disable_mission_portal_docroot_sync_from_share_gui::
-      "$(cfe_internal_hub_vars.docroot)"
-      comment => "Copy the basic knowledge base configuration from the installation to doc root",
-      handle => "cfe_internal_setup_knowledge_files_doc_root_1",
-      copy_from => no_backup_cp_compare("$(sys.workdir)/share/GUI", "binary"),
-      depth_search => recurse("inf");
+    mpf_enable_mission_portal_docroot_sync_from_share_gui::
+      "$(cfe_internal_hub_vars.docroot)" -> { "ENT-13172" }
+        comment => "Copy the basic knowledge base configuration from the installation to doc root",
+        handle => "cfe_internal_setup_knowledge_files_doc_root_1",
+        copy_from => no_backup_cp_compare("$(sys.workdir)/share/GUI", "binary"),
+        depth_search => recurse("inf");
 
     any::
 
@@ -370,6 +370,14 @@ bundle agent cfe_internal_setup_knowledge
                     web-server, then Mission Portal users will be unable to
                     upload custom action scripts.";
 
+  reports:
+
+    mpf_disable_mission_portal_docroot_sync_from_share_gui::
+      "$(with)" -> { "ENT-13172" }
+        with => concat( "The class 'default:mpf_disable_mission_portal_docroot_sync_from_share_gui'",
+                        " is no longer necessary. Synchronizing files from share/GUI to Mission",
+                        " Portal is now done only if explicitly requested by defining the class",
+                        " 'default:mpf_enable_mission_portal_docroot_sync_from_share_gui'" );
 }
 
 bundle agent cfe_internal_permissions


### PR DESCRIPTION
There are very many files under share/GUI. Mirroring these files has been
observed to take multiple 10s of seconds. Instead of actively mirroring by
default, now the files will only be mirrored when the class
default:mpf_enable_mission_portal_docroot_sync_from_share_gui is defined.

Ticket: ENT-13172