### PR TITLE
Renamed plucked.cf.sub to plucked.sub.cf

### DIFF
--- a/tests/acceptance/Makefile.am
+++ b/tests/acceptance/Makefile.am
@@ -2,6 +2,7 @@ ENV_FILE=testall.env
 
 copy:
 	cp $(core_dir)/tests/acceptance/*.cf.sub .
+	cp $(core_dir)/tests/acceptance/*.sub.cf .
 
 env:
 	echo export CORE=\"$(core_dir)\" > $(ENV_FILE)
@@ -22,7 +23,7 @@ check-local: create-env
 
 CLEANFILES  = testall.env summary.log test.log test.xml Makefile.testall
 #These are created by running the submakefile
-CLEANFILES += dcs.cf.sub default.cf.sub plucked.cf.sub
+CLEANFILES += dcs.cf.sub default.cf.sub plucked.sub.cf
 
 
 EXTRA_DIST  = README.md

--- a/tests/acceptance/README.org
+++ b/tests/acceptance/README.org
@@ -1,10 +1,10 @@
 * Writing tests against the stdlib
 
 The test framework for masterfiles piggy backs on the test framework from core.
-It's important to note =plucked.cf.sub= comes from the core repository and that
+It's important to note =plucked.sub.cf= comes from the core repository and that
 it includes bodies and bundles from the stdlib which are useful in writing tests
 in core. This presents a problem for writing tests in the masterfiles framework
-because =plucked.cf.sub= is included and simply including the stdlib could
+because =plucked.sub.cf= is included and simply including the stdlib could
 result in duplicate definition of bundle errors.
 
 To work around this complication you can create a subtest that includes the

--- a/tests/acceptance/lib/files/edit_line_converge.cf
+++ b/tests/acceptance/lib/files/edit_line_converge.cf
@@ -11,7 +11,7 @@ bundle common classes
   classes:
       "testing_masterfiles_policy_framework"
         scope => "namespace",
-        comment => "This class is needed so that dcs.cf.sub includes the stdlib instead of using plucked.cf.sub from core which might get out of date and cause us to not test current code from the MPF.";
+        comment => "This class is needed so that dcs.cf.sub includes the stdlib instead of using plucked.sub.cf from core which might get out of date and cause us to not test current code from the MPF.";
 }
 bundle agent init
 {

--- a/tests/acceptance/lib/files/edit_line_converge_prepend.cf
+++ b/tests/acceptance/lib/files/edit_line_converge_prepend.cf
@@ -12,7 +12,7 @@ bundle common classes
 
       "testing_masterfiles_policy_framework"
         scope => "namespace",
-        comment => "This class is needed so that dcs.cf.sub includes the stdlib instead of using plucked.cf.sub from core which might get out of date and cause us to not test current code from the MPF.";
+        comment => "This class is needed so that dcs.cf.sub includes the stdlib instead of using plucked.sub.cf from core which might get out of date and cause us to not test current code from the MPF.";
 }
 
 bundle agent init

--- a/tests/acceptance/lib/files/replace_uncommented_substrings.cf
+++ b/tests/acceptance/lib/files/replace_uncommented_substrings.cf
@@ -12,7 +12,7 @@ bundle common classes
   classes:
 
       "testing_masterfiles_policy_framework"
-        comment => "This class is needed so that dcs.cf.sub includes the stdlib instead of using plucked.cf.sub from core which might get out of date and cause us to not test current code from the MPF.";
+        comment => "This class is needed so that dcs.cf.sub includes the stdlib instead of using plucked.sub.cf from core which might get out of date and cause us to not test current code from the MPF.";
 }
 
 bundle agent test


### PR DESCRIPTION
This is a CFEngine policy file and should have a .cf file extension.
These definisions are necessary for cfengine lint to find when
it's looking for all the bodies and bundles defined in all .cf
policy files.

Merge together:
https://github.com/cfengine/core/pull/6104
https://github.com/cfengine/masterfiles/pull/3152
https://github.com/cfengine/enterprise/pull/904