### PR TITLE
Revert: CFE-4623: Added file sep to directory

### DIFF
--- a/cfe_internal/update/update_policy.cf
+++ b/cfe_internal/update/update_policy.cf
@@ -805,7 +805,7 @@ bundle agent modules_presence
     "_custom_template_dir" string => "$(this.promise_dirname)$(const.dirsep)..$(const.dirsep)..$(const.dirsep)modules$(const.dirsep)mustache$(const.dirsep)";
     "_vendored_paths" slist => findfiles("$(_vendored_dir)*.mustache");
     "_custom_template_paths" slist => findfiles("$(_custom_template_dir)*.mustache"), if => isdir( "$(_custom_template_dir)" );
-    "_package_paths" slist => filter("$(_override_dir)vendored$(const.dirsep)", _package_paths_tmp, "false", "true", 999);
+    "_package_paths" slist => filter("$(_override_dir)vendored", _package_paths_tmp, "false", "true", 999);
 
     windows::
       "_package_paths_tmp" slist => findfiles("$(_override_dir)*");


### PR DESCRIPTION
Reverts https://github.com/cfengine/masterfiles/pull/3114

This reverts commit 3842469153019413f727c6295b9e0a64247b07f6.

Caused valgrind checks to fail
```
  notice: Q: ".../cf-agent" -f /":    error: Maximum recursion level reached at '/var/cfengine/inputs/cfe_internal/update/../../modules/packages/vendored'
Q: ".../cf-agent" -f /":    error: Errors encountered when actuating files promise '/var/cfengine/modules/packages/vendored'
Q: ".../cf-agent" -f /":    error: Method 'modules_presence' failed in some repairs
Q: ".../cf-agent" -f /":    error: Method 'cfe_internal_update_policy_cpv' failed in some repairs
```

[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline)](https://ci.cfengine.com/job/pr-pipeline/13495/)