### PR TITLE
Removed stale comment about maplist not working

### DIFF
--- a/cfe_internal/core/host_info_report.cf
+++ b/cfe_internal/core/host_info_report.cf
@@ -75,7 +75,6 @@ bundle agent host_info_report_cfengine
                   calculated locally.";
 
   vars:
-    # doesn't work :( # "interface_flags" slist => maparray("$(this.k): IP $(sys.ipv4[$(this.k)]), flags $(this.v)", "sys.interface_flags");
     "interface_flags"
       slist => maparray("$(this.k): $(this.v)", "sys.interface_flags");
 


### PR DESCRIPTION
It most certainly does:

,#+begin_src cfengine3
  bundle agent main
  {
    vars:

        "interface_flags" slist => maparray("$(this.k): IP $(sys.ipv4[$(this.k)]), flags $(this.v)", "sys.interface_flags");

    reports:
        "$(interface_flags)";
  }
,#+end_src

,#+RESULTS:
,#+begin_example
R: tailscale0: IP 100.121.164.102, flags up pointopoint running noarp multicast
R: virbr1: IP 192.168.121.1, flags up broadcast running multicast
R: lo: IP 127.0.0.1, flags up loopback running
R: virbr0: IP 192.168.122.1, flags up broadcast multicast
R: eth0: IP 192.168.42.78, flags up broadcast running multicast
R: tun0: IP 192.168.24.194, flags up pointopoint running noarp multicast
R: wlp0s20f3: IP 192.168.8.139, flags up broadcast running multicast
R: docker0: IP 172.17.0.1, flags up broadcast multicast
R: virbr2: IP 192.168.56.1, flags up broadcast running multicast
R: br-413843af2fd7: IP $(sys.ipv4[br-413843af2fd7]), flags up broadcast multicast
R: br-8e38d4bfbf4f: IP $(sys.ipv4[br-8e38d4bfbf4f]), flags up broadcast multicast
R: br-82ed373660ec: IP $(sys.ipv4[br-82ed373660ec]), flags up broadcast multicast
R: br-491f3f0a0a16: IP $(sys.ipv4[br-491f3f0a0a16]), flags up broadcast multicast
,#+end_example