### PR TITLE
ENT-11189: Fix cf-apache restart-loop during hub upgrades

### DIFF
--- a/cfe_internal/enterprise/mission_portal.cf
+++ b/cfe_internal/enterprise/mission_portal.cf
@@ -368,6 +368,13 @@ bundle agent mission_portal_apache_from_stage(config, staged_config)
         contain => in_shell,
         comment => "We restart apache after the new valid config is in place";
 
+  methods:
+    systemd_supervised::
+      "Reset cf-apache failed state" -> { "ENT-11189" }
+        usebundle => cf_apache_reset_failed_state,
+        if => "mission_portal_apache_config_repaired",
+        comment => "Clear any latched failed state before restarting cf-apache";
+
   services:
     systemd_supervised::
       "cf-apache"
@@ -540,4 +547,16 @@ bundle agent cfe_enterprise_selfsigned_cert
 
       "DEBUG $(this.bundle): No Certificate Generation Requested"
         if => "!_cfe_enterprise_selfsigned_cert_regenerate_certificate";
+}
+
+bundle agent cf_apache_reset_failed_state
+# @brief Clear any latched 'failed' state on cf-apache.service so subsequent
+# service operations are not refused by systemd's start rate limiter
+# (StartLimitBurst). Safe no-op when the unit is not in a failed state.
+{
+  commands:
+      "$(paths.systemctl) reset-failed cf-apache" -> { "ENT-11189" }
+        contain => in_shell,
+        handle => "cf_apache_systemctl_reset_failed",
+        comment => "Reset latched failed state on cf-apache.service";
 }

--- a/cfe_internal/enterprise/mission_portal.cf
+++ b/cfe_internal/enterprise/mission_portal.cf
@@ -288,9 +288,10 @@ bundle agent mission_portal_apache_from_stage(config, staged_config)
         string => "Configure apache based on successfully staged config";
 
   classes:
-      "systemd_supervised"
-        expression => returnszero("$(paths.systemctl) -q is-active cf-apache > /dev/null 2>&1", "useshell"),
-        if => fileexists( $(paths.systemctl) );
+      "systemd_supervised" -> { "ENT-11189" }
+        expression => returnszero("$(paths.systemctl) cat cf-apache > /dev/null 2>&1", "useshell"),
+        if => fileexists( $(paths.systemctl) ),
+        comment => "Set when cf-apache.service is a unit known to systemd";
 
       "httpd_config_validated"
         expression => strcmp("$(validate_result[exit_code])", "0");

--- a/templates/cf-apache.service.mustache
+++ b/templates/cf-apache.service.mustache
@@ -18,6 +18,11 @@ ExecStart={{{vars.sys.workdir}}}/httpd/bin/apachectl start
 ExecStop={{{vars.sys.workdir}}}/httpd/bin/apachectl stop
 ExecReload={{{vars.sys.workdir}}}/httpd/bin/apachectl graceful
 PIDFile={{{vars.sys.workdir}}}/httpd/httpd.pid
+# ENT-11189: apachectl writes the PID file shortly after fork. On a busy host
+# (e.g. mid-upgrade with SELinux relabel, cf-postgres and cf-php-fpm churning)
+# the default 90s start timeout has been observed to fire while apache is still
+# coming up, leaving worker children bound to :80 and the unit in a restart loop.
+TimeoutStartSec=300
 Restart=always
 RestartSec=10
 UMask=0177


### PR DESCRIPTION
## Summary

In sequential-tests build [#208](https://ci.cfengine.com/job/sequential-tests/208/) the rhel-8 hub got stuck in a cf-apache restart loop during the 3.24.4 → 3.27.1 → master upgrade, failing with `(98) Address already in use: AH00072: could not bind to address 0.0.0.0:80`. Investigation traced this to three independent issues that compound each other.

## Three commits, three independent fixes

1. **`Raised cf-apache.service start timeout to avoid PID-file race`** — `cf-apache.service` is `Type=forking` with `PIDFile=`, but `apachectl` writes the PID file a beat after fork. On a busy host (mid-upgrade) that gap exceeded the inherited default `TimeoutStartSec=90s` ([systemd-system.conf(5)](https://www.man7.org/linux/man-pages/man5/systemd-system.conf.5.html)). systemd then SIGKILLed the apache parent, but worker children survived holding :80, and the unit entered a restart loop. Raised to 300 s — still bounded, just enough headroom for slow startups.

2. **`Check 'systemctl cat' instead of 'is-active' for cf-apache`** — `mission_portal_apache_from_stage` uses the `systemd_supervised` class to choose between the systemd code path (`services:` promise) and direct apachectl invocation (`commands:` promise). The probe was `systemctl -q is-active cf-apache`, which returns non-zero whenever the unit is transiently inactive or failed. During the restart loop above, the policy fell back to the apachectl branch and raced systemd. Switching to `systemctl cat cf-apache` answers the right question — "does systemd know this unit?" — independent of the unit's current state.

3. **`Reset cf-apache failed state before restarting it`** — systemd's start rate limiter (`StartLimitBurst` / `StartLimitIntervalSec`, default 5 failures in 10 s) can latch the unit as `failed`, after which `systemctl restart cf-apache` returns "Start request repeated too quickly" and the policy's `service_policy => \"restart\"` becomes a silent no-op. Added a `methods:` promise (runs before `services:` in CFEngine's promise-type order) that invokes `systemctl reset-failed cf-apache` via a small helper bundle, gated on `mission_portal_apache_config_repaired` so it only fires when the agent is about to restart anyway. Idle runs do nothing.

Commits 1 and 2 close the *known* failure path. Commit 3 closes the *general* recovery path so future failure modes can't permanently wedge the hub through the same latch.

Ticket: ENT-11189

Backported to:
- https://github.com/cfengine/masterfiles/pull/3162
- https://github.com/cfengine/masterfiles/pull/3163