### PR TITLE
ENT-14205: Add leech2 reporting drop-in directory

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -235,6 +235,9 @@ do
     done
 done
 
+dnl leech2 reporting drop-in directory (ENT-14205)
+MASTERFILES_INSTALL_TARGETS="$MASTERFILES_INSTALL_TARGETS $srcdir/leech2/README.txt"
+
 
 AC_SUBST(MASTERFILES_INSTALL_TARGETS)
 

--- a/leech2/README.txt
+++ b/leech2/README.txt
@@ -1,0 +1,13 @@
+leech2 reporting drop-in directory
+==================================
+
+Files in this directory extend the leech2 configuration.
+
+leech2's base config (/var/cfengine/.leech2/config.json) includes every
+*.json file found here, deep-merging each one into the configuration
+(last writer wins). Use this to add or override reporting tables without
+editing the shipped config.json, which package upgrades overwrite.
+
+To deploy a fragment to your hosts, place a *.json file under leech2/ in
+your masterfiles; the policy update distributes it to inputs/leech2/ on
+every host. Only *.json files are loaded; this README is ignored.


### PR DESCRIPTION
Ship `leech2/README.txt` documenting the `inputs/leech2/` drop-in directory, where `*.json` fragments extend the leech2 reporting configuration. The policy update distributes it to `inputs/leech2/` on every host.

Together with:
- https://github.com/cfengine/enterprise/pull/945
- https://github.com/cfengine/nova/pull/2635
- https://github.com/cfengine/buildscripts/pull/2317