### PR TITLE
Don't advertise federation host with empty SSH fingerprint (3.24.x)

### DIFF
--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -920,6 +920,9 @@ bundle agent setup_status
       # parse sshd config to find the file and then readfile():
       string => execresult("ssh-keyscan localhost 2>/dev/null | sed 's/localhost //g' | sort", useshell);
   classes:
+    "ssh_server_fingerprint_collected"
+      expression => not(strcmp("$(ssh_server_fingerprint)", ""));
+
     "superhub_setup_status_complete"
       expression => "any",
       depends_on => {
@@ -930,7 +933,12 @@ bundle agent setup_status
       };
 
   files:
-    superhub_setup_status_complete::
+    # An empty fingerprint (ssh-keyscan returned nothing, e.g. sshd not yet
+    # reachable on localhost) must not be advertised: a superhub would render
+    # an empty known_hosts entry for this host and its rsync pull would later
+    # fail with "Host key verification failed". Skip the status update until
+    # the fingerprint is collected; the next agent run will retry.
+    superhub_setup_status_complete.ssh_server_fingerprint_collected::
       "$(cfengine_enterprise_federation:config.path_setup_status)"
         create => "true",
         perms => default:mog( "600", "cfapache", "root" ),
@@ -943,7 +951,11 @@ bundle agent setup_status
           "transport_ssh_public_key": "$(ssh_pub_key)",
           "transport_ssh_server_fingerprint": "$(ssh_server_fingerprint)",
         }',
-        if => isvariable( ssh_pub_key );
+        if => isvariable(ssh_pub_key);
+
+  reports:
+    superhub_setup_status_complete.!ssh_server_fingerprint_collected::
+      "warning: 'ssh-keyscan localhost' returned no SSH host key; federation setup status not written yet. Will retry next run.";
 }
 
 bundle agent distributed_cleanup_setup


### PR DESCRIPTION
If ssh-keyscan returns no host key, the setup status was still written
with an empty transport_ssh_server_fingerprint. Superhubs then rendered
an empty known_hosts entry for the host and the rsync pull later failed
with "Host key verification failed". Gate the status update on a
non-empty fingerprint and retry on subsequent runs.

Changelog: Don't advertise federation host with empty SSH fingerprint
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
(cherry picked from commit 18a70ef843df688b3adaafc4cd23369c6c3c01b7)

Backported from https://github.com/cfengine/masterfiles/pull/3183