### PR TITLE
Fixed the source tarball still not being reproducible

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -37,6 +37,9 @@ export TAR_OPTIONS
 LC_ALL = C
 export LC_ALL
 
+# --no-name strips the mtime from the gzip header. --best is automake's default.
+GZIP_ENV = "--best --no-name"
+
 # Store the permissions properly in the tarball for acceptance tests to succeed.
 # Also normalize directory permissions (which would otherwise be affected by the
 # builder's umask). When SOURCE_DATE_EPOCH is set, clamp every mtime to it so


### PR DESCRIPTION
72c04dd9 covered everything but gzip's header, which records the time it ran, so two builds of the same tree still differed.

```
$ ./build-in-container.py --tarballs --build-type DEBUG --output-dir output/a/
 ---snip---
$ ./build-in-container.py --tarballs --build-type DEBUG --output-dir output/b/
 ---snip---
$ cat output/{a,b}/tarballs/sha256sums.txt
adefc308051307a6f7a45f062e2778fb31ea814f86c4519116a829c8b9dee758  cfengine-3.29.0a.a83bad3aa.tar.gz
ac9527080d1a389e6405656f528a3ac15e66d406536c7d2ede33135c8c31d45e  cfengine-masterfiles-3.29.0a.586c7ec2f-1.pkg.tar.gz
d537ae82d86a5a0d1a8b7b10d5654d08bd0a28535b3af9c918e97fd70a303a3c  cfengine-masterfiles-3.29.0a.586c7ec2f.tar.gz
adefc308051307a6f7a45f062e2778fb31ea814f86c4519116a829c8b9dee758  cfengine-3.29.0a.a83bad3aa.tar.gz
ac9527080d1a389e6405656f528a3ac15e66d406536c7d2ede33135c8c31d45e  cfengine-masterfiles-3.29.0a.586c7ec2f-1.pkg.tar.gz
d537ae82d86a5a0d1a8b7b10d5654d08bd0a28535b3af9c918e97fd70a303a3c  cfengine-masterfiles-3.29.0a.586c7ec2f.tar.gz
```

Changelog: The source tarball is now reproducible
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>

Together with https://github.com/cfengine/buildscripts/pull/2402