### PR TITLE
ENT-7923: Removed cfe_internal_update_health_failures bundle

### DIFF
--- a/cfe_internal/enterprise/CFE_hub_specific.cf
+++ b/cfe_internal/enterprise/CFE_hub_specific.cf
@@ -790,11 +790,15 @@ bundle agent cfe_internal_refresh_events_table
 bundle agent cfe_internal_update_health_failures
 # @brief Update table that contains health diagnostics failures hosts
 {
+@if before_version(3.28)
+  # The update_health_failures CLI task is moved to cf-reactor.
+  # Remove this bundle once CFEngine 3.28 is end-of-life.
   meta:
 
     (policy_server|am_policy_hub).enterprise_edition::
 
       "tags" slist => { "enterprise_maintenance" };
+@endif
 
   commands:
 


### PR DESCRIPTION
cf-reactor now schedules the update_health_failures CLI task on its own
1-minute timer. The policy bundle is no longer needed.

Together with:
* https://github.com/cfengine/mission-portal/pull/3174
* https://github.com/cfengine/nova/pull/2596