### PR TITLE
inventory/linux: Use Python script to check version

### DIFF
--- a/inventory/linux.cf
+++ b/inventory/linux.cf
@@ -75,8 +75,8 @@ bundle common inventory_linux
                            " acceptable ( 3.x or 2.4 or greater ) for package",
                            " modules. We use this guard to prevent errors",
                            " related to missing python modules."),
-        expression => returnszero("$(sys.bindir)/cfengine-selected-python -V 2>&1 | grep ^Python | cut -d' ' -f 2 | ( IFS=. read v1 v2 v3 ; [ $v1 -ge 3 ] || [ $v1 -eq 2 -a $v2 -ge 4 ] )",
-                                  useshell);
+        expression => returnszero("$(sys.bindir)/cfengine-selected-python -c 'import sys; exit(sys.version_info < (2, 4))'",
+                                  noshell);
 }
 
 bundle monitor measure_entropy_available


### PR DESCRIPTION
Get rid of shells and other command and use Python itself for version check.
Get major/minor via tuple for compatibility with very ancient Python versions (sys.version_info.major etc introduced in 2.7) [1].

[1] https://docs.python.org/2/library/sys.html#sys.version_info