### PR TITLE
Fixed error when rendering mustache template on RHEL 10

### DIFF
--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -245,7 +245,7 @@ bundle agent semanage_installed
                   warn or fix based.";
     debian_6|debian_7|debian_8|ubuntu_12|ubuntu_14|ubuntu_16|rhel_5::
       "semanage_package" string => "policycoreutils";
-    debian_9|debian_10|ubuntu_18|redhat_8|centos_8|redhat_9|rocky_9::
+    debian_9|debian_10|ubuntu_18|redhat_8|centos_8|redhat_9|redhat_10|rocky_9::
       "semanage_package" string => "policycoreutils-python-utils";
     redhat_6|centos_6|redhat_7|centos_7::
       "semanage_package" string => "policycoreutils-python";


### PR DESCRIPTION
Fixed error rendering
`/opt/cfengine/federation/cfapache/setup-status.json`:
```
Error: Unable to find a match: $(semanage_package)
```
on Red Hat 10.

Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
