### PR TITLE
CFE-4452: Made system_log_level configurable via Augments (3.24)

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -1440,6 +1440,26 @@ Example definition in augments file:
 
 * Added in 3.22.0, 3.21.2
 
+### Configure the minimum log level for system log
+
+When `default:def.control_common_system_log_level` is defined the value controls the minimum log level required for log messages to go to the system log (e.g. syslog, Windows Event Log).
+
+Example definition in augments file:
+
+```json
+{
+  "variables": {
+    "default:def.control_common_system_log_level": {
+      "value": "info",
+      "comment": "We want syslog to recieve messages tha are level info and above."
+    }
+  }
+}
+```
+**History:**
+
+* Added in 3.25.0
+
 ### Configure users allowed to initiate execution via cf-runagent
 
 cf-serverd only allows specified users to request unscheduled execution remotely via cf-runagent.

--- a/controls/def.cf
+++ b/controls/def.cf
@@ -275,6 +275,8 @@ bundle common def
         int => "30",
         if => not( isvariable( "control_agent_maxconnections" ) );
 
+      # Common Controls
+
       # Because in some versions of cfengine bundlesequence in body common
       # control does not support iteration over data containers we must first
       # pick out the bundles into a shallow container that we can then get a
@@ -417,6 +419,11 @@ bundle common def
                            # It's challenging to keep this aligned with the core agent code
                            # cf-promises --syntax-description=json | jq -r '.bodyTypes.common.attributes.protocol_version.range'
                            " (1|classic|2|tls|3|cookie|4|filestream|latest)" );
+      "control_common_system_log_level_defined" -> { "CFE-4452" }
+        expression => isvariable( "default:def.control_common_system_log_level" ),
+        comment => concat( "The minimum log level required for log messages to go to the",
+                           " system log (e.g. syslog or Windows Event Log).",
+                           " (critical|error|warning|notice|info)" );
   vars:
 
     debian::

--- a/controls/update_def.cf.in
+++ b/controls/update_def.cf.in
@@ -12,6 +12,11 @@ bundle common update_def
                            # It's challenging to keep this aligned with the core agent code
                            # cf-promises --syntax-description=json | jq -r '.bodyTypes.common.attributes.protocol_version.range'
                            " (1|classic|2|tls|3|cookie|4|filestream|latest)" );
+      "control_common_system_log_level_defined" -> { "CFE-4452" }
+        expression => isvariable( "default:def.control_common_system_log_level" ),
+        comment => concat( "The minimum log level required for log messages to go to the",
+                           " system log (e.g. syslog or Windows Event Log).",
+                           " (critical|error|warning|notice|info)" );
 
   vars:
       "hub_binary_version" -> { "ENT-10664" }

--- a/promises.cf.in
+++ b/promises.cf.in
@@ -141,6 +141,8 @@ body common control
 
     control_common_protocol_version_defined::
       protocol_version => "$(default:def.control_common_protocol_version)";
+    control_common_system_log_level_defined::
+        system_log_level => "$(default:def.control_common_system_log_level)";
 }
 
 bundle common inventory

--- a/standalone_self_upgrade.cf.in
+++ b/standalone_self_upgrade.cf.in
@@ -50,6 +50,12 @@ bundle common def_standalone_self_upgrade
                            # It's challenging to keep this aligned with the core agent code
                            # cf-promises --syntax-description=json | jq -r '.bodyTypes.common.attributes.protocol_version.range'
                            " (1|classic|2|tls|3|cookie|4|filestream|latest)" );
+      "control_common_system_log_level_defined" -> { "CFE-4452" }
+        expression => isvariable( "default:def.control_common_system_log_level" ),
+        comment => concat( "The minimum log level required for log messages to go to the",
+                           " system log (e.g. syslog or Windows Event Log).",
+                           " (critical|error|warning|notice|info)" );
+
 }
 body agent control
 # @brief Agent controls for standalone self upgrade
@@ -909,6 +915,8 @@ body common control
 
     control_common_protocol_version_defined::
         protocol_version => "$(default:def.control_common_protocol_version)";
+    control_common_system_log_level_defined::
+        system_log_level => "$(default:def.control_common_system_log_level)";
 }
 
 body depth_search u_recurse_basedir(d)

--- a/update.cf.in
+++ b/update.cf.in
@@ -43,6 +43,8 @@ body common control
 
     control_common_protocol_version_defined::
         protocol_version => "$(default:def.control_common_protocol_version)";
+    control_common_system_log_level_defined::
+        system_log_level => "$(default:def.control_common_system_log_level)";
 }
 
 #############################################################################


### PR DESCRIPTION
Cherry-pick of #2964 to 3.24.x

This change exposes the variable `default:def.control_common_system_log_level` to be configurable via Augments. This way you can adjust the level of logs that go to the system log without having to modify vendored policy.

Ticket: CFE-4452
Changelog: Title