### PR TITLE
ENT-13667: Fixed bad regex in packages promise method for pip (3.24.x)

### DIFF
--- a/lib/packages.cf
+++ b/lib/packages.cf
@@ -414,9 +414,9 @@ bundle common pip_knowledge
   vars:
       "call_pip" string => "$(paths.path[pip])";
 
-      "pip_list_name_regex"    string => "^([[:alnum:]-_]+)\s\([\d.]+\)";
-      "pip_list_version_regex" string => "^[[:alnum:]-_]+\s\(([\d.]+)\)";
-      "pip_installed_regex"    string => "^([[:alnum:]-_]+\s\([\d.]+\))";
+      "pip_list_name_regex"    string => "^([[:alnum:]\-_]+)\s\([\d.]+\)";
+      "pip_list_version_regex" string => "^[[:alnum:]\-_]+\s\(([\d.]+)\)";
+      "pip_installed_regex"    string => "^([[:alnum:]\-_]+\s\([\d.]+\))";
 }
 
 bundle common solaris_knowledge


### PR DESCRIPTION
The packages promise method for pip fails with error:
```
error: Regular expression error: 'invalid range in character class' in expression '^([[:alnum:]-_]+\s\([\d.]+\))' (offset: 13)
```

This is probably a regression after upgrading from PCRE to PCRE2.

The regex engine complains about the hyphen, which has a special meaning
within the square brackets. The bug is easily fixed by escaping the
hyphen.

Ticket: ENT-13667
Changelog: Title
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
(cherry picked from commit 8871aeffd9dd58b755547aac20b1ce3aa530a8dc)

Back ported from https://github.com/cfengine/masterfiles/pull/3099