### PR TITLE
ENT-13210: Prevented nfs server inventory from doing unnecessary extra work (3.24)

### DIFF
--- a/inventory/linux.cf
+++ b/inventory/linux.cf
@@ -41,22 +41,18 @@ bundle common inventory_linux
         if => strcmp("$(proc_routes[$(routeidx)][1])", "00000000");
 
     linux::
-      "nfs_servers" -> { "CFE-3259" }
-        comment => "NFS servers (to list hosts impacted by NFS outages)",
-        slist => maplist( regex_replace( $(this) , ":.*", "", "g"),
-                          # NFS server is before the colon (:), that's all we want
-                          # e.g., nfs.example.com:/vol/homedir/user1 /home/user1 ...
-                          #       ^^^^^^^^^^^^^^^
-                          grep( ".* nfs .*",
-                                readstringlist("/proc/mounts", "", "\n", inf, inf)
-                              )
-                        ),
-        if => fileexists( "/proc/mounts" );
+      "mounts" string => "/proc/mounts";
 
+      "nfs_mounts"
+        slist => grep( ".* nfs .*",
+                       readstringlist("$(mounts)", "", "\n", inf, inf) ),
+        if => and( not( isvariable( "$(this.promiser)" ) ),
+                   fileexists( "$(mounts)" ) );
 
-        "nfs_server[$(nfs_servers)]"
-          string => "$(nfs_servers)",
-          meta => { "inventory", "attribute_name=NFS Server" };
+      "nfs_server[$(nfs_mounts)]" -> { "CFE-3259", "ENT-13210" }
+        string => regex_replace( "$(nfs_mounts)", ":.*", "", "g" ),
+        meta => { "inventory", "attribute_name=NFS Server" },
+        if => not( isvariable( "$(this.promiser)" ) );
 
 
   classes:


### PR DESCRIPTION
We have received reports of slow policy execution on hosts with many
nfs mounts (hundreds). Part of this expense has to do with the fact that the
promise re-defined the itself on each pass of the policy.

This change prevents that additional un-necessary processing and re-definition
by restricting the promise only to when inventory_linux.nfs_servers is not
already defined. This single change reduced processing time in one case by ~70
seconds (from ~90 seconds to ~20 seconds).

Ticket: ENT-13210
Changelog: Title