### PR TITLE
CFE-4639: Removed conflicting --global flag from standard_services systemctl invocation (3.27.x)

### DIFF
--- a/lib/services.cf
+++ b/lib/services.cf
@@ -369,7 +369,7 @@ bundle agent systemd_services(service,state)
   vars:
     systemd::
       "call_systemctl"
-        string => "$(paths.systemctl) --no-ask-password --global --system";
+        string => "$(paths.systemctl) --no-ask-password --system";
 
       "systemd_properties"
         string => "-pLoadState,CanStop,UnitFileState,ActiveState,LoadState,CanStart,CanReload";


### PR DESCRIPTION
## Summary

The `call_systemctl` command in the `systemd_services` bundle passed both `--global` and `--system` to `systemctl`. These flags are mutually exclusive:

- `--global` operates on the global user configuration (affects all users' `systemd --user` instances)
- `--system` operates on the system manager

Passing both causes `systemctl` to fail with an error about conflicting options, breaking the default `standard_services` bundle.

Since `standard_services` manages system services, `--system` is the correct scope; `--global` has been removed.

Backported from https://github.com/cfengine/masterfiles/pull/3134
