### PR TITLE
ENT-13243: Stopped enforcing permissions of public docroot scripts

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -1954,6 +1954,28 @@ application docroot consists of only packaged files.
 * Added `default:mpf_enable_mission_portal_docroot_sync_from_share_gui` in
   CFEngine 3.27.0
 
+### Enable permission enforcement for files under `WORKDIR/httpd/htdocs/public/scripts`
+
+If the class `default:mpf_enable_mission_portal_public_docroot_scripts_not_dir_perms` is defined then permissions of non-directories will be enforced from policy.
+
+```json
+{
+  "classes": {
+    "default:mpf_enable_mission_portal_public_docroot_scripts_not_dir_perms": {
+      "class_expressions": [
+        "enterprise_edition.am_policy_hub::"
+      ]
+    }
+  }
+}
+```
+
+**History:**
+
+* Stopped enforcing permissions for `WORKDIR/httpd/htdocs/public/scripts` by default in CFEngine 3.27.0.
+
+* Added class `default:mpf_enable_mission_portal_public_docroot_scripts_not_dir_perms` to enable enforcement of permissions for this directory in CFEngine 3.27.0.
+
 ### Enable permission enforcement for files under WORKDIR/share/GUI
 
 The MPF used to actively enforce permissions of files and directories under `$(sys.workdir)/share/GUI`, to re-enable this active permission enforcement define the class `default:mpf_enforce_workdir_share_gui_perms`.

--- a/cfe_internal/enterprise/CFE_knowledge.cf
+++ b/cfe_internal/enterprise/CFE_knowledge.cf
@@ -141,13 +141,14 @@ bundle agent cfe_internal_setup_knowledge
       create => "true",
       perms => mog("0570", "root", $(def.cf_apache_group) );
 
-      "$(cfe_internal_hub_vars.public_docroot)/scripts/." -> { "CFE-951" }
+      "$(cfe_internal_hub_vars.public_docroot)/scripts/." -> { "CFE-951", "ENT-13243" }
         comment => "Ensure permissions for $(cfe_internal_hub_vars.public_docroot)/scripts",
         handle => "cfe_internal_setup_knowledge_files_doc_root_scripts_not_dir",
         create => "true",
         file_select => not_dir,
         depth_search => recurse_basedir("inf"),
-        perms => mog("0440", "root", $(def.cf_apache_group) );
+        perms => mog("0440", "root", $(def.cf_apache_group) ),
+        if => "mpf_enable_mission_portal_public_docroot_scripts_not_dir_perms";
 
       "$(cfe_internal_hub_vars.docroot)/static/." -> { "CFE-951" }
       handle => "cfe_internal_setup_knowledge_files_doc_root_static_dir",


### PR DESCRIPTION
This change stops enforcing permissions of files in the scripts subdirectory of
the public docroot. The volume of files in this directory do not make it
sensible to check permissions during each agent execution.

To improve performance of policy runs on hubs this specific enforcement is
skipped unless a class is set. These files permission should be fully handled by
the package.

Ticket: ENT-13243