### PR TITLE
CFE-4648: Add smtpport support to masterfiles

### DIFF
--- a/MPF.md
+++ b/MPF.md
@@ -900,6 +900,27 @@ This setting can be customized via Augments, for example:
 }
 ```
 
+### smtpport
+
+The SMTP port that `cf-execd` should use when connecting to the SMTP server. Defaults to `25`.
+
+This setting can be customized via Augments, for example:
+
+```json
+{
+  "variables": {
+    "default:def.smtpport": {
+        "value": "26",
+        "comment": "The smtp port that should be used when sending email from cf-execd."
+    }
+  }
+}
+```
+
+**History:**
+
+- Added in CFEngine 3.28.0
+
 ### smtpserver
 
 The SMTP server that `cf-execd` should use to send emails. Defaults to `localhost`.

--- a/controls/cf_execd.cf
+++ b/controls/cf_execd.cf
@@ -26,6 +26,9 @@ body executor control
       mailto       => "$(def.mailto)";
       mailfrom     => "$(def.mailfrom)";
       smtpserver   => "$(def.smtpserver)";
+@if minimum_version(3.28.0)
+      smtpport     => "$(def.smtpport)";
+@endif
       mailmaxlines => "$(default:def.control_executor_mailmaxlines)";
 
     control_executor_mailsubject_configured.cfengine_internal_agent_email.!cfengine_internal_disable_agent_email::

--- a/controls/def.cf
+++ b/controls/def.cf
@@ -37,6 +37,10 @@ bundle common def
         string => "localhost",
         if => not(isvariable("smtpserver"));
 
+      "smtpport"
+        string => "25",
+        if => not(isvariable("smtpport"));
+
       "control_executor_mailmaxlines" -> { "ENT-9614" }
         int => "30",
         if => not( isvariable( "control_executor_mailmaxlines" ));


### PR DESCRIPTION
Instruments support for the smtpport attribute in executor control,
matching the existing pattern for smtpserver.

- Added def.smtpport variable with default value "25"
- Added smtpport to body executor control in cf_execd.cf
- Documented smtpport in MPF.md with augments example
- Can be overridden via augments like other mail settings