### PR TITLE
ENT-14140: psql_wrapper.sh: retry psql commands on transient failures

### DIFF
--- a/templates/federated_reporting/psql_wrapper.sh.mustache
+++ b/templates/federated_reporting/psql_wrapper.sh.mustache
@@ -14,8 +14,22 @@ fi
 
 TMP=$(mktemp)
 cd /tmp
-OUT=$(su - cfpostgres --command "{{{vars.sys.bindir}}}/psql --quiet --tuples-only --no-align --no-psqlrc \"$1\" --command=\"$2\"" 2> $TMP)
-RETURN_CODE=$?
+
+# psql returns 2 when the connection to the server went bad, which can happen
+# transiently while postgres is being restarted. Retry a few times so that the
+# wrapper doesn't fail the promise just because postgres is briefly unavailable.
+MAX_ATTEMPTS=10
+ATTEMPT=1
+while : ; do
+    OUT=$(su - cfpostgres --command "{{{vars.sys.bindir}}}/psql --quiet --tuples-only --no-align --no-psqlrc \"$1\" --command=\"$2\"" 2> $TMP)
+    RETURN_CODE=$?
+    if [ $RETURN_CODE -ne 2 ] || [ $ATTEMPT -ge $MAX_ATTEMPTS ]; then
+        break
+    fi
+    ATTEMPT=$((ATTEMPT + 1))
+    sleep 3
+done
+
 ERR=$(<$TMP)
 
 EXIT_CODE=$(echo $OUT | awk -F= '{ if ( /exit_code/ ) print $2}')


### PR DESCRIPTION
Observed a race condition in CI where `bundle agent superhub_schema` interacts with postgres shortly after service restart.

```
03:12:04 systemd: Stopping CFEngine Enterprise PostgreSQL Database...
03:12:04 systemd: Started CFEngine Enterprise PostgreSQL Database.
03:12:04 cf-agent: Executing ... psql_wrapper.sh cfdb select superhub_schema(...)
03:12:05 cf-agent: returned code '2' defined as promise failed
```

Fixed by gating `superhub_schema`, `ensure_feeders`, and `imported_data` on a persistent class set by the cf-postgres restart.

Ticket: ENT-14140

Backported to:
- https://github.com/cfengine/masterfiles/pull/3167
- https://github.com/cfengine/masterfiles/pull/3168